### PR TITLE
Moved tags under package name on view package page

### DIFF
--- a/src/Packagist/WebBundle/Resources/public/css/main.css
+++ b/src/Packagist/WebBundle/Resources/public/css/main.css
@@ -471,6 +471,8 @@ form ul {
 .package .tags {
   overflow: hidden;
   white-space: nowrap;
+  clear: left;
+  margin-bottom: 14px;
 }
 .package .tags a {
   background: #c67700;


### PR DESCRIPTION
Currently, if the package name is a bit lengthy, the tags are cut off:

![cutoff](https://cloud.githubusercontent.com/assets/15487/3173935/a2f89af2-ebec-11e3-9122-56322cff1948.png)

I've attached CSS changes that attempt to fix this by shifting tags onto the next line:

![visible](https://cloud.githubusercontent.com/assets/15487/3173941/b2ea0ed2-ebec-11e3-853f-91eff618f179.png)
