### PR TITLE
Add gitlab webhook support

### DIFF
--- a/src/Packagist/WebBundle/Controller/ApiController.php
+++ b/src/Packagist/WebBundle/Controller/ApiController.php
@@ -104,6 +104,26 @@ class ApiController extends Controller
         return $this->receivePost($request, $repoUrl, $urlRegex);
     }
 
+
+    /**
+     * @Route("/api/gitlab", name="gitlab_postreceive", defaults={"_format" = "json"})
+     * @Method({"POST"})
+     */
+    public function gitlabPostReceive(Request $request)
+    {
+        // parse the Gitlab payload
+        $payload = json_decode($request->getContent(), true);
+
+        if (!$payload || !isset($payload['repository']['url'])) {
+            return new Response(json_encode(array('status' => 'error', 'message' => 'Missing or invalid payload',)), 406);
+        }
+
+        $urlRegex = '{^(?:https?://|git://|git@)(?P<host>([^/]+))[:/](?P<path>[\w.-]+/[\w.-]+?)(?:\.git)$}';
+        $repoUrl = $payload['repository']['url'];
+
+        return $this->receivePost($request, $repoUrl, $urlRegex);
+    }
+
     /**
      * @Route("/api/bitbucket", name="bitbucket_postreceive", defaults={"_format" = "json"})
      * @Method({"POST"})


### PR DESCRIPTION
Add support for gitlab webhooks.

Ex.
https://packagist.org/api/gitlab?username=[username]&apiToken=[apiToken]

Documentation of the webhook: https://gitlab.com/help/web_hooks
