### PR TITLE
save a lot of memory when retrive packages.json file

### DIFF
--- a/src/Packagist/WebBundle/Entity/PackageRepository.php
+++ b/src/Packagist/WebBundle/Entity/PackageRepository.php
@@ -239,17 +239,9 @@ class PackageRepository extends EntityRepository
     public function getFullPackages(array $ids = null, $filters = array())
     {
         $qb = $this->getEntityManager()->createQueryBuilder();
-        $qb->select('p', 'v', 't', 'a', 'req', 'devReq', 'sug', 'rep', 'con', 'pro')
+        $qb->select('p', 'v')
             ->from('Packagist\WebBundle\Entity\Package', 'p')
             ->leftJoin('p.versions', 'v')
-            ->leftJoin('v.tags', 't')
-            ->leftJoin('v.authors', 'a')
-            ->leftJoin('v.require', 'req')
-            ->leftJoin('v.devRequire', 'devReq')
-            ->leftJoin('v.suggest', 'sug')
-            ->leftJoin('v.replace', 'rep')
-            ->leftJoin('v.conflict', 'con')
-            ->leftJoin('v.provide', 'pro')
             ->orderBy('v.development', 'DESC')
             ->addOrderBy('v.releasedAt', 'DESC');
 


### PR DESCRIPTION
These days, I tried so hard to set up a local composer repo by packagist. But the memory problem happened after adding to much package to local repo. 
Could you believe that a single request to get packages.json would took up over 1G memory?
So that why I made this pull request.
I thought this would help other guys to solve these memory-problem.