### PR TITLE
Add autofocus attribute on search input

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/Web/searchForm.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/searchForm.html.twig
@@ -2,7 +2,7 @@
     <p class="submit-wrapper"><input class="submit" type="submit" value="Search" /></p>
     <p>
         {{ form_errors(searchForm.query) }}
-        {{ form_widget(searchForm.query, {'attr': {'autocomplete': 'off', 'placeholder': 'Search packages...', 'tabindex': 1}}) }}
+        {{ form_widget(searchForm.query, {'attr': {'autocomplete': 'off', 'autofocus': 'autofocus', 'placeholder': 'Search packages...', 'tabindex': 1}}) }}
         {{ form_rest(searchForm) }}
     </p>
 </form>


### PR DESCRIPTION
I simply added the autofocus HTML5 attribute on search input, so that we can avoid the "boring" mouse click on page load to select the search field :)
