### PR TITLE
[WIP] Integrate HWIOAuthBundle for GitHub integration/login

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -20,6 +20,7 @@ class AppKernel extends Kernel
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new FOS\UserBundle\FOSUserBundle(),
+            new HWI\Bundle\OAuthBundle\HWIOAuthBundle(),
             new Snc\RedisBundle\SncRedisBundle(),
             new Packagist\WebBundle\PackagistWebBundle(),
             new WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle(),

--- a/app/Resources/FOSUserBundle/views/Security/login.html.twig
+++ b/app/Resources/FOSUserBundle/views/Security/login.html.twig
@@ -5,7 +5,7 @@
     <div>{{ error }}</div>
 {% endif %}
 
-<form action="{{ path("fos_user_security_check") }}" method="post">
+<form action="/login_check" method="post">
     <div>
         <label for="username">{{ 'security.login.username'|trans({}, 'FOSUserBundle') }}</label>
         <input type="text" id="username" name="_username" value="{{ last_username }}" />

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -72,6 +72,19 @@ fos_user:
         form:
             handler: packagist.form.handler.registration
 
+hwi_oauth:
+    firewall_name: main
+    connect:
+        account_connector: packagist.user_provider
+        registration_form_handler: packagist.oauth.registration_form_handler
+        registration_form: packagist.oauth.registration_form
+    resource_owners:
+        github:
+            type:          github
+            client_id:     %github.client_id%
+            client_secret: %github.client_secret%
+            scope:         ""
+
 nelmio_solarium:
     adapter: ~
 

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -21,3 +21,7 @@ parameters:
 
     google_analytics:
         ga_key:
+
+    github:
+        client_id:
+        client_secret:

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -2,9 +2,6 @@ _packagist:
     resource: "@PackagistWebBundle/Controller"
     type:     annotation
 
-fos_user_security:
-    resource: "@FOSUserBundle/Resources/config/routing/security.xml"
-
 fos_user_profile:
     resource: "@FOSUserBundle/Resources/config/routing/profile.xml"
     prefix: /profile
@@ -19,3 +16,29 @@ fos_user_resetting:
 
 fos_user_change_password:
     resource: "@FOSUserBundle/Resources/config/routing/change_password.xml"
+
+
+hwi_oauth_connect:
+    resource: "@HWIOAuthBundle/Resources/config/routing/connect.xml"
+    prefix:   /connect
+
+# overrides the fosub /login page
+hwi_oauth_login:
+    resource: "@HWIOAuthBundle/Resources/config/routing/login.xml"
+    prefix:   /login
+
+hwi_oauth_redirect:
+    resource: "@HWIOAuthBundle/Resources/config/routing/redirect.xml"
+    prefix:   /login
+
+github_login:
+    pattern: /login/github
+
+github_check:
+    pattern: /login/check-github
+
+logout:
+    pattern: /logout
+
+login_check:
+    pattern: /login_check

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -26,6 +26,13 @@ security:
                 lifetime: 31104000 # 1y
             logout:       true
             anonymous:    true
+            oauth:
+                resource_owners:
+                    github: "/login/check-github"
+                login_path:        /login
+                failure_path:      /login
+                oauth_user_provider:
+                    service: packagist.user_provider
 
     access_control:
         # The WDT has to be allowed to anonymous users to avoid requiring the login with the AJAX request

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "doctrine/doctrine-bundle": "dev-master",
         "doctrine/orm": "2.2.*",
         "friendsofsymfony/user-bundle": "dev-master",
