### PR TITLE
Improve searching, fixes #158

### DIFF
--- a/doc/schema.xml
+++ b/doc/schema.xml
@@ -38,11 +38,12 @@
     <fieldType name="text_edgengram" class="solr.TextField" positionIncrementGap="100">
         <analyzer type="index">
             <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.WordDelimiterFilterFactory" splitOnCaseChange="1" generateWordParts="1" preserveOriginal="1"/>
             <filter class="solr.LowerCaseFilterFactory"/>
             <filter class="solr.EdgeNGramFilterFactory" minGramSize="1" maxGramSize="100" />
         </analyzer>
         <analyzer type="query">
-            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
             <filter class="solr.LowerCaseFilterFactory"/>
         </analyzer>
     </fieldType>
@@ -267,6 +268,5 @@
    <copyField source="name" dest="name_split"/>
 
    <copyField source="name" dest="text_ngram"/>
-   <copyField source="description" dest="text_ngram"/>
    <copyField source="tags" dest="text_ngram"/>
 </schema>

--- a/src/Packagist/WebBundle/Controller/WebController.php
+++ b/src/Packagist/WebBundle/Controller/WebController.php
@@ -115,11 +115,13 @@ class WebController extends Controller
 
                 $select = $solarium->createSelect();
 
-                $escapedQuery = $select->getHelper()->escapePhrase($form->getData()->getQuery());
+                $escapedQuery = $select->getHelper()->escapeTerm($form->getData()->getQuery());
 
                 $dismax = $select->getDisMax();
-                $dismax->setQueryFields(array('name', 'description', 'tags', 'text', 'text_ngram', 'name_split'));
-                $dismax->setBoostQuery('name:'.$escapedQuery.'^2 name_split:'.$escapedQuery.'^1.5');
+                $dismax->setQueryFields(array('name^2', 'description', 'tags', 'text', 'text_ngram', 'name_split^1.5'));
+                $dismax->setPhraseFields(array('description^30'));
+                //this is very lenient, and may want to be refined
+                $dismax->setMinimumMatch(1);
                 $dismax->setQueryParser('edismax');
                 $select->setQuery($escapedQuery);
 


### PR DESCRIPTION
Changes :
- Filters package names such that they are searchable (#158)
- set dismas qf to highly boost phrases found in description (appears to be the only long text field we have at the moment)
- move the specified bq boosts to qf
- set the dismax minimum patch parameter to 1 (this is very lenient and you may want to refine)
- remove the description from the ngram field, as it will just create a load of false positives
