### PR TITLE
Added copy/paste Version String

### DIFF
--- a/src/Packagist/WebBundle/Resources/public/css/main.css
+++ b/src/Packagist/WebBundle/Resources/public/css/main.css
@@ -527,6 +527,10 @@ form ul {
   margin-left: 2px;
   list-style: disc inside none;
 }
+.package .include {
+    font-family: courier;
+    padding: 3px 0 3px 0;
+}
 .package .package-links .provides {
   clear: left;
 }

--- a/src/Packagist/WebBundle/Resources/views/Web/versionDetails.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/versionDetails.html.twig
@@ -1,5 +1,9 @@
 {% import "PackagistWebBundle::macros.html.twig" as packagist %}
 
+<div class="include">
+    "{{ version.package.vendor }}/{{ version.package.packageName }}": "{{ version.version }}"
+</div>
+
 <h2 class="authors">Author{{ version.authors|length > 1 ? 's' : '' }}</h2>
 <ul>
     {% for author in version.authors %}


### PR DESCRIPTION
For each release of a package, I've added a version string that can be copy/pasted into your composer.json.  I find this useful, having used it on sites likes clojars (eg. https://clojars.org/ring)
