### PR TITLE
Abandoned status metadata

### DIFF
--- a/src/Packagist/WebBundle/Entity/Package.php
+++ b/src/Packagist/WebBundle/Entity/Package.php
@@ -168,7 +168,8 @@ class Package
             'maintainers' => $maintainers,
             'versions' => $versions,
             'type' => $this->getType(),
-            'repository' => $this->getRepository()
+            'repository' => $this->getRepository(),
+            'abandoned' => $this->isAbandoned()
         );
         return $data;
     }


### PR DESCRIPTION
Added the abandoned status to the `toArray` method of packages so it is
attached to the json data also.

This complements the abandon package feature and allows us to carry on
with work in composer to warn users of abandoned packages at install
time.
