### PR TITLE
Nicer number format for download counts

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/Web/viewPackage.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/viewPackage.html.twig
@@ -63,9 +63,9 @@
             {% endif %}
 
             <p class="downloads">
-                <span>Overall:</span> {% if downloads.total is defined %}{{ downloads.total }} install{{ downloads.total == 1 ? '' : 's' }}{% else %}N/A{% endif %}<br />
-                <span>This month:</span> {% if downloads.monthly is defined %}{{ downloads.monthly }} install{{ downloads.monthly == 1 ? '' : 's' }}{% else %}N/A{% endif %}<br />
-                <span>Today:</span> {% if downloads.daily is defined %}{{ downloads.daily }} install{{ downloads.daily == 1 ? '' : 's' }}{% else %}N/A{% endif %}<br />
+                <span>Overall:</span> {% if downloads.total is defined %}{{ downloads.total|number_format }} install{{ downloads.total == 1 ? '' : 's' }}{% else %}N/A{% endif %}<br />
+                <span>This month:</span> {% if downloads.monthly is defined %}{{ downloads.monthly|number_format }} install{{ downloads.monthly == 1 ? '' : 's' }}{% else %}N/A{% endif %}<br />
+                <span>Today:</span> {% if downloads.daily is defined %}{{ downloads.daily|number_format }} install{{ downloads.daily == 1 ? '' : 's' }}{% else %}N/A{% endif %}<br />
             </p>
 
             <p class="description">{{ package.description }}</p>


### PR DESCRIPTION
At the moment large numbers can look quite confusing, e.g. 1000000

This pull request simply formats them a bit more nicely, e.g. 1,000,000

Note that I only edited the single package page. There might be other pages where this would be useful.
