### PR TITLE
improve readability of found package name

### DIFF
--- a/src/Packagist/WebBundle/Resources/public/js/submitPackage.js
+++ b/src/Packagist/WebBundle/Resources/public/js/submitPackage.js
@@ -12,7 +12,7 @@
                 $('#submit-package-form div').prepend('<ul>'+html+'</ul>');
             } else {
                 $('#submit-package-form input[type="submit"]').before(
-                    '<div class="confirmation">The package name found for your repository is: '+data.name+', press Submit to confirm.</div>'
+                    '<div class="confirmation">The package name found for your repository is: <strong>'+data.name+'</strong>, press Submit to confirm.</div>'
                 );
                 $('#submit').val('Submit');
                 $('#submit-package-form').unbind('submit');


### PR DESCRIPTION
When submitting a new package (I recently added about 20 in human batch mode), I had a hard time focussing the package name. Highlighting it makes it easier to see the important part. :-)
