### PR TITLE
Sorting of search results by multiple ordered fields

### DIFF
--- a/doc/schema.xml
+++ b/doc/schema.xml
@@ -237,6 +237,8 @@
    <field name="tags" type="text_general_rev" indexed="true" stored="true" multiValued="true"/>
    <field name="type" type="text_general_rev" indexed="true" stored="true"/>
    <field name="trendiness" type="float" indexed="true" stored="true" />
+   <field name="downloads" type="int" indexed="true" stored="true" />
+   <field name="favers" type="int" indexed="true" stored="true" />
    <field name="repository" type="string" indexed="false" stored="true" />
    <field name="abandoned" type="int" indexed="false" stored="true" />
    <field name="replacementPackage" type="string" indexed="false" stored="true" />

--- a/src/Packagist/WebBundle/Command/IndexPackagesCommand.php
+++ b/src/Packagist/WebBundle/Command/IndexPackagesCommand.php
@@ -12,8 +12,6 @@
 
 namespace Packagist\WebBundle\Command;
 
-use DateTime;
-use Exception;
 use Packagist\WebBundle\Entity\Package;
 use Packagist\WebBundle\Model\DownloadManager;
 use Packagist\WebBundle\Model\FavoriteManager;
@@ -128,8 +126,8 @@ class IndexPackagesCommand extends ContainerAwareCommand
                     $this->updateDocumentFromPackage($document, $package, $redis, $downloadManager, $favoriteManager);
                     $update->addDocument($document);
 
-                    $package->setIndexedAt(new DateTime);
-                } catch (Exception $e) {
+                    $package->setIndexedAt(new \DateTime);
+                } catch (\Exception $e) {
                     $output->writeln('<error>Exception: '.$e->getMessage().', skipping package '.$package->getName().'.</error>');
                 }
 
@@ -151,7 +149,7 @@ class IndexPackagesCommand extends ContainerAwareCommand
                                 $document->setField('abandoned', 0);
                                 $document->setField('replacementPackage', '');
                                 $update->addDocument($document);
-                            } catch (Exception $e) {
+                            } catch (\Exception $e) {
                                 $output->writeln('<error>Exception: '.$e->getMessage().', skipping package '.$package->getName().':provide:'.$provide->getPackageName().'</error>');
                             }
                         }

--- a/src/Packagist/WebBundle/Controller/WebController.php
+++ b/src/Packagist/WebBundle/Controller/WebController.php
@@ -263,8 +263,6 @@ class WebController extends Controller
             $allowedOrders = array(
                 'asc' => 1,
                 'desc' => 1,
-                'ASC' => 1,
-                'DESC' => 1
             );
 
             $filteredOrderBys = array();

