### PR TITLE
Show source reference for development versions

### DIFF
--- a/src/Packagist/WebBundle/Resources/public/css/main.css
+++ b/src/Packagist/WebBundle/Resources/public/css/main.css
@@ -512,6 +512,10 @@ form ul {
   margin-bottom: 5px;
   cursor: pointer;
 }
+.package .version .source-reference {
+  padding-left: 10px;
+  font-size: 12px;
+}
 .package .version .release-date {
   padding-left: 10px;
   font-size: 14px;

--- a/src/Packagist/WebBundle/Resources/views/Web/viewPackage.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/viewPackage.html.twig
@@ -124,6 +124,9 @@
                                     {% if version.hasVersionAlias() %}
                                         / {{ version.versionAlias }}
                                     {% endif %}
+                                    {% if version.isDevelopment %}
+                                    <span class="source-reference">reference: {{ version.source.reference|prettify_source_reference }}</span>
+                                    {% endif %}
                                     <span class="release-date">{{ version.releasedAt|date("Y-m-d H:i") }} UTC</span>
                                     <span class="license{% if not version.license %} unknown{% endif %}">{{ version.license ? version.license|join(', ') : 'Unknown License' }}</span>
                                 </h1>

--- a/src/Packagist/WebBundle/Twig/PackagistExtension.php
+++ b/src/Packagist/WebBundle/Twig/PackagistExtension.php
@@ -23,6 +23,13 @@ class PackagistExtension extends \Twig_Extension
         );
     }
 
+    public function getFilters()
+    {
+        return array(
+            'prettify_source_reference' => new \Twig_Filter_Method($this, 'prettifySourceReference')
+        );
+    }
+
     public function getName()
     {
         return 'packagist';
@@ -36,5 +43,14 @@ class PackagistExtension extends \Twig_Extension
 
         return $this->doctrine->getRepository('PackagistWebBundle:Package')
             ->packageExists($package);
+    }
+
+    public function prettifySourceReference($sourceReference)
+    {
+        if (preg_match('/^[a-f0-9]{40}$/', $sourceReference)) {
+            return substr($sourceReference, 0, 7);
+        }
+
+        return $sourceReference;
     }
 }


### PR DESCRIPTION
I can't count the number of times I wanted to know which hash Packagist had for a branch to see whether or not Packagist was accurately reflecting my repository. I looked for an open issue on this as I thought I had seen one at one point. The closest I found was  #216 though it did not request this functionality directly.
