### PR TITLE
Moved the composer bin back in the vendor folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,9 +54,6 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets"
         ]
     },
-    "config": {
-        "bin-dir": "bin"
-    },
     "extra": {
         "symfony-app-dir": "app",
         "symfony-web-dir": "web"

--- a/composer.lock
+++ b/composer.lock
@@ -1,5 +1,5 @@
 {
-    "hash": "f213345e7df3e164f2c73ef89edd81c4",
+    "hash": "7ec0e6e0a9c4da86f2c0093fc032a99a",
     "packages": [
         {
             "package": "composer/composer",


### PR DESCRIPTION
It does not make sense to put them in a non-ignored folder, and they are
not needed for packagist anyway.