--- a/src/Packagist/WebBundle/Controller/WebController.php
+++ b/src/Packagist/WebBundle/Controller/WebController.php
@@ -298,7 +298,7 @@ class WebController extends Controller
             if ($orderBys) {
                 $allowedSorts = array(
                     'downloads' => 1,
-                    'orders' => 1
+                    'favers' => 1
                 );
 
                 $allowedOrders = array(

--- a/src/Packagist/WebBundle/Controller/WebController.php
+++ b/src/Packagist/WebBundle/Controller/WebController.php
@@ -366,7 +366,10 @@ class WebController extends Controller
 
         $filteredOrderBys = $this->getFilteredOrderedBys($orderBys);
         $normalizedOrderBys = $this->getNormalizedOrderBys($filteredOrderBys);
-        $orderBysViewModel = $this->getOrderBysViewModel($req, $normalizedOrderBys);
+
+        if ($req->getRequestFormat() !== 'json' && !$req->isXmlHttpRequest()) {
+            $orderBysViewModel = $this->getOrderBysViewModel($req, $normalizedOrderBys);
+        }
 
         // transform q=search shortcut
         if ($req->query->has('q') || $req->query->has('orderBys')) {

--- a/src/Packagist/WebBundle/Controller/WebController.php
+++ b/src/Packagist/WebBundle/Controller/WebController.php
@@ -248,11 +248,11 @@ class WebController extends Controller
     }
 
     /**
-     * @param mixed $orderBys
+     * @param array $orderBys
      *
      * @return array
      */
-    protected function getFilteredOrderedBys($orderBys)
+    protected function getFilteredOrderedBys(array $orderBys)
     {
         if ($orderBys) {
             $allowedSorts = array(

--- a/src/Packagist/WebBundle/Form/Model/OrderBy.php
+++ b/src/Packagist/WebBundle/Form/Model/OrderBy.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of Packagist.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *     Nils Adermann <naderman@naderman.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Packagist\WebBundle\Form\Model;
+
+/**
+ * @author Benjamin Michalski <benjamin.michalski@gmail.com>
+ */
+class OrderBy
+{
+    /**
+     * @var string
+     */
+    protected $sort;
+
+    /**
+     * @var string
+     */
+    protected $order;
+
+    public function setSort($sort)
+    {
+        $this->sort = $sort;
+    }
+
+    public function getSort()
+    {
+        return $this->sort;
+    }
+
+    public function setOrder($order)
+    {
+        $this->order = $order;
+    }
+
+    public function getOrder()
+    {
+        return $this->order;
+    }
+}

--- a/src/Packagist/WebBundle/Form/Model/SearchQuery.php
+++ b/src/Packagist/WebBundle/Form/Model/SearchQuery.php
@@ -21,6 +21,11 @@ class SearchQuery
      */
     protected $query;
 
+    /**
+     * @var array
+     */
+    protected $orderBys;
+
     public function setQuery($query)
     {
         $this->query = $query;
@@ -29,5 +34,15 @@ class SearchQuery
     public function getQuery()
     {
         return $this->query;
+    }
+
+    public function setOrderBys($orderBys)
+    {
+        $this->orderBys = $orderBys;
+    }
+
+    public function getOrderBys()
+    {
+        return $this->orderBys;
     }
 }

--- a/src/Packagist/WebBundle/Form/Type/OrderByType.php
+++ b/src/Packagist/WebBundle/Form/Type/OrderByType.php
@@ -17,30 +17,32 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
- * @author Igor Wiedler <igor@wiedler.ch>
+ * @author Benjamin Michalski <benjamin.michalski@gmail.com>
  */
-class SearchQueryType extends AbstractType
+class OrderByType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('query', 'search');
-        $builder->add('orderBys', 'collection', array(
-            'type' => new OrderByType(),
-            'allow_add' => true,
-            'allow_delete' => true
+        $builder->add('sort');
+        $builder->add('order', 'choice', array(
+            'choices' => array(
+                'asc' => 'asc',
+                'desc' => 'desc'
+            )
         ));
     }
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(array(
-            'data_class' => 'Packagist\WebBundle\Form\Model\SearchQuery',
+            'data_class' => 'Packagist\WebBundle\Form\Model\OrderBy',
             'csrf_protection' => false,
         ));
     }
 
+
     public function getName()
     {
-        return 'search_query';
+        return 'order_by';
     }
 }

--- a/src/Packagist/WebBundle/Resources/public/css/main.css
+++ b/src/Packagist/WebBundle/Resources/public/css/main.css
@@ -454,26 +454,26 @@ form ul {
 }
 
 #search_query_orderBys {
-    display: none;
+  display: none;
 }
 
 .sortable #order-bys-wrapper {
-    margin-left: 0.7em;
-    display: inline;
-    font-size: 24px;
-    position: relative;
-    top: 4px;
+  margin-left: 0.7em;
+  display: inline;
+  font-size: 24px;
+  position: relative;
+  top: 4px;
 }
 
 .sortable #order-bys-wrapper a {
-    width: 46px;
-    margin-right: 7px;
-    display: inline-block;
+  width: 46px;
+  margin-right: 7px;
+  display: inline-block;
 }
 
 .sortable #order-bys-wrapper a.clear {
-    width: auto;
-    margin-right: 0px;
+  width: auto;
+  margin-right: 0px;
 }
 
 #search-form .submit-wrapper {

--- a/src/Packagist/WebBundle/Resources/public/css/main.css
+++ b/src/Packagist/WebBundle/Resources/public/css/main.css
@@ -437,11 +437,19 @@ form ul {
 
 
 /* Search */
+
 #search_query_query {
+  width: 890px;
+}
+.no-js #search_query_query {
+  width: 780px;
+}
+
+.sortable #search_query_query {
   width: 737px;
   display: inline;
 }
