### PR TITLE
added support for ssh protocol in updatePackageAction

### DIFF
--- a/src/Packagist/WebBundle/Controller/ApiController.php
+++ b/src/Packagist/WebBundle/Controller/ApiController.php
@@ -73,8 +73,8 @@ class ApiController extends Controller
             return new JsonResponse(array('status' => 'error', 'message' => 'Missing payload parameter'), 406);
         }
 
-        if (isset($payload['repository']['url'])) { // github/gitlab/anything hook
-            $urlRegex = '{^(?:https?://|git://|git@)?(?P<host>[a-z0-9.-]+)[:/](?P<path>[\w.-]+/[\w.-]+?)(?:\.git)?$}i';
+        if (isset($payload['repository']['url'])) { // github/gitlab/anything hook; added support for ssh protocol
+            $urlRegex = '{^(?:ssh://git@|https?://|git://|git@)?(?P<host>[a-z0-9.-]+)[:/](?P<path>[\w.-]+/[\w.-]+?)(?:\.git)?$}i';
             $url = $payload['repository']['url'];
         } elseif (isset($payload['canon_url']) && isset($payload['repository']['absolute_url'])) { // bitbucket hook
             $urlRegex = '{^(?:https?://|git://|git@)?(?P<host>bitbucket\.org)[/:](?P<path>[\w.-]+/[\w.-]+?)(\.git)?/?$}i';

--- a/src/Packagist/WebBundle/Controller/ApiController.php
+++ b/src/Packagist/WebBundle/Controller/ApiController.php
@@ -73,7 +73,7 @@ class ApiController extends Controller
             return new JsonResponse(array('status' => 'error', 'message' => 'Missing payload parameter'), 406);
         }
 
-        if (isset($payload['repository']['url'])) { // github/gitlab/anything hook; added support for ssh protocol
+        if (isset($payload['repository']['url'])) { // github/gitlab/anything hook
             $urlRegex = '{^(?:ssh://git@|https?://|git://|git@)?(?P<host>[a-z0-9.-]+)[:/](?P<path>[\w.-]+/[\w.-]+?)(?:\.git)?$}i';
             $url = $payload['repository']['url'];
         } elseif (isset($payload['canon_url']) && isset($payload['repository']['absolute_url'])) { // bitbucket hook

--- a/src/Packagist/WebBundle/Tests/Controller/ApiControllerTest.php
+++ b/src/Packagist/WebBundle/Tests/Controller/ApiControllerTest.php
@@ -70,7 +70,7 @@ class ApiControllerTest extends WebTestCase
     }
 
     /**
-     * @depends      testGithubFailsCorrectly
+     * @depends testGithubFailsCorrectly
      * @dataProvider urlProvider
      */
     public function testUrlDetection($endpoint, $url, $expectedOK)
@@ -117,6 +117,7 @@ class ApiControllerTest extends WebTestCase
             // valid others
             array('update-package', 'https://ghe.example.org/user/repository', true),
             array('update-package', 'https://gitlab.org/user/repository', true),
+            array('update-package', 'ssh://git@stash.xxxxx.com/uuuuu/qqqqq.git', true),
 
             // invalid URLs
             array('github', 'php://github.com/user/repository', false),
@@ -126,6 +127,8 @@ class ApiControllerTest extends WebTestCase
             array('github', 'https://github.com/user', false),
             array('github', 'https://github.com/', false),
             array('github', 'https://github.com', false),
+            array('update-package', 'ssh://git@stash.zzzzz.com/kkkkk.git', false),
+            array('update-package', 'ssh://ghe.example.org/user/jjjjj.git', false),
         );
     }
 }


### PR DESCRIPTION
I've noticed that Packagist doesn't work with urls like this:

ssh://git@stash.xxxxxx.com/yyyyyyy/standard-edition.git

If you try to create a *post receive hook* you'll get "Could not parse payload repository URL" error message.

I've modified src/Packagist/WebBundle/Controller/ApiController.php adding support for **ssh://git@**

So now even Atlassian Stash will work with Packagist, sending hooks when a repository is updated.