### PR TITLE
Expose the time a package is created via the JSON API

### DIFF
--- a/src/Packagist/WebBundle/Entity/Package.php
+++ b/src/Packagist/WebBundle/Entity/Package.php
@@ -145,6 +145,7 @@ class Package
         $data = array(
             'name' => $this->getName(),
             'description' => $this->getDescription(),
+            'time' => $this->getCreatedAt()->format('c'),
             'maintainers' => $maintainers,
             'versions' => $versions,
             'type' => $this->getType(),


### PR DESCRIPTION
- Exposes the time a package was created in the detail JSON.
- Uses the `time` key for consistency with package versions.