-.no-js #search_query_query {
+.sortable .no-js #search_query_query {
   width: 600px;
 }
 
@@ -449,7 +457,7 @@ form ul {
     display: none;
 }
 
-#order-bys-wrapper {
+.sortable #order-bys-wrapper {
     margin-left: 0.7em;
     display: inline;
     font-size: 24px;
@@ -457,13 +465,13 @@ form ul {
     top: 4px;
 }
 
-#order-bys-wrapper a {
+.sortable #order-bys-wrapper a {
     width: 46px;
     margin-right: 7px;
     display: inline-block;
 }
 
-#order-bys-wrapper a.clear {
+.sortable #order-bys-wrapper a.clear {
     width: auto;
     margin-right: 0px;
 }

--- a/src/Packagist/WebBundle/Resources/public/css/main.css
+++ b/src/Packagist/WebBundle/Resources/public/css/main.css
@@ -438,11 +438,36 @@ form ul {
 
 /* Search */
 #search_query_query {
-  width: 890px;
+  width: 737px;
+  display: inline;
 }
 .no-js #search_query_query {
-  width: 780px;
+  width: 600px;
 }
+
+#search_query_orderBys {
+    display: none;
+}
+
+#order-bys-wrapper {
+    margin-left: 0.7em;
+    display: inline;
+    font-size: 24px;
+    position: relative;
+    top: 4px;
+}
+
+#order-bys-wrapper a {
+    width: 46px;
+    margin-right: 7px;
+    display: inline-block;
+}
+
+#order-bys-wrapper a.clear {
+    width: auto;
+    margin-right: 0px;
+}
+
 #search-form .submit-wrapper {
   width: 100px;
   float: right;

