### PR TITLE
Added description field

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/Web/index.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/index.html.twig
@@ -53,6 +53,7 @@ require 'vendor/autoload.php';
                 <pre>
 {
     "name": "your-vendor-name/package-name",
+    "description": "A short description of what your package does",
     "require": {
         "php": ">=5.3.0",
         "another-vendor/package": "1.*"


### PR DESCRIPTION
As specified by the composer schema docs (https://getcomposer.org/doc/04-schema.md#description) and verified by personal experience with a previous version of https://packagist.org/packages/barnabywalters/gist-test not working, the `description` key MUST be present in a “strictly minimal” package definition.