+        "hwi/oauth-bundle": "dev-master",
         "nelmio/solarium-bundle": "dev-master",
         "predis/predis": "0.7.*",
         "sensio/distribution-bundle": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -1,5 +1,5 @@
 {
-    "hash": "f213345e7df3e164f2c73ef89edd81c4",
+    "hash": "49a3e2ecc65ede07edb521e3cdedf109",
     "packages": [
         {
             "package": "composer/composer",
@@ -36,6 +36,12 @@
             "commit-date": "1342274388"
         },
         {
+            "package": "hwi/oauth-bundle",
+            "version": "dev-master",
+            "source-reference": "ad2f468abdfe09e8f9c1398ad4637f51df7d7791",
+            "commit-date": "1342353157"
+        },
+        {
             "package": "justinrainbow/json-schema",
             "version": "1.1.0"
         },
@@ -50,6 +56,10 @@
             "version": "dev-master",
             "source-reference": "d6f89a3170c5280ad554347dc113eb25fdf00ad7",
             "commit-date": "1339515714"
+        },
+        {
+            "package": "kriswallsmith/buzz",
+            "version": "v0.7"
         },
         {
             "package": "monolog/monolog",
@@ -201,6 +211,7 @@
         "composer/composer": 20,
         "doctrine/doctrine-bundle": 20,
         "friendsofsymfony/user-bundle": 20,
+        "hwi/oauth-bundle": 20,
         "nelmio/solarium-bundle": 20,
         "sensio/distribution-bundle": 20,
         "sensio/framework-extra-bundle": 20,

--- a/src/Packagist/WebBundle/Entity/User.php
+++ b/src/Packagist/WebBundle/Entity/User.php
@@ -50,6 +50,12 @@ class User extends BaseUser
      */
     private $apiToken;
 
+    /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     * @var string
+     */
+    private $githubId;
+
     public function __construct()
     {
         $this->packages = new ArrayCollection();
@@ -144,5 +150,25 @@ class User extends BaseUser
     public function getApiToken()
     {
         return $this->apiToken;
+    }
+
+    /**
+     * Get githubId.
+     *
+     * @return string
+     */
+    public function getGithubId()
+    {
+        return $this->githubId;
+    }
+
+    /**
+     * Set githubId.
+     *
+     * @param string $githubId
+     */
+    public function setGithubId($githubId)
+    {
+        $this->githubId = $githubId;
     }
 }

--- a/src/Packagist/WebBundle/Form/Handler/OAuthRegistrationFormHandler.php
+++ b/src/Packagist/WebBundle/Form/Handler/OAuthRegistrationFormHandler.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of Packagist.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *     Nils Adermann <naderman@naderman.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Packagist\WebBundle\Form\Handler;
+
+use FOS\UserBundle\Model\UserManagerInterface;
+use FOS\UserBundle\Util\TokenGeneratorInterface;
+use HWI\Bundle\OAuthBundle\Form\RegistrationFormHandlerInterface;
+use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
+use Symfony\Component\Form\Form;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * OAuthRegistrationFormHandler
+ *
+ * @author Alexander <iam.asm89@gmail.com>
+ */
+class OAuthRegistrationFormHandler implements RegistrationFormHandlerInterface
+{
+    private $userManager;
+    private $tokenGenerator;
+
+    /**
+     * Constructor.
+     *
+     * @param UserManagerInterface $userManager
+     */
+    public function __construct(UserManagerInterface $userManager, TokenGeneratorInterface $tokenGenerator)
+    {
+        $this->tokenGenerator = $tokenGenerator;
+        $this->userManager = $userManager;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    function process(Request $request, Form $form, UserResponseInterface $userInformation)
+    {
+        $user = $this->userManager->createUser();
+
+        $form->setData($user);
+
+        if ('POST' === $request->getMethod()) {
+            $form->bindRequest($request);
+
+            if ($form->isValid()) {
+                $randomPassword = $this->tokenGenerator->generateToken();
+                $form->getData()->setPassword($randomPassword);
+
+                return true;
+            }
+        // if the form is not posted we'll try to set some properties
+        } else {
+            $user = $form->getData();
+
+            $user->setUsername($this->getUniqueUsername($userInformation->getUsername()));
+
+            if ($userInformation instanceof AdvancedUserResponseInterface) {
+                $user->setEmail($userInformation->getEmail());
+            }
+
+            $form->setData($user);
+        }
+
+        return false;
+    }
+
+    /**
+     * Attempts to get a unique username for the user.
+     *
+     * @param string $name
+     *
+     * @return string Name, or empty string if it failed after 10 times
+     *
+     * @see HWI\Bundle\OAuthBundle\Form\FOSUBRegistrationHandler
+     */
+    protected function getUniqueUserName($name)
+    {
+        $i = 0;
+        $testName = $name;
+
+        do {
+            $user = $this->userManager->findUserByUsername($testName);
+        } while ($user !== null && $i < 10 && $testName = $name.++$i);
+
+        return $user !== null ? '' : $testName;
+    }
+}

--- a/src/Packagist/WebBundle/Form/Type/OAuthRegistrationFormType.php
+++ b/src/Packagist/WebBundle/Form/Type/OAuthRegistrationFormType.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Packagist.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *     Nils Adermann <naderman@naderman.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Packagist\WebBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class OAuthRegistrationFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('username', null, array('label' => 'form.username', 'translation_domain' => 'FOSUserBundle'))
+            ->add('email', 'email', array('label' => 'form.email', 'translation_domain' => 'FOSUserBundle'))
+        ;
+    }
+
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => 'Packagist\WebBundle\Entity\User',
+            'intention'  => 'registration',
+        ));
+    }
+
+    public function getName()
+    {
+        return 'packagist_oauth_user_registration';
+    }
+}