--- a/src/Packagist/WebBundle/Resources/public/js/search.js
+++ b/src/Packagist/WebBundle/Resources/public/js/search.js
@@ -28,7 +28,15 @@
     };
 
     doSearch = function () {
-        var currentQuery;
+        var currentQuery,
+            pushStateArguments,
+            orderBys,
+            orderBysStrParts,
+            joinedOrderBys,
+            joinedOrderBysQryStrPart,
+            q,
+            pathname,
+            urlPrefix;
 
         if (searching) {
             searchQueued = true;
@@ -49,11 +57,57 @@
         }
 
         if (window.history.pushState) {
+            orderBys = [];
+
+            $('#search_query_orderBys > div').each(function (i, e) {
+                var sort,
+                    order;
+                sort = $(e).find('input').val();
+                order = $(e).find('select').val();
+
+                orderBys.push({
+                    sort: sort,
+                    order: order
+                });
+            });
+
+            orderBysStrParts = [];
+
+            orderBys.forEach(function (e, i) {
+                orderBysStrParts.push('orderBys[' + i + '][sort]=' + e.sort + '&orderBys[' + i + '][order]=' + e.order);
+            });
+
+            joinedOrderBys = orderBysStrParts.join('&');
+
+            q = encodeURIComponent($('input[type="search"]', form).val());
+
+            pathname = window.location.pathname;
+
+            if (pathname.indexOf('/app_dev.php') === 0) {
+                urlPrefix = '/app_dev.php';
+            } else if (pathname.indexOf('/app.php') === 0) {
+                urlPrefix = '/app.php';
+            } else {
+                urlPrefix = '';
+            }
+
+            if (joinedOrderBys === '') {
+                joinedOrderBysQryStrPart = '';
+            } else {
+                joinedOrderBysQryStrPart = '&' + joinedOrderBys;
+            }
+
+            pushStateArguments = [
+                null,
+                'Search',
+                urlPrefix + '/search/?q=' + q + joinedOrderBysQryStrPart
+            ];
+
             if (firstQuery) {
-                window.history.pushState(null, "Search", "/search/?q=" + encodeURIComponent($('input[type="search"]', form).val()));
+                window.history.pushState.apply(window.history, pushStateArguments);
                 firstQuery = false;
             } else {
-                window.history.replaceState(null, "Search", "/search/?q=" + encodeURIComponent($('input[type="search"]', form).val()));
+                window.history.replaceState.apply(window.history, pushStateArguments);
             }
         }
 

--- a/src/Packagist/WebBundle/Resources/public/js/search.js
+++ b/src/Packagist/WebBundle/Resources/public/js/search.js
@@ -29,14 +29,15 @@
 
     doSearch = function () {
         var currentQuery,
-            pushStateArguments,
             orderBys,
             orderBysStrParts,
             joinedOrderBys,
             joinedOrderBysQryStrPart,
             q,
             pathname,
-            urlPrefix;
+            urlPrefix,
+            url,
+            title;
 
         if (searching) {
             searchQueued = true;
@@ -97,17 +98,14 @@
                 joinedOrderBysQryStrPart = '&' + joinedOrderBys;
             }
 
-            pushStateArguments = [
-                null,
-                'Search',
-                urlPrefix + '/search/?q=' + q + joinedOrderBysQryStrPart
-            ];
+            url = urlPrefix + '/search/?q=' + q + joinedOrderBysQryStrPart;
+            title = 'Search';
 
             if (firstQuery) {
-                window.history.pushState.apply(window.history, pushStateArguments);
+                window.history.pushState(null, title, url);
                 firstQuery = false;
             } else {
-                window.history.replaceState.apply(window.history, pushStateArguments);
+                window.history.replaceState(null, title, url);
             }
         }
 

--- a/src/Packagist/WebBundle/Resources/views/Web/searchForm.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/searchForm.html.twig
@@ -1,19 +1,21 @@
 <form id="search-form" action="{{ path('search.ajax') }}" method="GET" {{ form_enctype(searchForm) }} autocomplete="off">
     <p class="submit-wrapper"><input class="submit" type="submit" value="Search" /></p>
-    <div>
+    <div class="{% if orderBys is defined %}sortable{% endif %}">
         {{ form_errors(searchForm.query) }}
         {{ form_widget(searchForm.query, {'attr': {'autocomplete': 'off', 'autofocus': 'autofocus', 'placeholder': 'Search packages...', 'tabindex': 1}}) }}
-        <div id="order-bys-wrapper">
-            {% for sort,param in orderBys %}
-                <a title="{{ param.title }}" href="{{ param.href }}">
-                    <i class="icon {{ param.class }}"></i>
-                    <i class="icon {{ param.arrowClass }}"></i>
+        {% if orderBys is defined %}
+            <div id="order-bys-wrapper">
+                {% for sort,param in orderBys %}
+                    <a title="{{ param.title }}" href="{{ param.href }}">
+                        <i class="icon {{ param.class }}"></i>
+                        <i class="icon {{ param.arrowClass }}"></i>
+                    </a>
+                {% endfor %}
+                <a title="Clear order bys" href="?q={{ searchForm.vars.value.query }}" class="clear">
+                    <i class="icon icon-remove-circle"></i>
                 </a>
-            {% endfor %}
-            <a title="Clear order bys" href="?q={{ searchForm.vars.value.query }}" class="clear">
-                <i class="icon icon-remove-circle"></i>
-            </a>
-        </div>
+            </div>
+        {% endif  %}
         <div
             class="hidden">
             {{ form_widget(searchForm.orderBys) }}

--- a/src/Packagist/WebBundle/Resources/views/Web/searchForm.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/searchForm.html.twig
@@ -3,6 +3,27 @@
     <p>
         {{ form_errors(searchForm.query) }}
         {{ form_widget(searchForm.query, {'attr': {'autocomplete': 'off', 'autofocus': 'autofocus', 'placeholder': 'Search packages...', 'tabindex': 1}}) }}
+        <div
+            id="order-bys-wrapper">
+            {% for sort,param in orderBys %}
+                <a
+                    title="{{ param.title }}"
+                    href="{{ param.href }}">
+                    <i class="icon {{ param.class }}"></i>
+                    <i class="icon {{ param.arrowClass }}"></i>
+                </a>
+            {% endfor %}
+            <a
+                title="Clear order bys"
+                href="?q={{ searchForm.vars.value.query }}"
+                class="clear">
+                <i class="icon icon-remove-circle"></i>
+            </a>
+        </div>
+        <div
+            class="hidden">
+            {{ form_widget(searchForm.orderBys) }}
+        </div>
         {{ form_rest(searchForm) }}
     </p>
 </form>

--- a/src/Packagist/WebBundle/Resources/views/Web/searchForm.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/searchForm.html.twig
@@ -1,22 +1,16 @@
 <form id="search-form" action="{{ path('search.ajax') }}" method="GET" {{ form_enctype(searchForm) }} autocomplete="off">
     <p class="submit-wrapper"><input class="submit" type="submit" value="Search" /></p>
-    <p>
+    <div>
         {{ form_errors(searchForm.query) }}
         {{ form_widget(searchForm.query, {'attr': {'autocomplete': 'off', 'autofocus': 'autofocus', 'placeholder': 'Search packages...', 'tabindex': 1}}) }}
-        <div
-            id="order-bys-wrapper">
+        <div id="order-bys-wrapper">
             {% for sort,param in orderBys %}
-                <a
-                    title="{{ param.title }}"
-                    href="{{ param.href }}">
+                <a title="{{ param.title }}" href="{{ param.href }}">
                     <i class="icon {{ param.class }}"></i>
                     <i class="icon {{ param.arrowClass }}"></i>
                 </a>
             {% endfor %}
-            <a
-                title="Clear order bys"
-                href="?q={{ searchForm.vars.value.query }}"
-                class="clear">
+            <a title="Clear order bys" href="?q={{ searchForm.vars.value.query }}" class="clear">
                 <i class="icon icon-remove-circle"></i>
             </a>
         </div>
@@ -25,6 +19,6 @@
             {{ form_widget(searchForm.orderBys) }}
         </div>
         {{ form_rest(searchForm) }}
-    </p>
+    </div>
 </form>
 

--- a/src/Packagist/WebBundle/Tests/Controller/WebControllerTest.php
+++ b/src/Packagist/WebBundle/Tests/Controller/WebControllerTest.php
@@ -249,7 +249,7 @@ class WebControllerTest extends WebTestCase
 
         $kernelRootDir = $container->getParameter('kernel.root_dir');
 
-        $this->executeCommand($kernelRootDir . '/console doctrine:database:drop --env=test --force');
+        $this->executeCommand($kernelRootDir . '/console doctrine:database:drop --env=test --force', false);
         $this->executeCommand($kernelRootDir . '/console doctrine:database:create --env=test');
         $this->executeCommand($kernelRootDir . '/console doctrine:schema:create --env=test');
         $this->executeCommand($kernelRootDir . '/console redis:flushall --env=test -n');
@@ -269,14 +269,6 @@ class WebControllerTest extends WebTestCase
         } else {
             $orderBysQryStrPart = '';
         }
