### PR TITLE
Make search field 100% wide on mobile

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/Web/searchForm.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/searchForm.html.twig
@@ -1,7 +1,7 @@
 <form id="search-form" action="{{ path('search.ajax') }}" method="GET" {{ form_enctype(searchForm) }} autocomplete="off">
     <div class="{% if orderBys is defined %}sortable{% endif %} row">
         <div class="hidden">{{ form_errors(searchForm.query) }}</div>
-        <div class="col-xs-8 col-sm-9">
+        <div class="col-xs-12 col-sm-9">
             {{ form_widget(searchForm.query, {'attr': {'autocomplete': 'off', 'autofocus': 'autofocus', 'placeholder': 'Search packages...', 'tabindex': 1}}) }}
         </div>
 


### PR DESCRIPTION
This makes the search form fill all the width on mobile devices. A wider search form looks way more usable to me:
Before:
![screenshot 2015-06-13 15 52 23](https://cloud.githubusercontent.com/assets/345754/8144084/9337e8e2-11e4-11e5-970e-d150157251d1.png)
After:
![screenshot 2015-06-13 15 52 46](https://cloud.githubusercontent.com/assets/345754/8144085/973e6ace-11e4-11e5-8331-d19b0027f720.png)