--- a/src/Packagist/WebBundle/Resources/config/services.yml
+++ b/src/Packagist/WebBundle/Resources/config/services.yml
@@ -32,3 +32,20 @@ services:
     fos_user.util.user_manipulator:
         class: Packagist\WebBundle\Util\UserManipulator
         arguments: [@fos_user.user_manager, @fos_user.util.token_generator]
+
+    packagist.oauth.registration_form_handler:
+        class: Packagist\WebBundle\Form\Handler\OAuthRegistrationFormHandler
+        arguments: [@fos_user.user_manager, @fos_user.util.token_generator]
+
+    packagist.oauth.registration_form_type:
+        class: Packagist\WebBundle\Form\Type\OAuthRegistrationFormType
+        tags:
+            - { name: form.type, alias: packagist_oauth_user_registration }
+
+    packagist.oauth.registration_form:
+        factory_method: createNamed
+        factory_service: form.factory
+        class: Symfony\Component\Form\Form
+        arguments:
+            - 'packagist_oauth_user_registration'
+            - 'packagist_oauth_user_registration'

--- a/src/Packagist/WebBundle/Resources/views/Web/index.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/index.html.twig
@@ -64,7 +64,7 @@ require 'vendor/autoload.php';
                 <h2>Commit The File</h2>
                 <p>You surely don't need help with that.</p>
                 <h2>Publish It</h2>
-                <p><a href="{{ path('fos_user_security_login') }}">Login</a> or <a href="{{ path('fos_user_registration_register') }}">register</a> on this site, then hit the big fat green button above that says <a href="{{ path('submit') }}">submit</a>.</p>
+                <p><a href="{{ path('hwi_oauth_connect') }}">Login</a> or <a href="{{ path('fos_user_registration_register') }}">register</a> on this site, then hit the big fat green button above that says <a href="{{ path('submit') }}">submit</a>.</p>
                 <p>Once you entered your public repository URL in there, your package will be automatically crawled periodically. You just have to make sure you keep the composer.json file up to date.</p>
             </div>
         </section>

--- a/src/Packagist/WebBundle/Resources/views/layout.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/layout.html.twig
@@ -33,11 +33,11 @@
         <div class="container">
             <div class="user">
                 {% if app.user %}
-                    <a href="{{ path('fos_user_profile_show') }}">{{ app.user.username }}</a> | <a href="{{ path('fos_user_security_logout') }}">Logout</a>
+                    <a href="{{ path('fos_user_profile_show') }}">{{ app.user.username }}</a> | <a href="/logout">Logout</a>
                 {% else %}
                     <a href="{{ path('fos_user_registration_register') }}">Create a new account</a>
                     |
-                    <a href="{{ path('fos_user_security_login') }}">Login</a>
+                    <a href="{{ path('hwi_oauth_connect') }}">Login</a>
                 {% endif %}
             </div>
 
@@ -81,10 +81,10 @@
             <ul>
                 {% if app.user %}
                     <li><a href="{{ path('fos_user_profile_show') }}">{{ 'menu.profile'|trans }}</a></li>
-                    <li><a href="{{ path('fos_user_security_logout') }}">{{ 'menu.logout'|trans }}</a></li>
+                    <li><a href="/logout">{{ 'menu.logout'|trans }}</a></li>
                 {% else %}
                     <li><a href="{{ path('fos_user_registration_register') }}">{{ 'menu.register'|trans }}</a></li>
-                    <li><a href="{{ path('fos_user_security_login') }}">{{ 'menu.login'|trans }}</a></li>
+                    <li><a href="{{ path('hwi_oauth_connect') }}">{{ 'menu.login'|trans }}</a></li>
                 {% endif %}
             </ul>
             <ul>


### PR DESCRIPTION
Note that this is a WIP. I haven't thoroughly tested it yet and there is still quite some stuff to do.

TODO:
- Style login page (and render the FOSUB login form there too)
- Style 'connect' page
- Add "Register with GitHub" button to registration page
- Add "Connect your GitHub account" to profile page
- Add unique validation to the email address (oauth registration form)

@Seldaek
- I guess the access token should be saved with the user too?
- The oauth registration form currently contains both the username and the mail address. Do you want the mail address to be optional?
