### PR TITLE
Throw error response if package was not found

### DIFF
--- a/src/Packagist/WebBundle/Controller/WebController.php
+++ b/src/Packagist/WebBundle/Controller/WebController.php
@@ -286,6 +286,10 @@ class WebController extends Controller
                 ->getRepository('PackagistWebBundle:Package')
                 ->getFullPackageByName($name);
         } catch (NoResultException $e) {
+            if ('json' === $req->getRequestFormat()) {
+                return new JsonResponse(array('status' => 'error', 'message' => 'Package not found'), 404);
+            }
+
             return $this->redirect($this->generateUrl('search', array('q' => $name, 'reason' => 'package_not_found')));
         }
 


### PR DESCRIPTION
When calling `packages/{name}.json`, throw error response if package was not found, rather than redirecting to search page.
