### PR TITLE
Fix tag wrapping

### DIFF
--- a/src/Packagist/WebBundle/Resources/public/css/main.css
+++ b/src/Packagist/WebBundle/Resources/public/css/main.css
@@ -470,6 +470,7 @@ form ul {
 }
 .package .tags {
   line-height: 34px;
+  word-wrap: break-word;
 }
 .package .tags a {
   background: #c67700;


### PR DESCRIPTION
This fixes the issue where tags don't wrap if there is a huge amount of them. See https://packagist.org/packages/omnipay/omnipay for example.
