### PR TITLE
Remove unused use statements

### DIFF
--- a/src/Packagist/WebBundle/Command/ClearVersionsCommand.php
+++ b/src/Packagist/WebBundle/Command/ClearVersionsCommand.php
@@ -13,12 +13,9 @@
 namespace Packagist\WebBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
-use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\HttpKernel\KernelInterface;
-use Symfony\Component\Finder\Finder;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>

--- a/src/Packagist/WebBundle/Command/CompileStatsCommand.php
+++ b/src/Packagist/WebBundle/Command/CompileStatsCommand.php
@@ -15,16 +15,7 @@ namespace Packagist\WebBundle\Command;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\OutputInterface;
-use Packagist\WebBundle\Package\Updater;
-use Composer\Repository\VcsRepository;
-use Composer\Factory;
-use Composer\Package\Loader\ValidatingArrayLoader;
-use Composer\Package\Loader\ArrayLoader;
-use Composer\IO\BufferIO;
-use Composer\IO\ConsoleIO;
-use Composer\Repository\InvalidRepositoryException;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>

--- a/src/Packagist/WebBundle/Command/DumpPackagesCommand.php
+++ b/src/Packagist/WebBundle/Command/DumpPackagesCommand.php
@@ -15,7 +15,6 @@ namespace Packagist\WebBundle\Command;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Packagist/WebBundle/Controller/AboutController.php
+++ b/src/Packagist/WebBundle/Controller/AboutController.php
@@ -12,7 +12,6 @@
 
 namespace Packagist\WebBundle\Controller;
 
-use Symfony\Component\HttpFoundation\Response;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 

--- a/src/Packagist/WebBundle/Controller/PackageController.php
+++ b/src/Packagist/WebBundle/Controller/PackageController.php
@@ -4,18 +4,13 @@ namespace Packagist\WebBundle\Controller;
 
 use Packagist\WebBundle\Form\Type\AbandonedType;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 
 use Packagist\WebBundle\Entity\Package;
-use Packagist\WebBundle\Package\Updater;
 
-use Composer\IO\NullIO;
-use Composer\Factory;
-use Composer\Repository\VcsRepository;
 
 class PackageController extends Controller
 {

--- a/src/Packagist/WebBundle/Entity/Author.php
+++ b/src/Packagist/WebBundle/Entity/Author.php
@@ -13,8 +13,6 @@
 namespace Packagist\WebBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\ExecutionContext;
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**

--- a/src/Packagist/WebBundle/Entity/ConflictLink.php
+++ b/src/Packagist/WebBundle/Entity/ConflictLink.php
@@ -13,7 +13,6 @@
 namespace Packagist\WebBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @ORM\Entity

--- a/src/Packagist/WebBundle/Entity/DevRequireLink.php
+++ b/src/Packagist/WebBundle/Entity/DevRequireLink.php
@@ -13,7 +13,6 @@
 namespace Packagist\WebBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @ORM\Entity

--- a/src/Packagist/WebBundle/Entity/Package.php
+++ b/src/Packagist/WebBundle/Entity/Package.php
@@ -19,7 +19,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Composer\IO\NullIO;
 use Composer\Factory;
 use Composer\Repository\VcsRepository;
-use Composer\Repository\RepositoryManager;
 use Composer\Repository\Vcs\GitHubDriver;
 
 /**

--- a/src/Packagist/WebBundle/Entity/PackageLink.php
+++ b/src/Packagist/WebBundle/Entity/PackageLink.php
@@ -13,7 +13,6 @@
 namespace Packagist\WebBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @ORM\MappedSuperclass()

--- a/src/Packagist/WebBundle/Entity/ProvideLink.php
+++ b/src/Packagist/WebBundle/Entity/ProvideLink.php
@@ -13,7 +13,6 @@
 namespace Packagist\WebBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @ORM\Entity

--- a/src/Packagist/WebBundle/Entity/ReplaceLink.php
+++ b/src/Packagist/WebBundle/Entity/ReplaceLink.php
@@ -13,7 +13,6 @@
 namespace Packagist\WebBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @ORM\Entity

--- a/src/Packagist/WebBundle/Entity/RequireLink.php
+++ b/src/Packagist/WebBundle/Entity/RequireLink.php
@@ -13,7 +13,6 @@
 namespace Packagist\WebBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @ORM\Entity

--- a/src/Packagist/WebBundle/Entity/SuggestLink.php
+++ b/src/Packagist/WebBundle/Entity/SuggestLink.php
@@ -13,7 +13,6 @@
 namespace Packagist\WebBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @ORM\Entity

--- a/src/Packagist/WebBundle/Security/Provider/UserProvider.php
+++ b/src/Packagist/WebBundle/Security/Provider/UserProvider.php
@@ -13,7 +13,6 @@
 namespace Packagist\WebBundle\Security\Provider;
 
 use FOS\UserBundle\Model\UserManagerInterface;
-use HWI\Bundle\OAuthBundle\Connect\AccountConnectorInterface;
 use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\Exception\AccountNotLinkedException;
 use HWI\Bundle\OAuthBundle\Security\Core\User\OAuthAwareUserProviderInterface;


### PR DESCRIPTION
Hi,

i studied Packagist a little bit the last couple of days, because we want to build a composer repository for the Drupal community.

I noticed there a few unused use statements. I applied the php-cs-fixer from fabpot lib to remove those statements to get a better overview.
