### PR TITLE
 Sorting of search results

### DIFF
--- a/doc/schema.xml
+++ b/doc/schema.xml
@@ -236,6 +236,8 @@
    <field name="description" type="text_general_rev" indexed="true" stored="true"/>
    <field name="tags" type="text_general_rev" indexed="true" stored="true" multiValued="true"/>
    <field name="type" type="text_general_rev" indexed="true" stored="true"/>
+   <field name="downloads" type="int" indexed="true" stored="true" />
+   <field name="favorites" type="int" indexed="true" stored="true" />
    <field name="trendiness" type="float" indexed="true" stored="true" />
    <field name="repository" type="string" indexed="false" stored="true" />
    <field name="abandoned" type="int" indexed="false" stored="true" />

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+web:
+    build: docker
+    volumes:
+        - .:/app
+    ports:
+        - "80:80"
+    links:
+        - database
+        - redis
+        - solr
+
+database:
+    image: mysql
+    ports:
+        - "3306:3306"
+    environment:
+        MYSQL_ROOT_PASSWORD: roots3cr3t
+        MYSQL_DATABASE: packagist
+
+redis:
+    image: redis
+    ports:
+        - "6379:6379"
+
+solr:
+    image: apopelo/solr-3.6.2
+    volumes:
+        - ./doc/schema.xml:/opt/solr/example/solr/conf/schema.xml
+    ports:
+        - "8983:8983"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ web:
         - .:/app
     ports:
         - "80:80"
+    dns:
+        - 8.8.8.8
+        - 8.8.4.4
     links:
         - database
         - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,18 @@
+# In order to run packagist as docker containers
+# install `docker` and `docker-compose` tool from:
+# http://docs.docker.com/compose/install/
+#
+# After installation navigate to the local packagist repo
+# and execute `docker-compose up` this will build the web
+# image and download the redis, mysql and solr images in
+# order to run the whole app.
+#
+# app/config/parameters.yml.docker is a sample file to use
+# in this environment the only thing needed here are the github
+# client id and secret
+#
+# app/config/config.yml.docker is the configuration to replace config.yml
+# to support a solr external server
 web:
     build: docker
     volumes:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,52 @@
+FROM php:fpm
+MAINTAINER Marcelo Andrade <marcelo.andrade.r@gmail.com>
+
+ADD sources.list /etc/apt/
+RUN apt-get update -y
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
+		--no-install-recommends \
+		-o Dpkg::Options::="--force-confdef" \
+		-o Dpkg::Options::="--force-confold" \
+		git-core \
+		curl \
+		wget \
+		supervisor \
+		zlib1g-dev \
+		nginx \
+		mysql-client-5.5 \
+		openssh-client
+RUN curl -sS https://getcomposer.org/installer | php && \
+    mv composer.phar /usr/local/bin/composer
+RUN docker-php-ext-install mbstring
+RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install pcntl
+RUN docker-php-ext-install zip
+ENV PATH $PATH:/root/.composer/vendor/bin
+
+RUN wget https://phar.phpunit.de/phpunit.phar && \
+	mv phpunit.phar /usr/local/bin/phpunit && \
+	chmod u+x /usr/local/bin/phpunit
+
+EXPOSE 80
+VOLUME ["/app"]
+
+WORKDIR /app
+
+# Supervisor Configuration
+ADD supervisord-php5-fpm.conf /etc/supervisor/conf.d/
+ADD supervisord-nginx.conf /etc/supervisor/conf.d/
+
+# Nginx Configuration
+RUN rm /etc/nginx/sites-enabled/default
+RUN ln -s /app/docker/nginx.conf /etc/nginx/sites-enabled/packagist.conf
+
+# PHP-FPM Configuration
+ADD php-fpm.conf /usr/local/etc/
+ADD ./project.ini /usr/local/etc/php/conf.d/project.ini
+
+ADD ./my.cnf /root/.my.cnf
+
+# Workaround for boot2docker on mac
+RUN usermod -u 1000 www-data
+
+CMD ["supervisord", "-n"]

