### PR TITLE
Fix for Long "require" statements being hidden on the packagist site

### DIFF
--- a/src/Packagist/WebBundle/Resources/public/css/main.css
+++ b/src/Packagist/WebBundle/Resources/public/css/main.css
@@ -555,7 +555,7 @@ form ul {
   border-radius: 0;
   background-color: transparent;
   font-family: Courier;
-  min-width: 300px;
+  min-width: 500px;
   width: auto;
 }
 .package .package-links .provides {


### PR DESCRIPTION
Take a look at this example package:
https://packagist.org/packages/jmhobbs/swiftmailer-transport-aws-ses

Look where it provides the "require" string to add to your project's composer.json file:
"jmhobbs/swiftmailer-transport-aws-ses": "dev-master"

The package name causes the string to be larger than the 300px width of the read-only text-input, essentially cutting the string off. Because there is no border around the input and the background is transparent, it can be confusing and/or cause issues for users.

You can view the entire string by clicking and highlighting to the right while the input scrolls, but this is not easy to notice. 

This pull request is just making that input field larger to accommodate "require" strings.
