### PR TITLE
Ensure a `composer.json` file is present before to fetch information.

### DIFF
--- a/src/Packagist/WebBundle/Command/UpdatePackagesCommand.php
+++ b/src/Packagist/WebBundle/Command/UpdatePackagesCommand.php
@@ -71,8 +71,9 @@ EOF
 
             try {
                 foreach ($repository->getTags() as $tag => $identifier) {
-                    // TODO parse tag name (or fetch composer file?) w/ composer version parser, if no match, ignore the tag
-                    $this->fetchInformation($output, $doctrine, $package, $repository, $identifier);
+                    if ($repository->hasComposerFile($identifier)) {
+                        $this->fetchInformation($output, $doctrine, $package, $repository, $identifier);
+                    }
                 }
 
                 foreach ($repository->getBranches() as $branch => $identifier) {

--- a/src/Packagist/WebBundle/Repository/Repository/GitHubRepository.php
+++ b/src/Packagist/WebBundle/Repository/Repository/GitHubRepository.php
@@ -97,8 +97,19 @@ class GitHubRepository implements RepositoryInterface
      */
     public function getBranches()
     {
-        // TODO implement
-        return array();
+        if (null === $this->branches) {
+            $branchesData = json_decode(file_get_contents('http://github.com/api/v2/json/repos/show/'.$this->owner.'/'.$this->repository.'/branches'), true);
+            $this->branches = $branchesData['branches'];
+        }
+        return $this->branches;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasComposerFile($identifier)
+    {
+        return (false !== @fopen('https://raw.github.com/'.$this->owner.'/'.$this->repository.'/'.$identifier.'/composer.json', 'r'));
     }
 
     protected function getRepositoryData()

--- a/src/Packagist/WebBundle/Repository/Repository/RepositoryInterface.php
+++ b/src/Packagist/WebBundle/Repository/Repository/RepositoryInterface.php
@@ -54,4 +54,12 @@ interface RepositoryInterface
      * @return string
      */
     function getType();
+    /**
+     * Return true if the repository has a composer file for a given identifier,
+     * false otherwise.
+     *
+     * @param string $identifier Any identifier to a specific branch/tag/commit
+     * @return boolean Whether the repository has a composer file for a given identifier.
+     */
+    function hasComposerFile($identifier);
 }


### PR DESCRIPTION
Hi,

As discussed here: https://github.com/propelorm/Propel/commit/0e2463c55de9aa6d81922fb1d5abf4721d19c519, I took time to fix the issue. It works fine and without a lot of changes.

That PR allows to fetch information from repositories which don't have a `composer.json` file on all branches/tags.

Note I used the `fopen()` function to fetch the file in order to know if it exists or not but maybe another function will be better. I guess the `fopen` is faster than `file_get_contents()`.

Regards,
William.
