### PR TITLE
Fix: Update autoloading information on home page

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/Web/index.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/index.html.twig
@@ -36,7 +36,7 @@ curl -s http://getcomposer.org/installer | php
 php composer.phar install
 </pre>
                 <h2>Autoload Dependencies</h2>
-                <p>If all your packages follow the <a href="https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md">PSR-0</a> standard, you can autoload all the dependencies by adding this to your code:</p>
+                <p>If your packages specify <a href="https://getcomposer.org/doc/01-basic-usage.md#autoloading">autoloading information</a>, you can autoload all the dependencies by adding this to your code:</p>
                 <pre>
 require 'vendor/autoload.php';
 </pre>


### PR DESCRIPTION
This PR

* [x] updates the autoloading information section on the home page

Since composer not only provides PSR-0, but PSR-4 and classmap autoloading support, it makes sense to update this section to be less specific.