### PR TITLE
Enhancement: Automatically focus on search input

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/Web/searchForm.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/searchForm.html.twig
@@ -2,7 +2,7 @@
     <div class="{% if orderBys is defined %}sortable{% endif %} row">
         <div class="hidden">{{ form_errors(searchForm.query) }}</div>
         <div class="{% if searchForm.vars.value.query is empty %}col-xs-12{% else %}col-xs-8{% endif %} js-search-field-wrapper col-md-9">
-            {{ form_widget(searchForm.query, {'attr': {'autocomplete': 'off', 'placeholder': 'Search packages...', 'tabindex': 1}}) }}
+            {{ form_widget(searchForm.query, {'attr': {'autocomplete': 'off', 'placeholder': 'Search packages...', 'tabindex': 1, 'autofocus': true}}) }}
         </div>
 
         {% set hasActiveOrderBy = false %}


### PR DESCRIPTION
This PR

* [x] sets the value of the `autofocus` attribute of the search query input to `true`, so we can start typing in whatever package we're looking for already

### Before

![screen shot 2015-06-28 at 23 08 23](https://cloud.githubusercontent.com/assets/605483/8400327/a729a6d0-1dea-11e5-8ff7-9100a6211d0f.png)

### After

![screen shot 2015-06-28 at 23 08 38](https://cloud.githubusercontent.com/assets/605483/8400329/abb037f0-1dea-11e5-9365-7c46d353e250.png)
