### PR TITLE
Packagist cannot add packages from ssh url

### DIFF
--- a/src/Packagist/WebBundle/Entity/Package.php
+++ b/src/Packagist/WebBundle/Entity/Package.php
@@ -163,7 +163,7 @@ class Package
         $property = 'repository';
         $driver = $this->vcsDriver;
         if (!is_object($driver)) {
-            if (preg_match('{//.+@}', $this->repository)) {
+            if (preg_match('{https?://.+@}', $this->repository)) {
                 $context->addViolationAtSubPath($property, 'URLs with user@host are not supported, use a read-only public URL', array(), null);
             } else {
                 $context->addViolationAtSubPath($property, 'No valid/supported repository was found at the given URL', array(), null);
@@ -326,7 +326,7 @@ class Package
         $this->repository = $repository;
 
         // avoid user@host URLs
-        if (preg_match('{//.+@}', $repository)) {
+        if (preg_match('{https?://.+@}', $repository)) {
             return;
         }
 


### PR DESCRIPTION
This PR updates the regex patterns to check for https? when matching to the user@host format.  This allows for ssh repos to be still accessible when apache is configured to have a private key.
