### PR TITLE
fixed order of steps in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Installation
 ------------
 
 1. Clone the repository
-2. Install dependencies: `php composer.phar install`
-3. Copy `app/config/parameters.yml.dist` to `app/config/parameters.yml` and edit the relevant values for your setup.
+2. Copy `app/config/parameters.yml.dist` to `app/config/parameters.yml` and edit the relevant values for your setup.
+3. Install dependencies: `php composer.phar install`
 4. Run `app/console doctrine:schema:create` to setup the DB.
 5. Run `app/console assets:install web` to deploy the assets on the web dir.
 6. Make a VirtualHost with DocumentRoot pointing to web/


### PR DESCRIPTION
Having no configuration makes the post-install scripts die.
