### PR TITLE
Fixed license alignment issue

### DIFF
--- a/src/Packagist/WebBundle/Resources/public/css/main.css
+++ b/src/Packagist/WebBundle/Resources/public/css/main.css
@@ -523,7 +523,6 @@ form ul {
 }
 .package .version .license {
   float: right;
-  width: 250px;
   font-size: 14px;
   clear: right;
   text-align: right;


### PR DESCRIPTION
This should fix the alignment issue reported by @stof, though it is not clear to me why the license had a fixed width before? I'm guessing for some license entries that were too long? If there are things I can test against on here I'd be happy to do so. Otherwise this looks to work for textile, Guzzle, Sculpin, and zendframework1 in my development environment.
