### PR TITLE
Fix: Undefined classes

### DIFF
--- a/src/Packagist/WebBundle/Controller/UserController.php
+++ b/src/Packagist/WebBundle/Controller/UserController.php
@@ -12,6 +12,7 @@
 
 namespace Packagist\WebBundle\Controller;
 
+use Doctrine\ORM\NoResultException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Packagist/WebBundle/Entity/Package.php
+++ b/src/Packagist/WebBundle/Entity/Package.php
@@ -157,7 +157,7 @@ class Package
         }
         $maintainers = array();
         foreach ($this->getMaintainers() as $maintainer) {
-            /** @var $maintainer Maintainer */
+            /** @var $maintainer User */
             $maintainers[] = $maintainer->toArray();
         }
         $data = array(

--- a/src/Packagist/WebBundle/Form/Handler/OAuthRegistrationFormHandler.php
+++ b/src/Packagist/WebBundle/Form/Handler/OAuthRegistrationFormHandler.php
@@ -16,7 +16,6 @@ use FOS\UserBundle\Model\UserManagerInterface;
 use FOS\UserBundle\Util\TokenGeneratorInterface;
 use HWI\Bundle\OAuthBundle\Form\RegistrationFormHandlerInterface;
 use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
-use HWI\Bundle\OAuthBundle\OAuth\Response\AdvancedUserResponseInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -52,10 +51,6 @@ class OAuthRegistrationFormHandler implements RegistrationFormHandlerInterface
         // Try to get some properties for the initial form when coming from github
         if ('GET' === $request->getMethod()) {
             $user->setUsername($this->getUniqueUsername($userInformation->getNickname()));
-
-            if ($userInformation instanceof AdvancedUserResponseInterface) {
-                $user->setEmail($userInformation->getEmail());
-            }
         }
 
         $form->setData($user);


### PR DESCRIPTION
This PR

* [x] fixes an inline comment which referred to non-existent `Entity\Maintainer`, but should be `Entity\User`
* [x] imports `Doctrine\ORM\NoResultException` so `NoResultException` can actually be caught
* [x] removes a condition depending on an interface which was removed in `hwi/oauth-bundle:0.3.0-alpha1`