### PR TITLE
Make package name and version copy/paste-friendly

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/Web/versionDetails.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/versionDetails.html.twig
@@ -1,6 +1,6 @@
 {% import "PackagistWebBundle::macros.html.twig" as packagist %}
 
-<p class="requireme">require: <input type="text" readonly="readonly" value="{{ "\"#{version.package.vendor}/#{version.package.packageName}\": \"#{version.hasVersionAlias() ? version.requireVersionAlias : version.requireVersion}\"" }}" /></p>
+<p class="requireme">require: <input type="text" readonly="readonly" value="{{ "\"#{version.package.vendor}/#{version.package.packageName}\":\"#{version.hasVersionAlias() ? version.requireVersionAlias : version.requireVersion}\"" }}" /></p>
 
 <h2 class="authors">Author{{ version.authors|length > 1 ? 's' : '' }}</h2>
 <ul>


### PR DESCRIPTION
Tries to alleviate some problems with users copying the full package name and version and pasting it into the "require" command, which doesn't support spaces for a _single_ argument, like `composer require "doctrine/orm": "2.5.*@dev"` (note the space after `:`). Symfony sees that as _two_ args - `doctrine/orm:` and `2.5.*@dev` and cracks trying to get the second "package".

This goes all the way down to how Symfony parses the user's console input arguments (i.e. `command arg1 arg2`).

By removing the space, the command text can be used in _both_ composer.json and CLI.

Original issue: https://github.com/composer/composer/issues/3367