### PR TITLE
Note the version of solr that the schema works for

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You should now be able to access the site, create a user, etc.
 Setting up search
 -----------------
 
-The search index uses [Solr](http://lucene.apache.org/solr/), so you will have to install that on your server.
+The search index uses [Solr](http://lucene.apache.org/solr/) 3.6, so you will have to install that on your server.
 If you are running it on a non-standard host or port, you will have to adjust the configuration. See the
 [NelmioSolariumBundle](https://github.com/nelmio/NelmioSolariumBundle) for more details.
 


### PR DESCRIPTION
I did some trial and error with 4.0 and I could not get it to work. I'm guessing that the schema is specific to 3.6? If so, putting that in the docs will save some time for the next person trying to set it up.

I am sure that Solar setup and installation is out of scope for this README but I spent a _lot_ of time trying to get it going. It was not easy at all. At least knowing which version of Solr to install probably would have helped shave off some of that time.
