### PR TITLE
Packagist is truncating `PackageLink` versions.

### DIFF
--- a/src/Packagist/WebBundle/Entity/PackageLink.php
+++ b/src/Packagist/WebBundle/Entity/PackageLink.php
@@ -33,7 +33,7 @@ abstract class PackageLink
     private $packageName;
 
     /**
-     * @ORM\Column()
+     * @ORM\Column(type="text")
      */
     private $packageVersion;
 


### PR DESCRIPTION
As a pseudo-code to reproduce the issue, try following:

``` php
public function testDoesNotTruncateVersions()
{
    $version = str_repeat('>=1', 1000);
    $require = new \Packagist\WebBundle\Entity\RequireLink();

    $require->setPackageVersion($version);

    $this->entityManager->persist($require);
    $this->entityManager->flush($require);
    $this->entityManager->refresh($require);

    $this->assertSame($version, $require->getPackageVersion());
}
```

This is currently causing an issue for a package that I was hoping to release today:

``` sh
~$ composer required roave/security-advisories:dev-master@DEV
```

Produces: 

![error screenshot](http://marco-pivetta.com/screen/caps/45a251.png)

After looking at https://packagist.org/packages/roave/security-advisories.json I noticed that the version constraints were being truncated at 255 chars:

![truncated strings](http://marco-pivetta.com/screen/caps/c96f1c.png)

This hotfix also requires following migration SQL in production:

``` sql
ALTER TABLE link_require CHANGE packageVersion packageVersion TEXT;
ALTER TABLE link_conflict CHANGE packageVersion packageVersion TEXT;
ALTER TABLE link_require_dev CHANGE packageVersion packageVersion TEXT;
ALTER TABLE link_provide CHANGE packageVersion packageVersion TEXT;
ALTER TABLE link_replace CHANGE packageVersion packageVersion TEXT;
ALTER TABLE link_require CHANGE packageVersion packageVersion TEXT;
ALTER TABLE link_suggest CHANGE packageVersion packageVersion TEXT;
```
