### PR TITLE
Update packages on demand by PUT request

### DIFF
--- a/src/Packagist/WebBundle/Controller/WebController.php
+++ b/src/Packagist/WebBundle/Controller/WebController.php
@@ -269,7 +269,7 @@ class WebController extends Controller
             $request->query->get('apiToken');
 
         $update = $request->request->get('update', $request->query->get('update'));
-        $autoUpdated = $request->request->get('auto_updated', $request->query->get('auto_updated'));
+        $autoUpdated = $request->request->get('autoUpdated', $request->query->get('autoUpdated'));
 
         $user = $doctrine
             ->getRepository('PackagistWebBundle:User')


### PR DESCRIPTION
This will update the `autoUpdated` status of a package and will also crawl a packages based on a PUT request:

```
curl -i -X PUT \
    -d username=USERNAME\
    -d apiToken=TOKEN\
    -d auto_updated=1 \
    -d update=1 \
    http://packagist.org/packages/composer/composer
```
