### PR TITLE
Fixing issue #240: Adding basic open search support to packagist.org

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/layout.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/layout.html.twig
@@ -23,6 +23,8 @@
         <link rel="alternate" type="application/rss+xml" title="Newly Submitted Packages - Packagist" href="{{ url('feed_packages', {_format: 'rss'}) }}" />
         <link rel="alternate" type="application/rss+xml" title="New Releases - Packagist" href="{{ url('feed_releases', {_format: 'rss'}) }}" />
 
+        <link rel="search" type="application/opensearchdescription+xml" href="{{ asset('search.osd') }}" title="Packagist.org search" />
+
         {# {% stylesheets
             '@PackagistWebBundle/Resources/public/css/main.css'
             'css/humane/jackedup.css'

--- a/web/search.osd
+++ b/web/search.osd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+<ShortName>Packagist.org Search</ShortName>
+<Description>Use Packagist.org to search for packages.</Description>
+<Tags>packagist composer</Tags>
+<Contact>contact@packagist.org</Contact>
+<Url type="text/html" 
+    template="http://packagist.org/search/?q={searchTerms}"/>
+</OpenSearchDescription>


### PR DESCRIPTION
Added very basic "Open Search" support:
- basic search.osd for Packagist.org with web search results.
- added a basic auto-discovery tag to the layout.php.twig that references the new file.

To test:
- checkout my branch
- load any of the pages and in the search box dropdown (at least in Firefox) you should see a new option to add "Packagist.org" search.