--- a/docker/my.cnf
+++ b/docker/my.cnf
@@ -1,0 +1,17 @@
+[mysql]
+user = root
+password = roots3cr3t
+host = db
+port = 3306
+
+[mysqladmin]
+user = root
+password = roots3cr3t
+host = db
+port = 3306
+
+[mysqldump]
+user = root
+password = roots3cr3t
+host = db
+port = 3306

--- a/docker/my.cnf
+++ b/docker/my.cnf
@@ -1,17 +1,17 @@
 [mysql]
 user = root
 password = roots3cr3t
-host = db
+host = database
 port = 3306
 
 [mysqladmin]
 user = root
 password = roots3cr3t
-host = db
+host = database
 port = 3306
 
 [mysqldump]
 user = root
 password = roots3cr3t
-host = db
+host = database
 port = 3306

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,30 @@
+client_max_body_size 5m;
+
+server {
+    listen 80 default_server;
+
+    root /app/web;
+    index index.php;
+
+    server_name _;
+
+    location / {
+        try_files $uri /app.php$is_args$args;
+    }
+
+    # PROD
+    location ~ ^/app\.php(/|$) {
+        fastcgi_pass unix:/var/run/php5-fpm.sock;
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param HTTPS off;
+        # Prevents URIs that include the front controller. This will 404:
+        # http://domain.tld/app.php/some-path
+        # Remove the internal directive to allow URIs like this
+        internal;
+    }
+
+    error_log /var/log/nginx/packagist_error.log;
+    access_log /var/log/nginx/packagist_access.log;
+}

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -4,12 +4,22 @@ server {
     listen 80 default_server;
 
     root /app/web;
-    index index.php;
 
     server_name _;
 
     location / {
-        try_files $uri /app.php$is_args$args;
+        try_files $uri /app_dev.php$is_args$args;
+    }
+
+    # DEV
+    # This rule should only be placed on your development environment
+    # In production, don't include this and don't deploy app_dev.php or config.php
+    location ~ ^/(app_dev|config)\.php(/|$) {
+        fastcgi_pass unix:/var/run/php5-fpm.sock;
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param HTTPS off;
     }
 
     # PROD

--- a/docker/php-fpm.conf
+++ b/docker/php-fpm.conf
@@ -1,0 +1,26 @@
+; This file was initially adapated from the output of: (on PHP 5.6)
+;   grep -vE '^;|^ *$' /usr/local/etc/php-fpm.conf.default
+
+[global]
+
+error_log = /var/log/php-fpm-error.log
+daemonize = no
+
+[www]
+
+; if we send this to /proc/self/fd/1, it never appears
+access.log = /var/log/php-fpm-access.log
+
+user = www-data
+group = www-data
+
+listen = /var/run/php5-fpm.sock
+listen.owner = www-data
+listen.group = www-data
+listen.mode = 0660
+
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3

--- a/docker/project.ini
+++ b/docker/project.ini
@@ -1,0 +1,1 @@
+date.timezone = 'UTC'

--- a/docker/sources.list
+++ b/docker/sources.list
@@ -1,0 +1,10 @@
+# From http://debgen.simplylinux.ch/ :  Testing, 64 bits, Main, Security, Updates from USA
+
+deb http://ftp.us.debian.org/debian testing main
+
+deb http://ftp.debian.org/debian/ jessie-updates main
+
+deb http://security.debian.org/ jessie/updates main
+
+	
+

--- a/docker/supervisord-nginx.conf
+++ b/docker/supervisord-nginx.conf
@@ -1,0 +1,7 @@
+[program:nginx]
+command=/usr/sbin/nginx -g "daemon off;"
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+pidfile=/var/run/nginx.pid
+autostart=true
+autorestart=true

--- a/docker/supervisord-php5-fpm.conf
+++ b/docker/supervisord-php5-fpm.conf
@@ -1,0 +1,6 @@
+[program:php5-fpm]
+command=/usr/local/sbin/php-fpm --nodaemonize
+priority=999
+username=www-data
+autostart=true
+autorestart=true

--- a/src/Packagist/WebBundle/Command/IndexPackagesCommand.php
+++ b/src/Packagist/WebBundle/Command/IndexPackagesCommand.php
@@ -166,10 +166,15 @@ class IndexPackagesCommand extends ContainerAwareCommand
 
     private function updateDocumentFromPackage(\Solarium_Document_ReadWrite $document, Package $package, $redis)
     {
+        $downloads = $this->getContainer()->get('packagist.download_manager')->getTotalDownloads($package);
+        $favorites = $this->getContainer()->get('packagist.favorite_manager')->getFaverCount($package);
+
         $document->setField('id', $package->getId());
         $document->setField('name', $package->getName());
         $document->setField('description', $package->getDescription());
         $document->setField('type', $package->getType());
+        $document->setField('downloads', $downloads);
+        $document->setField('favorites', $favorites);
         $document->setField('trendiness', $redis->zscore('downloads:trending', $package->getId()));
         $document->setField('repository', $package->getRepository());
         if ($package->isAbandoned()) {

--- a/src/Packagist/WebBundle/Controller/WebController.php
+++ b/src/Packagist/WebBundle/Controller/WebController.php
@@ -256,8 +256,8 @@ class WebController extends Controller
         $form = $this->createSearchForm();
 
         // transform q=search shortcut
-        if ($req->query->has('q')) {
-            $req->query->set('search_query', array('query' => $req->query->get('q')));
+        if ($req->query->has('q') || $req->query->has('s')) {
+            $req->query->set('search_query', array('query' => $req->query->get('q'), 'sort_by' => $req->query->get('s')));
         }
 
         $typeFilter = $req->query->get('type');
@@ -304,17 +304,14 @@ class WebController extends Controller
                         $escapedQuery = str_replace('\\"', '"', $escapedQuery);
                     }
                     $select->setQuery($escapedQuery);
-                }
-            }
-
-            if ($req->query->has('sort_by')) {
-                $sortField = $req->query->get('sort_by');
-                switch($sortField) {
-                    case 'downloads':
-                    case 'favorites':
-                        $select->addSort($sortField, 'desc');
-                        break;
-                    default:
+                    $sortField = $form->getData()->getSortBy();
+                    switch($sortField) {
+                        case 'downloads':
+                        case 'favorites':
+                            $select->addSort($sortField, 'desc');
+                            break;
+                        default:
+                    }
                 }
             }
 

--- a/src/Packagist/WebBundle/Controller/WebController.php
+++ b/src/Packagist/WebBundle/Controller/WebController.php
@@ -307,6 +307,17 @@ class WebController extends Controller
                 }
             }
 
