### PR TITLE
Accept username and API token from POST in addition to GET

### DIFF
--- a/src/Packagist/WebBundle/Controller/ApiController.php
+++ b/src/Packagist/WebBundle/Controller/ApiController.php
@@ -58,12 +58,17 @@ class ApiController extends Controller
             return new Response(json_encode(array('status' => 'error', 'message' => 'Missing or invalid payload',)), 406);
         }
 
-        $username = $request->query->get('username');
-        $apiToken = $request->query->get('apiToken');
+        $username = $request->request->has('username') ?
+            $request->request->get('username') :
+            $request->query->get('username');
+
+        $apiToken = $request->request->has('apiToken') ?
+            $request->request->get('apiToken') :
+            $request->query->get('apiToken');
 
         $doctrine = $this->get('doctrine');
         $user = $doctrine
-            ->getRepository('Packagist\WebBundle\Entity\User')
+            ->getRepository('PackagistWebBundle:User')
             ->findOneBy(array('username' => $username, 'apiToken' => $apiToken));
 
         if (!$user) {


### PR DESCRIPTION
In preparation for GitHub service hooks, I'd like to update this code to accept the username and API token from POST first, then GET param later.

I would have used `$request->get()` but the docs seemed to indicate that is not a good way to do things. If that is cleaner and/or appropriate here I'd be happy to do it that way.

I also changed the `getRepository` call in this section to use `PackagistWebBundle:User` instead of the entity's fully qualified class name.