-
-        $client->request('GET', '/search.json?q=' . $orderBysQryStrPart);
-
-        $response = $client->getResponse();
-
-        $content = $client->getResponse()->getContent();
-
-        $this->assertSame(200, $response->getStatusCode(), $content);
 
         $twigPackage = new Package();
 
@@ -302,6 +294,14 @@ class WebControllerTest extends WebTestCase
         $onBeforeIndex($container, $twigPackage, $packagistPackage, $symfonyPackage);
 
         $this->executeCommand($kernelRootDir . '/console packagist:index --env=test --force');
+
+        $client->request('GET', '/search.json?q=' . $orderBysQryStrPart);
+
+        $response = $client->getResponse();
+
+        $content = $client->getResponse()->getContent();
+
+        $this->assertSame(200, $response->getStatusCode(), $content);
 
         return json_decode($content, true);
     }
@@ -387,11 +387,13 @@ class WebControllerTest extends WebTestCase
      * Executes a given command.
      *
      * @param string $command a command to execute
+     * @param bool $errorHandling
      *
      * @throws Exception when the return code is not 0.
      */
     protected function executeCommand(
-        $command
+        $command,
+        $errorHandling = true
     ) {
         $output = array();
 
@@ -399,7 +401,7 @@ class WebControllerTest extends WebTestCase
 
         exec($command, $output, $returnCode);
 
-        if ($returnCode !== 0) {
+        if ($errorHandling && $returnCode !== 0) {
             throw new Exception(
                 sprintf(
                     'Error executing command "%s", return code was "%s".',

--- a/src/Packagist/WebBundle/Tests/Controller/WebControllerTest.php
+++ b/src/Packagist/WebBundle/Tests/Controller/WebControllerTest.php
@@ -2,7 +2,11 @@
 
 namespace Packagist\WebBundle\Tests\Controller;
 
+use Exception;
+use Packagist\WebBundle\Entity\Package;
+use Packagist\WebBundle\Model\DownloadManager;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class WebControllerTest extends WebTestCase
 {
@@ -13,7 +17,7 @@ class WebControllerTest extends WebTestCase
         $crawler = $client->request('GET', '/');
         $this->assertEquals('Getting Started', $crawler->filter('.getting-started h1')->text());
     }
-    
+
     public function testPackages()
     {
         $client = self::createClient();
@@ -21,15 +25,252 @@ class WebControllerTest extends WebTestCase
         $crawler = $client->request('GET', '/packages/');
         $this->assertTrue($crawler->filter('.packages li')->count() > 0);
     }
-    
+
     public function testPackage()
     {
         $client = self::createClient();
         //we expect package to be clickable and showing at least 'package' div
         $crawler = $client->request('GET', '/packages/');
         $link = $crawler->filter('.packages li h1 a')->first()->attr('href');
-        
+
         $crawler = $client->request('GET', $link);
         $this->assertTrue($crawler->filter('.package')->count() > 0);
+    }
+
+    /**
+     * @covers ::nothing
+     */
+    public function testSearchNoOrderBysAction()
+    {
+        $json = $this->commonTestSearchActionOrderBysDownloads();
+
+        $this->assertSame(
+            $this->getJsonResults(
+                array(
+                    $this->getJsonResult('twig/twig', 25, 0),
+                    $this->getJsonResult('composer/packagist', 12, 0),
+                    $this->getJsonResult('symfony/symfony', 42, 0),
+                )
+            ),
+            $json
+        );
+    }
+
+    /**
+     * @covers ::nothing
+     */
+    public function testSearchOrderByDownloadsAscAction()
+    {
+        $json = $this->commonTestSearchActionOrderBysDownloads(
+            array(
+                array(
+                    'sort' => 'downloads',
+                    'order' => 'asc',
+                ),
+            )
+        );
+
+        $this->assertSame(
+            $this->getJsonResults(
+                array(
+                    $this->getJsonResult('composer/packagist', 12, 0),
+                    $this->getJsonResult('twig/twig', 25, 0),
+                    $this->getJsonResult('symfony/symfony', 42, 0),
+                )
+            ),
+            $json
+        );
+    }
+
+    /**
+     * @covers ::nothing
+     */
+    public function testSearchOrderByDownloadsDescAction()
+    {
+        $json = $this->commonTestSearchActionOrderBysDownloads(
+            array(
+                array(
+                    'sort' => 'downloads',
+                    'order' => 'desc',
+                ),
+            )
+        );
+
+        $this->assertSame(
+            $this->getJsonResults(
+                array(
+                    $this->getJsonResult('symfony/symfony', 42, 0),
+                    $this->getJsonResult('twig/twig', 25, 0),
+                    $this->getJsonResult('composer/packagist', 12, 0),
+                )
+            ),
+            $json
+        );
+    }
+
+    /**
+     * @param callable $onBeforeIndex TODO Add typehint when migrating to 5.4+
+     * @param array $orderBys
+     *
+     * @return array
+     */
+    protected function commonTestSearchActionOrderBysAction(
+        $onBeforeIndex,
+        array $orderBys = array()
+    ) {
+        $client = self::createClient();
+
+        $container = $client->getContainer();
+
+        $kernelRootDir = $container->getParameter('kernel.root_dir');
+
+        $this->executeCommand($kernelRootDir . '/console doctrine:database:drop --env=test --force');
+        $this->executeCommand($kernelRootDir . '/console doctrine:database:create --env=test');
+        $this->executeCommand($kernelRootDir . '/console doctrine:schema:create --env=test');
+        $this->executeCommand($kernelRootDir . '/console redis:flushall --env=test -n');
+
+        $lock = $container->getParameter('kernel.cache_dir').'/composer-indexer.lock';
+
+        $this->executeCommand('rm -f ' . $lock);
+
+        $em = $container->get('doctrine')->getManager();
+
+        if (!empty($orderBys)) {
+            $orderBysQryStrPart = '&' . http_build_query(
+                array(
+                    'orderBys' => $orderBys
+                )
+            );
+        } else {
+            $orderBysQryStrPart = '';
+        }
+
+        $client->request('GET', '/search.json?q=' . $orderBysQryStrPart);
+
+        $response = $client->getResponse();
+
+        $content = $client->getResponse()->getContent();
+
+        $this->assertSame(200, $response->getStatusCode(), $content);
+
+        $package = new Package();
+
+        $package->setName('twig/twig');
+        $package->setRepository('https://github.com/twig/twig');
+
+        $package1 = new Package();
+
+        $package1->setName('composer/packagist');
+        $package1->setRepository('https://github.com/composer/packagist');
+
+        $package2 = new Package();
+
+        $package2->setName('symfony/symfony');
+        $package2->setRepository('https://github.com/symfony/symfony');
+
+        $em->persist($package);
+        $em->persist($package1);
+        $em->persist($package2);
+
+        $em->flush();
+
+        $onBeforeIndex($container, $package, $package1, $package2);
+
+        $this->executeCommand($kernelRootDir . '/console packagist:index --env=test --force');
+
+        return json_decode($content, true);
+    }
+
+    /**
+     * @param array $orderBys
+     *
+     * @return array
+     */
+    protected function commonTestSearchActionOrderBysDownloads(
+        array $orderBys = array()
+    ) {
+        return $this->commonTestSearchActionOrderBysAction(
+            function (
+                ContainerInterface $container,
+                Package $package,
+                Package $package1,
+                Package $package2
+            ) {
+                $downloadManager = $container->get('packagist.download_manager');
+
+                /* @var $downloadManager DownloadManager */
+
+                for ($i = 0; $i < 25; $i += 1) {
+                    $downloadManager->addDownload($package->getId(), 25);
+                }
+                for ($i = 0; $i < 12; $i += 1) {
+                    $downloadManager->addDownload($package1->getId(), 12);
+                }
+                for ($i = 0; $i < 42; $i += 1) {
+                    $downloadManager->addDownload($package2->getId(), 42);
+                }
+            },
+            $orderBys
+        );
+    }
+
+    /**
+     * Executes a given command.
+     *
+     * @param string $command a command to execute
+     *
+     * @throws Exception when the return code is not 0.
+     */
+    protected function executeCommand(
+        $command
+    ) {
+        $output = array();
+
+        $returnCode = null;;
+
+        exec($command, $output, $returnCode);
+
+        if ($returnCode !== 0) {
+            throw new Exception(
+                sprintf(
+                    'Error executing command "%s", return code was "%s".',
+                    $command,
+                    $returnCode
+                )
+            );
+        }
+    }
+
+    /**
+     * @param string $package
+     * @param int $downloads
+     * @param int $favers
+     *
+     * @return array
+     */
+    protected function getJsonResult($package, $downloads, $favers)
+    {
+        return array(
+            'name' => $package,
+            'description' => '',
+            'url' => 'http://localhost/packages/' . $package,
+            'repository' => 'https://github.com/' . $package,
+            'downloads' => $downloads,
+            'favers' => $favers,
+        );
+    }
+
+    /**
+     * @param array $results
+     *
+     * @return array
+     */
+    protected function getJsonResults(
+        array $results
+    ) {
+        return array(
+            'results' => $results,
+            'total' => count($results)
+        );
     }
 }


### PR DESCRIPTION
This pull request fixes the issue #365, in a slight different way than https://github.com/composer/packagist/pull/481.

It enables to sort by multiple ordered field, using HTML or JSON.

Even though the user interface does not permit it, as it may not be user friendly, the API does support a combination of ordering parameters.

Even if at the moment it may not be needed, it might come in handy when you decide to add other criterias to order by.

Below are some screenshots:

By downloads:

![screenshot from 2015-05-04 21 11 47](https://cloud.githubusercontent.com/assets/1917997/7460554/237c551a-f2a4-11e4-9e0e-f38088a03fb0.png)

By favorites:

![screenshot from 2015-05-04 21 12 36](https://cloud.githubusercontent.com/assets/1917997/7460568/2a0f17e6-f2a4-11e4-8a2a-f0236ce6fe7a.png)

It also comes with automated tests.

Please be aware that these tests should not be run on a production machine, as they first drop / create the database to ensure isolation.