### PR TITLE
Remove password fields when logged in with Github

### DIFF
--- a/app/Resources/FOSUserBundle/views/Profile/edit_content.html.twig
+++ b/app/Resources/FOSUserBundle/views/Profile/edit_content.html.twig
@@ -1,7 +1,9 @@
 <form action="{{ path('fos_user_profile_edit') }}" {{ form_enctype(form) }} method="POST" class="fos_user_profile_edit">
     {{ form_row(form.username) }}
     {{ form_row(form.email) }}
+    {% if not user.githubId %}
     {{ form_row(form.current_password) }}
+    {% endif %}
 
     <div class="notifications">
         {{ form_errors(form.failureNotifications) }}

--- a/app/Resources/FOSUserBundle/views/Profile/show.html.twig
+++ b/app/Resources/FOSUserBundle/views/Profile/show.html.twig
@@ -6,8 +6,8 @@
     <div class="box clearfix">
         <h1>{{ user.username }} (that's you!)</h1>
         <p><a href="{{ path('fos_user_profile_edit') }}">Edit your information</a></p>
-        <p><a href="{{ path('fos_user_change_password') }}">Change your password</a></p>
         {% if not user.githubId %}
+        <p><a href="{{ path('fos_user_change_password') }}">Change your password</a></p>
         <p><a href="{{ hwi_oauth_login_url('github') }}">Connect your github account</a></p>
         {% endif %}
         <p><a href="{{ path('user_favorites', {name: app.user.username}) }}">View your favorites</a></p>

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -12,6 +12,10 @@ fos_user_profile_show:
     requirements:
         _method: GET
 
+fos_user_profile_edit:
+    pattern: /profile/edit/
+    defaults: { _controller: PackagistWebBundle:Profile:edit }
+
 fos_user_register:
     resource: "@FOSUserBundle/Resources/config/routing/registration.xml"
     prefix: /register

--- a/src/Packagist/WebBundle/Controller/ProfileController.php
+++ b/src/Packagist/WebBundle/Controller/ProfileController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Packagist\WebBundle\Controller;
+
+use FOS\UserBundle\Controller\ProfileController as BaseController;
+use FOS\UserBundle\Model\UserInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+class ProfileController extends BaseController
+{
+    public function editAction()
+    {
+        $user = $this->container->get('security.context')->getToken()->getUser();
+        if (!is_object($user) || !$user instanceof UserInterface) {
+            throw new AccessDeniedException('This user does not have access to this section.');
+        }
+
+        $form = $this->container->get('fos_user.profile.form');
+        $formHandler = $this->container->get('fos_user.profile.form.handler');
+
+        $process = $formHandler->process($user);
+        if ($process) {
+            $this->setFlash('fos_user_success', 'profile.flash.updated');
+
+            return new RedirectResponse($this->getRedirectionUrl($user));
+        }
+
+        return $this->container->get('templating')->renderResponse(
+            'FOSUserBundle:Profile:edit.html.'.$this->container->getParameter('fos_user.template.engine'),
+            array('form' => $form->createView(), 'user' => $user)
+        );
+    }
+}

--- a/src/Packagist/WebBundle/Form/Type/ProfileFormType.php
+++ b/src/Packagist/WebBundle/Form/Type/ProfileFormType.php
@@ -52,20 +52,13 @@ class ProfileFormType extends BaseType
         $builder->add('failureNotifications', null, array('required' => false, 'label' => 'Notify me of package update failures'));
     }
 
-    private function addPasswordField(&$event)
+    private function addPasswordField($event)
     {
-        if (class_exists('Symfony\Component\Security\Core\Validator\Constraints\UserPassword')) {
-            $constraint = new UserPassword();
-        } else {
-            // Symfony 2.1 support with the old constraint class
-            $constraint = new OldUserPassword();
-        }
-
         $event->getForm()->add('current_password', 'password', array(
             'label' => 'form.current_password',
             'translation_domain' => 'FOSUserBundle',
             'mapped' => false,
-            'constraints' => $constraint,
+            'constraints' => new UserPassword(),
         ));
     }
 

--- a/src/Packagist/WebBundle/Form/Type/ProfileFormType.php
+++ b/src/Packagist/WebBundle/Form/Type/ProfileFormType.php
@@ -28,12 +28,14 @@ class ProfileFormType extends BaseType
         $builder->add('username', null, array('label' => 'form.username', 'translation_domain' => 'FOSUserBundle'))
                 ->add('email', 'email', array('label' => 'form.email', 'translation_domain' => 'FOSUserBundle'));
 
-        $builder->addEventListener(FormEvents::PRE_SET_DATA, function(FormEvent $event)
+        // Horrible hack for people stuck in the past on PHP5.3
+        $self = $this;
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function(FormEvent $event) use ($self)
         {
             if ( ! ($user = $event->getData())) return;
 
             if ( ! $user->getGithubId()) {
-                $this->addPasswordField($event);
+                $self->addPasswordField($event);
             }
         });
 

