### PR TITLE
Set subpixel antialiasing for navbar

### DIFF
--- a/src/Packagist/WebBundle/Resources/public/css/main.css
+++ b/src/Packagist/WebBundle/Resources/public/css/main.css
@@ -92,6 +92,7 @@ strong {
 .navbar {
     margin: 0;
     border: 0;
+    -webkit-font-smoothing: subpixel-antialiased;
 }
 
 .navbar .navbar-brand {


### PR DESCRIPTION
Forcing subpixel-antialiasing stops Safari falling back to traditional anti-aliasing during animation of the dropdown menus.  The usual anti-aliasing switch makes the navbar text appear thin and wiry.