### PR TITLE
Make navigation dropdown click area larger

### DIFF
--- a/src/Packagist/WebBundle/Resources/public/css/main.css
+++ b/src/Packagist/WebBundle/Resources/public/css/main.css
@@ -200,6 +200,7 @@ strong {
 .navbar .nav > .nav-user > section a {
     color: #fff;
     text-decoration: none;
+    display: block;
 }
 
 .navbar .nav > .nav-user > section:hover {


### PR DESCRIPTION
It now fills the entire row, instead of just the text/icon.