+            if ($req->query->has('sort_by')) {
+                $sortField = $req->query->get('sort_by');
+                switch($sortField) {
+                    case 'downloads':
+                    case 'favorites':
+                        $select->addSort($sortField, 'desc');
+                        break;
+                    default:
+                }
+            }
+
             $paginator = new Pagerfanta(new SolariumAdapter($solarium, $select));
 
             $perPage = $req->query->getInt('per_page', 15);

--- a/src/Packagist/WebBundle/Form/Model/SearchQuery.php
+++ b/src/Packagist/WebBundle/Form/Model/SearchQuery.php
@@ -21,6 +21,11 @@ class SearchQuery
      */
     protected $query;
 
+    /**
+     * @var string
+     */
+    protected $sortBy;
+
     public function setQuery($query)
     {
         $this->query = $query;
@@ -29,5 +34,15 @@ class SearchQuery
     public function getQuery()
     {
         return $this->query;
+    }
+
+    public function setSortBy($sortBy)
+    {
+        $this->sortBy = $sortBy;
+    }
+
+    public function getSortBy()
+    {
+        return $this->sortBy;
     }
 }

--- a/src/Packagist/WebBundle/Form/Type/SearchQueryType.php
+++ b/src/Packagist/WebBundle/Form/Type/SearchQueryType.php
@@ -24,6 +24,10 @@ class SearchQueryType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->add('query', 'search');
+        $builder->add('sort_by', 'choice', array(
+            'empty_value' => '-Sort By-',
+            'choices' => array('downloads' => 'Downloads', 'favorites' => 'Favorites'),
+          ));
     }
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)

