### PR TITLE
Added missing asset publishing step to the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,6 @@ Installation
 - Run `bin/vendors install` to get all the vendors.
 - Copy `app/config/parameters.yml.dist` to `app/config/parameters.yml` and edit the relevant values for your setup.
 - Run `app/console doctrine:schema:create` to setup the DB.
+- Run `app/console assets:install web` to deploy the assets on the web dir.
 - Make a VirtualHost with DocumentRoot pointing to web/
 - You should now be able to access the site, create a user, etc.


### PR DESCRIPTION
I'm starting to play with the packagist repo on my local machine and noticed that the installation instructions missed the step for publishing the assets on the web dir, so here it is! :)
