### PR TITLE
Added version aliasing.

### DIFF
--- a/src/Packagist/WebBundle/Entity/Package.php
+++ b/src/Packagist/WebBundle/Entity/Package.php
@@ -113,6 +113,9 @@ class Package
         $versions = array();
         foreach ($this->getVersions() as $version) {
             $versions[$version->getVersion()] = $version->toArray();
+            if ($version->hasVersionAlias()) {
+                $versions[$version->getVersionAlias()] = $version->toArray();
+            }
         }
         $maintainers = array();
         foreach ($this->getMaintainers() as $maintainer) {

--- a/src/Packagist/WebBundle/Entity/Version.php
+++ b/src/Packagist/WebBundle/Entity/Version.php
@@ -618,6 +618,26 @@ class Version
     }
 
     /**
+     * @return boolean
+     */
+    public function hasVersionAlias()
+    {
+        return $this->getDevelopment() && (boolean) $this->getVersionAlias();
+    }
+
+    /**
+     * @return string
+     */
+    public function getVersionAlias()
+    {
+        $extra = $this->getExtra();
+
+        if (isset($extra['branch-alias'][$this->getVersion()])) {
+            return $extra['branch-alias'][$this->getVersion()];
+        }
+    }
+
+    /**
      * Set development
      *
      * @param Boolean $development

--- a/src/Packagist/WebBundle/Resources/views/Web/viewPackage.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/viewPackage.html.twig
@@ -66,8 +66,8 @@
                             <section>
                                 <h1>
                                     {{ version.version }}
-                                    {% if version.development and version.extra['branch-alias'][version.version] is defined %}
-                                        / {{ version.extra['branch-alias'][version.version] }}
+                                    {% if version.hasVersionAlias %}
+                                        / {{ version.versionAlias }}
                                     {% endif %}
                                     <span class="release-date">{{ version.releasedAt|date("Y-m-d H:i") }} UTC</span>
                                     <span class="license">{{ version.license ? version.license|join(', ') : '' }}</span>


### PR DESCRIPTION
Hello, I wanted to add some stuff in Silex today... but I cannot fetch deps through composer, so investigated things and made this PR

Problem (example):
symfony/routing have dev-master version which I can fetch from packagist. Dev-master is alias for 2.1-dev version... but when I set this version directly I cannot fetch it (yeah WAT)... I do no want set dev-master in my composer.json cause new version of something can appear at any time.

This is my propsal how to resolve it. Please take a look.
