### PR TITLE
Added information on the update schedule to the about page.

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/About/about.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/About/about.html.twig
@@ -80,11 +80,11 @@ v1.x
 
         <h1>Update Schedule</h1>
 
-        <p>New packages will be crawled <strong>every five minutes</strong>.</p>
+        <p>New packages will be crawled <strong>within ten minutes</strong>.</p>
 
         <p>Existing packages will be crawled <strong>every hour</strong>.</p>
 
-        <p>The search index is rebuilt <strong>every hour</strong>. It will index (or reindex) any package that has been crawled since the last time the search indexer ran.</p>
+        <p>The search index is updated <strong>every five minutes</strong>. It will index (or reindex) any package that has been crawled since the last time the search indexer ran.</p>
 
         <p>Crawling cannot currently be triggered on commit or by other means. This is planned for a future release.</p>
     </div>


### PR DESCRIPTION
Moved the majority of the content from composer/composer#284 to the about page for Packagist.