--- a/src/Packagist/WebBundle/Resources/public/css/main.css
+++ b/src/Packagist/WebBundle/Resources/public/css/main.css
@@ -438,7 +438,19 @@ form ul {
 
 /* Search */
 #search_query_query {
-  width: 890px;
+  width: 765px;
+}
+#search_query_sort_by {
+  height: 36px;
+  width: 118px;
+  padding: 6px 12px;
+  font-size: 14px;
+  line-height: 1.42857;
+  color: #555;
+  background-color: #FFF;
+  background-image: none;
+  border: 1px solid #CCC;
+  border-radius: 4px;
 }
 .no-js #search_query_query {
   width: 780px;

--- a/src/Packagist/WebBundle/Resources/public/js/search.js
+++ b/src/Packagist/WebBundle/Resources/public/js/search.js
@@ -50,10 +50,12 @@
 
         if (window.history.pushState) {
             if (firstQuery) {
-                window.history.pushState(null, "Search", "/search/?q=" + encodeURIComponent($('input[type="search"]', form).val()));
+                window.history.pushState(null, "Search", "/search/?q=" + encodeURIComponent($('input[type="search"]', form).val()) +
+                  '&s=' + encodeURIComponent($('#search_query_sort_by').val()));
                 firstQuery = false;
             } else {
-                window.history.replaceState(null, "Search", "/search/?q=" + encodeURIComponent($('input[type="search"]', form).val()));
+                window.history.replaceState(null, "Search", "/search/?q=" + encodeURIComponent($('input[type="search"]', form).val()) +
+                  '&s=' + encodeURIComponent($('#search_query_sort_by').val()));
             }
         }
 
@@ -68,6 +70,8 @@
     };
 
     form.bind('keyup search', doSearch);
+
+    form.bind('change sort_by', doSearch);
 
     form.bind('keydown', function (event) {
         var keymap,

--- a/src/Packagist/WebBundle/Resources/views/Web/searchForm.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/searchForm.html.twig
@@ -3,6 +3,7 @@
     <p>
         {{ form_errors(searchForm.query) }}
         {{ form_widget(searchForm.query, {'attr': {'autocomplete': 'off', 'autofocus': 'autofocus', 'placeholder': 'Search packages...', 'tabindex': 1}}) }}
+        {{ form_widget(searchForm.sort_by, {'attr': {'tabindex': 2}}) }}
         {{ form_rest(searchForm) }}
     </p>
 </form>


### PR DESCRIPTION
This pull request has the changes needed to support sort by downloads or favorites count when searching packages.

By downloads:

![by-download](https://cloud.githubusercontent.com/assets/57552/6742920/eee31a7a-ce61-11e4-974d-8bdf86bf52a5.png)

By favorites:

![by-favorites](https://cloud.githubusercontent.com/assets/57552/6742941/2488a6ea-ce62-11e4-88e3-d4fe98fa6a95.png)

I've added the downloads and favorites field on the schema.xml on solr and on the packagist:index action to get those values and send them to solr. So when this change goes to production a full re-index will be needed.

Not sure if this can be a good thing for the repo, but also included some files to create the packagist dev environment as docker contaiers using `docker-compose` to orchestrate the 4 services (web, database, redis, solr) and be up and running with 1 command.