--- a/src/Packagist/WebBundle/Form/Type/ProfileFormType.php
+++ b/src/Packagist/WebBundle/Form/Type/ProfileFormType.php
@@ -25,26 +25,16 @@ use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
  */
 class ProfileFormType extends BaseType
 {
-    private $securityContext;
-
-    public function __construct($class, SecurityContext $securityContext)
-    {
-        parent::__construct($class);
-
-        $this->securityContext = $securityContext;
-    }
-
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->add('username', null, array('label' => 'form.username', 'translation_domain' => 'FOSUserBundle'))
                 ->add('email', 'email', array('label' => 'form.email', 'translation_domain' => 'FOSUserBundle'));
 
-        $user = $this->securityContext->getToken()->getUser();
-
-        $builder->addEventListener(FormEvents::PRE_SET_DATA, function(FormEvent $event) use ($user)
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function(FormEvent $event)
         {
-            if ( ! $user->getGithubId())
-            {
+            if ( ! ($user = $event->getData())) return;
+
+            if ( ! $user->getGithubId()) {
                 $this->addPasswordField($event);
             }
         });

--- a/src/Packagist/WebBundle/Form/Type/ProfileFormType.php
+++ b/src/Packagist/WebBundle/Form/Type/ProfileFormType.php
@@ -16,8 +16,6 @@ use FOS\UserBundle\Form\Type\ProfileFormType as BaseType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Security\Core\SecurityContext;
-use Symfony\Component\Security\Core\Validator\Constraint\UserPassword as OldUserPassword;
 use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
 
 /**

--- a/src/Packagist/WebBundle/Form/Type/ProfileFormType.php
+++ b/src/Packagist/WebBundle/Form/Type/ProfileFormType.php
@@ -14,17 +14,59 @@ namespace Packagist\WebBundle\Form\Type;
 
 use FOS\UserBundle\Form\Type\ProfileFormType as BaseType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Security\Core\SecurityContext;
+use Symfony\Component\Security\Core\Validator\Constraint\UserPassword as OldUserPassword;
+use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
 class ProfileFormType extends BaseType
 {
+    private $securityContext;
+
+    public function __construct($class, SecurityContext $securityContext)
+    {
+        parent::__construct($class);
+
+        $this->securityContext = $securityContext;
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        parent::buildForm($builder, $options);
+        $builder->add('username', null, array('label' => 'form.username', 'translation_domain' => 'FOSUserBundle'))
+                ->add('email', 'email', array('label' => 'form.email', 'translation_domain' => 'FOSUserBundle'));
+
+        $user = $this->securityContext->getToken()->getUser();
+
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function(FormEvent $event) use ($user)
+        {
+            if ( ! $user->getGithubId())
+            {
+                $this->addPasswordField($event);
+            }
+        });
 
         $builder->add('failureNotifications', null, array('required' => false, 'label' => 'Notify me of package update failures'));
+    }
+
+    private function addPasswordField(&$event)
+    {
+        if (class_exists('Symfony\Component\Security\Core\Validator\Constraints\UserPassword')) {
+            $constraint = new UserPassword();
+        } else {
+            // Symfony 2.1 support with the old constraint class
+            $constraint = new OldUserPassword();
+        }
+
+        $event->getForm()->add('current_password', 'password', array(
+            'label' => 'form.current_password',
+            'translation_domain' => 'FOSUserBundle',
+            'mapped' => false,
+            'constraints' => $constraint,
+        ));
     }
 
     public function getName()

--- a/src/Packagist/WebBundle/Form/Type/ProfileFormType.php
+++ b/src/Packagist/WebBundle/Form/Type/ProfileFormType.php
@@ -28,28 +28,21 @@ class ProfileFormType extends BaseType
         $builder->add('username', null, array('label' => 'form.username', 'translation_domain' => 'FOSUserBundle'))
                 ->add('email', 'email', array('label' => 'form.email', 'translation_domain' => 'FOSUserBundle'));
 
-        // Horrible hack for people stuck in the past on PHP5.3
-        $self = $this;
-        $builder->addEventListener(FormEvents::PRE_SET_DATA, function(FormEvent $event) use ($self)
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function(FormEvent $event)
         {
             if ( ! ($user = $event->getData())) return;
 
             if ( ! $user->getGithubId()) {
-                $self->addPasswordField($event);
+                $event->getForm()->add('current_password', 'password', array(
+                    'label' => 'form.current_password',
+                    'translation_domain' => 'FOSUserBundle',
+                    'mapped' => false,
+                    'constraints' => new UserPassword(),
+                ));
             }
         });
 
         $builder->add('failureNotifications', null, array('required' => false, 'label' => 'Notify me of package update failures'));
-    }
-
-    private function addPasswordField($event)
-    {
-        $event->getForm()->add('current_password', 'password', array(
-            'label' => 'form.current_password',
-            'translation_domain' => 'FOSUserBundle',
-            'mapped' => false,
-            'constraints' => new UserPassword(),
-        ));
     }
 
     public function getName()

--- a/src/Packagist/WebBundle/Resources/config/services.yml
+++ b/src/Packagist/WebBundle/Resources/config/services.yml
@@ -83,6 +83,6 @@ services:
 
     packagist.profile.form.type:
         class: Packagist\WebBundle\Form\Type\ProfileFormType
-        arguments: [%fos_user.model.user.class%, @security.context]
+        arguments: [%fos_user.model.user.class%]
         tags:
             - { name: form.type, alias: packagist_user_profile }

--- a/src/Packagist/WebBundle/Resources/config/services.yml
+++ b/src/Packagist/WebBundle/Resources/config/services.yml
@@ -83,6 +83,6 @@ services:
 
     packagist.profile.form.type:
         class: Packagist\WebBundle\Form\Type\ProfileFormType
-        arguments: [%fos_user.model.user.class%]
+        arguments: [%fos_user.model.user.class%, @security.context]
         tags:
             - { name: form.type, alias: packagist_user_profile }


### PR DESCRIPTION
If a user has used Github authentication to create their account, they are
not able to update their email as a password does not exist. This resolves the
issue by removing the Change Password form, and also the Password input on
the Edit Profile page.

One possible improvement that could be made in future would be additional
checks to ensure the user is still authenticated with Github, though I've
spent all day on this already so I'll leave that to somebody else to add in
;)
