### PR TITLE
Warn on similarly named packages

### DIFF
--- a/src/Packagist/WebBundle/Controller/WebController.php
+++ b/src/Packagist/WebBundle/Controller/WebController.php
@@ -261,7 +261,26 @@ class WebController extends Controller
         if ('POST' === $req->getMethod()) {
             $form->bind($req);
             if ($form->isValid()) {
-                $response = array('status' => 'success', 'name' => $package->getName());
+                list($vendor, $name) = explode('/', $package->getName(), 2);
+
+                $existingPackages = $this->getDoctrine()
+                    ->getRepository('PackagistWebBundle:Package')
+                    ->createQueryBuilder('p')
+                    ->where('p.name LIKE ?0')
+                    ->setParameters(array('%/'.$name))
+                    ->getQuery()
+                    ->getResult();
+
+                $similar = array();
+
+                foreach ($existingPackages as $existingPackage) {
+                    $similar[] = array(
+                        'name' => $existingPackage->getName(),
+                        'url' => $this->generateUrl('view_package', array('name' => $existingPackage->getName()), true),
+                    );
+                }
+
+                $response = array('status' => 'success', 'name' => $package->getName(), 'similar' => $similar);
             } else {
                 $errors = array();
                 if ($form->hasErrors()) {

--- a/src/Packagist/WebBundle/Resources/public/js/submitPackage.js
+++ b/src/Packagist/WebBundle/Resources/public/js/submitPackage.js
@@ -1,4 +1,5 @@
 (function ($) {
+    var showSimilarMax = 5;
     var onSubmit = function(e) {
         var success;
         $('div > ul, div.confirmation', this).remove();
@@ -11,6 +12,23 @@
                 });
                 $('#submit-package-form div').prepend('<ul>'+html+'</ul>');
             } else {
+                if (data.similar.length) {
+                    var $similar = $('<ul>');
+                    var limit = data.similar.length > showSimilarMax ? showSimilarMax : data.similar.length;
+                    for ( var i = 0; i < limit; i++ ) {
+                        var similar = data.similar[i];
+                        var $link = $('<a>').attr('href', similar.url).text(similar.name);
+                        $similar.append($('<li>').append($link))
+                    }
+                    if (limit != data.similar.length) {
+                        $similar.append($('<li>').text('And ' + (data.similar.length - limit) + ' more'));
+                    }
+                    $('#submit-package-form input[type="submit"]').before($('<div>').append(
+                        '<p><strong>Notice:</strong> One or more similarly named packages have already been submitted to Packagist. If this is a fork read the notice above regarding VCS Repositories.'
+                    ).append(
+                        '<p>Similarly named packages:'
+                    ).append($similar));
+                }
                 $('#submit-package-form input[type="submit"]').before(
                     '<div class="confirmation">The package name found for your repository is: <strong>'+data.name+'</strong>, press Submit to confirm.</div>'
                 );


### PR DESCRIPTION
Performs a search on the package name. If search returns any results for the detected package name a warning is displayed reading:

> **Notice:** One or more similarly named packages have already been submitted to Packagist. If this is a fork read the notice above regarding VCS Repositories.
> 
> Similarly named packages:
> - somevendor/somepackage

Up to 5 packages will be listed. If more, any packages after the 5th are rolled into one line stating, "And N more." So for example, if 13 packages are found, it will read, "And 8 more". The packages are clickable so that the user can have the opportunity to visit the already submitted packages.

refs #109

I'd say it closes it, but that is a more complicated solution (specific GitHub driver to detect **actual** forks) so we can close it if this does a solid enough job.

I'm new to Solr so I don't know if I did the query correctly. I only wanted to search based on name but what I'd really like to do is search based on just the latter part of the name but I don't think any of the indexes are currently setup for that.

For example, **someone/doctrine-bundle** should probably get a really high hit for **doctrine-bundle** and not so much worry about the **someone** part. As it is now, this will probably match quite often anytime someone submits anything with any of the big vendors in the name. But maybe that won't be a bad thing?
