### PR TITLE
Validate freshness of the packages.json to return 304 response if possible

### DIFF
--- a/src/Packagist/WebBundle/Controller/ApiController.php
+++ b/src/Packagist/WebBundle/Controller/ApiController.php
@@ -33,17 +33,25 @@ class ApiController extends Controller
      */
     public function packagesAction()
     {
-        $packages = $this->get('doctrine')
-            ->getRepository('Packagist\WebBundle\Entity\Package')
-            ->getFullPackages();
+        $packageRepository = $this->get('doctrine')->getRepository('Packagist\WebBundle\Entity\Package');
 
+        $response = new Response();
+        $reponse->setLastModified($packageRepository->getLastUpdate());
+
+        if ($response->isNotModified($this->getRequest())) {
+            return $response;
+        }
+
+        $packages = $packageRepository->getFullPackages();
         $data = array();
         foreach ($packages as $package) {
             $data[$package->getName()] = $package->toArray();
         }
 
-        $response = new Response(json_encode($data), 200);
+        $response->headers->set('Content-Type', 'application/json');
+        $response->setContent(json_encode($data));
         $response->setSharedMaxAge(60);
+
         return $response;
     }
 

--- a/src/Packagist/WebBundle/Entity/PackageRepository.php
+++ b/src/Packagist/WebBundle/Entity/PackageRepository.php
@@ -13,6 +13,7 @@
 namespace Packagist\WebBundle\Entity;
 
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\AbstractQuery;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -62,6 +63,16 @@ class PackageRepository extends EntityRepository
         }
 
         return $this->packageNames = $names;
+    }
+
+    public function getLastUpdate()
+    {
+        $lastUpdate = $this->getEntityManager()->createQueryBuilder();
+            ->select('MAX(p.updated_at)')
+            ->from('Packagist\WebBundle\Entity\Package', 'p')
+            ->getQuery()->getOneOrNullResult(AbstractQuery::HYDRATE_SINGLE_SCALAR);
+
+        return new \DateTime($lastUpdate);
     }
 
     public function getStalePackages()


### PR DESCRIPTION
Try to improve performance of packages.json by returning a 304 response based on last package update.

When composer will become able to cache this file, that will allow it to revalidate the file without actually downloading its content.

(Sorry if it's broken, I haven't tested)
