### PR TITLE
[WIP] Show nicer require line for numbered dev branches.

### DIFF
--- a/src/Packagist/WebBundle/Entity/Version.php
+++ b/src/Packagist/WebBundle/Entity/Version.php
@@ -385,6 +385,14 @@ class Version
     }
 
     /**
+     * @return string
+     */
+    public function getRequireVersion()
+    {
+        return str_replace('.x-dev', '.*@dev', $this->getVersion());
+    }
+
+    /**
      * Set normalizedVersion
      *
      * @param string $normalizedVersion
@@ -894,6 +902,14 @@ class Version
         }
 
         return '';
+    }
+
+    /**
+     * @return string
+     */
+    public function getRequireVersionAlias()
+    {
+        return str_replace('.x-dev', '.*@dev', $this->getVersionAlias());
     }
 
     public function __toString()

--- a/src/Packagist/WebBundle/Resources/views/Web/versionDetails.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/versionDetails.html.twig
@@ -1,6 +1,6 @@
 {% import "PackagistWebBundle::macros.html.twig" as packagist %}
 
-<p class="requireme">require: <input type="text" readonly="readonly" value="{{ "\"#{version.package.vendor}/#{version.package.packageName}\": \"#{version.hasVersionAlias() ? version.versionAlias : version.version}\"" }}" /></p>
+<p class="requireme">require: <input type="text" readonly="readonly" value="{{ "\"#{version.package.vendor}/#{version.package.packageName}\": \"#{version.hasVersionAlias() ? version.requireVersionAlias : version.requireVersion}\"" }}" /></p>
 
 <h2 class="authors">Author{{ version.authors|length > 1 ? 's' : '' }}</h2>
 <ul>


### PR DESCRIPTION
It is unclear to me if requiring "3.5.x-dev" behaves exactly the same way as "3.5.*@dev". Packagist currently suggests the former when I generally use the latter.

Best case, this is actually more correct and causes less problems down the line. Worse case, it just looks prettier to some people. :)

![2012-12-11_1717](https://f.cloud.github.com/assets/191200/7106/0a0ae306-43e9-11e2-9403-61ce4d2a4cab.png)
![2012-12-11_1717b](https://f.cloud.github.com/assets/191200/7107/0a180ae0-43e9-11e2-9070-365415202584.png)
