### PR TITLE
FIX Use strings for type keys

### DIFF
--- a/src/Packagist/WebBundle/Controller/WebController.php
+++ b/src/Packagist/WebBundle/Controller/WebController.php
@@ -281,7 +281,7 @@ class WebController extends Controller
                         $params['tags'] = (array) $tagsFilter;
                     }
                     if ($typeFilter) {
-                        $params['type'] = (array) $typeFilter;
+                        $params['type'] = $typeFilter;
                     }
                     $result['next'] = $this->generateUrl('search', $params, true);
                 }


### PR DESCRIPTION
The problem here is that doing a search.json?type=x causes the pagination to use ?type[0]=x which causes no results, as there is no handling of type being an array.
