### PR TITLE
capitalisation issue caused console, user login to fail

### DIFF
--- a/src/Packagist/WebBundle/Entity/User.php
+++ b/src/Packagist/WebBundle/Entity/User.php
@@ -25,7 +25,7 @@ class User extends BaseUser
     /**
      * @ORM\Id
      * @ORM\Column(type="integer")
-     * @ORM\generatedValue(strategy="AUTO")
+     * @ORM\GeneratedValue(strategy="AUTO")
      */
     protected $id;
 


### PR DESCRIPTION
The low case G caused the following error. upcasing it fixed the problem.

$ app/console cache:clear
Clearing the cache for the dev environment with debug true

  [Doctrine\Common\Annotations\AnnotationException]  
  [Semantical Error] The annotation "@Doctrine\ORM\Mapping\generatedValue" in property Packagist\WebBundle\Entity\User::$id does not exist,  
  or could not be auto-loaded.                                                                                                                
