### PR TITLE
Added repositories in package api export

### DIFF
--- a/src/Packagist/WebBundle/Entity/Package.php
+++ b/src/Packagist/WebBundle/Entity/Package.php
@@ -112,6 +112,7 @@ class Package
             'maintainers' => $maintainers,
             'versions' => $versions,
             'type' => $this->getType(),
+            'repository' => $this->getRepository()
         );
         return $data;
     }


### PR DESCRIPTION
Title self-explaining; enables exporting of 'repository', in `packages.json`, is handy for apps using packagist api.
