### PR TITLE
Optimized the queries for the package view

### DIFF
--- a/src/Packagist/WebBundle/Controller/WebController.php
+++ b/src/Packagist/WebBundle/Controller/WebController.php
@@ -219,7 +219,7 @@ class WebController extends Controller
         try {
             $package = $this->getDoctrine()
                 ->getRepository('PackagistWebBundle:Package')
-                ->findOneByName($name);
+                ->getFullPackageByName($name);
         } catch (\Doctrine\ORM\NoResultException $e) {
             return $this->redirect($this->generateUrl('search', array('q' => $name, 'reason' => 'package_not_found')));
         }

--- a/src/Packagist/WebBundle/Entity/PackageRepository.php
+++ b/src/Packagist/WebBundle/Entity/PackageRepository.php
@@ -49,6 +49,22 @@ class PackageRepository extends EntityRepository
         return $qb->getQuery()->getSingleResult();
     }
 
+    public function getFullPackageByName($name)
+    {
+        $qb = $this->getBaseQueryBuilder()
+            ->addSelect('a', 'req', 'rec', 'sug', 'rep', 'con', 'pro')
+            ->leftJoin('v.authors', 'a')
+            ->leftJoin('v.require', 'req')
+            ->leftJoin('v.recommend', 'rec')
+            ->leftJoin('v.suggest', 'sug')
+            ->leftJoin('v.replace', 'rep')
+            ->leftJoin('v.conflict', 'con')
+            ->leftJoin('v.provide', 'pro')
+            ->where('p.name = ?0')
+            ->setParameters(array($name));
+        return $qb->getQuery()->getSingleResult();
+    }
+
     public function findByTag($name)
     {
         return $this->getBaseQueryBuilder()


### PR DESCRIPTION
Here is the result of displaying the doctrine/dbal package:
Before: 94 queries
After: 3 queries (set names, auth, and only one for the page)

This solves the issue revealed by @Maks3w in the discussion on #85 (and his own example was still a light page in fact)
