### PR TITLE
Added some missing asset() calls in the templates

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/layout.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/layout.html.twig
@@ -27,7 +27,7 @@
             <link rel="stylesheet" href="{{ asset_url }}" />
         {% endstylesheets %} #}
 
-        <script src="/js/libs/modernizr-1.7.min.js"></script>
+        <script src="{{ asset('js/libs/modernizr-1.7.min.js') }}"></script>
     </head>
     <body>
         <div class="container">
@@ -99,7 +99,7 @@
         </footer>
 
         <script src="//ajax.googleapis.com/ajax/libs/jquery/1.5.2/jquery.min.js"></script>
-        <script>!window.jQuery && document.write(unescape('%3Cscript src="/js/libs/jquery-1.5.2.min.js"%3E%3C/script%3E'))</script>
+        <script>!window.jQuery && document.write(unescape('%3Cscript src="{{ asset('js/libs/jquery-1.5.2.min.js') }}"%3E%3C/script%3E'))</script>
         <script src="{{ asset('js/libs/humane.min.js') }}"></script>
         <script src="{{ asset('bundles/packagistweb/js/layout.js') }}"></script>
         <script src="{{ asset('bundles/packagistweb/js/search.js')}}"></script>


### PR DESCRIPTION
This makes these assets work also when the site is not at the root of the
domain (when developing without createing a dedicated virtual host).
