### PR TITLE
Splitting strategy: always keep 4 last trimesters

### DIFF
--- a/src/Packagist/WebBundle/Package/SymlinkDumper.php
+++ b/src/Packagist/WebBundle/Package/SymlinkDumper.php
@@ -550,37 +550,50 @@ class SymlinkDumper
         return !is_dir($path);
     }
 
+    private function getTargetListingBlocks($now)
+    {
+        $blocks = array();
+
+        // monday last week
+        $blocks['latest'] = strtotime('monday last week', $now);
+
+        $month = date('n', $now);
+        $month = ceil($month / 3) * 3 - 2; // 1 for months 1-3, 10 for months 10-12
+        $block = new \DateTime(date('Y', $now).'-'.$month.'-01'); // 1st day of current trimester
+
+        // split last 12 months in 4 trimesters
+        for ($i=0; $i < 4; $i++) {
+            $blocks[$block->format('Y-m')] = $block->getTimestamp();
+            $block->sub(new \DateInterval('P3M'));
+        }
+
+        $year = (int) $block->format('Y');
+
+        while ($year >= 2012) {
+            $blocks[''.$year] = strtotime($year.'-01-01');
+            $year--;
+        }
+
+        return $blocks;
+    }
+
     private function getTargetListing($file)
     {
-        static $limitLatest, $thisYear, $limitArchived;
+        static $blocks;
 
-        if (!$limitLatest) {
-            $limitLatest   = new \DateTime('monday last week');
-            $thisYear      = new \DateTime(date('Y') . '-01-01');
-            $limitArchived = new \DateTime('2012-01-01');
+        if (!$blocks) {
+            $blocks = $this->getTargetListingBlocks(time());
         }
 
-        $mtime = new \DateTime();
-        $mtime->setTimestamp(filemtime($file));
+        $mtime = filemtime($file);
 
-        if ($mtime >= $limitLatest) {
-            $label = 'latest';
-        } elseif ($mtime >= $thisYear) {
-            // split current by chunks of 3 months, current month included
-            // past chunks will never be updated this year
-            $month = $mtime->format('n');
-            $month = ceil($month / 3) * 3;
-            $month = str_pad($month, 2, '0', STR_PAD_LEFT);
-
-            $label = $mtime->format('Y') . '-' . $month;
-        } elseif ($mtime >= $limitArchived) {
-            // split by years, limit at 2012 so we never update 'archived' again
-            $label = $mtime->format('Y');
-        } else {
-            $label = 'archived';
+        foreach ($blocks as $label => $block) {
+            if ($mtime >= $block) {
+                return "provider-${label}.json";
+            }
         }
 
-        return "provider-${label}.json";
+        return "provider-archived.json";
     }
 
     private function writeFile($path, $contents, $mtime = null)

--- a/src/Packagist/WebBundle/Tests/Package/SymlinkDumperTest.php
+++ b/src/Packagist/WebBundle/Tests/Package/SymlinkDumperTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Packagist\WebBundle\Tests\Package;
+
+class SymlinkDumperTest extends \PHPUnit_Framework_TestCase
+{
+    private $mockDumper;
+
+    public function setUp()
+    {
+        $this->mockDumper = $this->getMockBuilder('Packagist\WebBundle\Package\SymlinkDumper')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function tearDown()
+    {
+        $this->mockDumper = null;
+    }
+
+    /**
+     * @dataProvider getTestGetTargetListingBlocks
+     */
+    public function testGetTargetListingBlocks($now, array $expected)
+    {
+
+        $blocks = self::invoke($this->mockDumper, 'getTargetListingBlocks', $now);
+
+        $blocks = array_map(function($timestamp) { return date('Y-m-d', $timestamp); }, $blocks);
+
+        $this->assertEquals($expected, $blocks);
+    }
+
+    public function getTestGetTargetListingBlocks()
+    {
+        return array(
+            array(
+                strtotime('2014-12-31'),
+                array(
+                    'latest'  => '2014-12-22',
+                    '2014-10' => '2014-10-01',
+                    '2014-07' => '2014-07-01',
+                    '2014-04' => '2014-04-01',
+                    '2014-01' => '2014-01-01',
+                    '2013'    => '2013-01-01',
+                    '2012'    => '2012-01-01',
+                ),
+            ),
+            array(
+                strtotime('2015-01-01'),
+                array(
+                    'latest'  => '2014-12-22',
+                    '2015-01' => '2015-01-01',
+                    '2014-10' => '2014-10-01',
+                    '2014-07' => '2014-07-01',
+                    '2014-04' => '2014-04-01',
+                    '2014'    => '2014-01-01',
+                    '2013'    => '2013-01-01',
+                    '2012'    => '2012-01-01',
+                ),
+            ),
+            array(
+                strtotime('2015-05-31'),
+                array(
+                    'latest'  => '2015-05-25',
+                    '2015-04' => '2015-04-01',
+                    '2015-01' => '2015-01-01',
+                    '2014-10' => '2014-10-01',
+                    '2014-07' => '2014-07-01',
+                    '2014'    => '2014-01-01',
+                    '2013'    => '2013-01-01',
+                    '2012'    => '2012-01-01',
+                ),
+            ),
+        );
+    }
+
+    private static function invoke($object, $method)
+    {
+        $refl = new \ReflectionMethod($object, $method);
+        $refl->setAccessible(true);
+
+        $args = func_get_args();
+        array_shift($args); // object
+        array_shift($args); // method
+
+        return $refl->invokeArgs($object, $args);
+    }
+}


### PR DESCRIPTION
This is a respin of #463

@Seldaek mentioned that the 2014 listing was always getting updated, this is true because we are at the beginning of the year.

This fixes it by calculating the last 4 trimesters before today. The rest of the logic remains unchanged.

This PR also adds a `getTargetListingBlocks` method that declares all blocks, this simplifies the code of `getTargetListing` and allows for easier testing.

And yeah, unit tests were added too.

Sample of generated blocks:
```
2014-12-31:
    'latest'  => '2014-12-22'
    '2014-10' => '2014-10-01'
    '2014-07' => '2014-07-01'
    '2014-04' => '2014-04-01'
    '2014-01' => '2014-01-01'
    '2013'    => '2013-01-01'
    '2012'    => '2012-01-01'

2015-01-01:
    'latest'  => '2014-12-22'
    '2015-01' => '2015-01-01'
    '2014-10' => '2014-10-01'
    '2014-07' => '2014-07-01'
    '2014-04' => '2014-04-01'
    '2014'    => '2014-01-01'
    '2013'    => '2013-01-01'
    '2012'    => '2012-01-01'

2015-05-31:
    'latest'  => '2015-05-25'
    '2015-04' => '2015-04-01'
    '2015-01' => '2015-01-01'
    '2014-10' => '2014-10-01'
    '2014-07' => '2014-07-01'
    '2014'    => '2014-01-01'
    '2013'    => '2013-01-01'
    '2012'    => '2012-01-01'
```