### PR TITLE
Add delete button to versions

### DIFF
--- a/src/Packagist/WebBundle/Controller/WebController.php
+++ b/src/Packagist/WebBundle/Controller/WebController.php
@@ -396,19 +396,9 @@ class WebController extends Controller
         /** @var \Packagist\WebBundle\Entity\VersionRepository $repo  */
         $repo = $this->getDoctrine()->getRepository('PackagistWebBundle:Version');
 
-        /** @var Version $version  */
-        $version = $repo->getFullVersion($versionId);
-        $package = $version->getPackage();
-
-        $isMaintainer   = $package->getMaintainers()->contains($this->getUser());
-        $mayEditPackage = $this->get('security.context')->isGranted('ROLE_EDIT_PACKAGES');
-
         $html = $this->renderView(
             'PackagistWebBundle:Web:versionDetails.html.twig',
-            array(
-                'version'    => $version,
-                'mayDelete' => $isMaintainer || $mayEditPackage,
-            )
+            array('version' => $repo->getFullVersion($versionId))
         );
 
         return new JsonResponse(array('content' => $html));
@@ -432,10 +422,7 @@ class WebController extends Controller
         $version = $repo->getFullVersion($versionId);
         $package = $version->getPackage();
 
-        $isMaintainer   = $package->getMaintainers()->contains($this->getUser());
-        $mayEditPackage = $this->get('security.context')->isGranted('ROLE_EDIT_PACKAGES');
-
-        if (!$isMaintainer || !$mayEditPackage) {
+        if (!$package->getMaintainers()->contains($this->getUser()) && !$this->get('security.context')->isGranted('ROLE_EDIT_PACKAGES')) {
             throw new AccessDeniedException;
         }
 

--- a/src/Packagist/WebBundle/Resources/views/Web/versionDetails.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/versionDetails.html.twig
@@ -1,6 +1,6 @@
 {% import "PackagistWebBundle::macros.html.twig" as packagist %}
 
-{% if mayDelete is defined and mayDelete %}
+{% if is_granted('ROLE_EDIT_PACKAGES') or version.package.maintainers.contains(app.user) %}
 <form class="action" action="{{ path("delete_version", {"versionId": version.id}) }}" method="post">
     <input type="hidden" name="_method" value="DELETE" />
     <input type="submit" value="Delete">


### PR DESCRIPTION
@seldaek indicated on IRC that he would very much love to be able to delete
versions using the web interface of packagist. Since I figured it shouldn't
be much work and he just deleted a version for me I decided to throw some time
against the issue and behold! A new button!

The button only appears if the current user is maintainer or has the
ROLE_EDIT_PACKAGES role; the action executing this code is also protected using
same credentials.

This button replicates the behaviour of the clearVersionsCommand as indicated
by Seldaek.

I have tested this in a local setup.

p.s. the button is explicitly disabled on the first version as that is the main version 
and it will only show when expanding the foldout. I assumed the interface would 
become too cluttered if I placed it in the top.
