### PR TITLE
Fixed link to community on submit page

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/Web/submitPackage.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/submitPackage.html.twig
@@ -21,7 +21,7 @@
     <div class="col-md-6">
         <p>Please make sure you have read the package <a href="{{ path('about') }}#naming-your-package">naming conventions</a> before submitting your package. The authoritative name of your package will be taken from the composer.json file inside the master branch or trunk of your repository, and it can not be changed after that.</p>
         <p><strong>Do not submit forks of existing packages.</strong> If you need to test changes to a package that you forked to patch, use <a href="https://getcomposer.org/doc/05-repositories.md#vcs">VCS Repositories</a> instead. If however it is a real long-term fork you intend on maintaining feel free to submit it.</p>
-        <p>If you need help or if you have any questions please get in touch with the Composer <a href="https://getcomposer.org/doc/06-community.md">community</a>.</p>
+        <p>If you need help or if you have any questions please get in touch with the Composer <a href="https://getcomposer.org/doc/07-community.md">community</a>.</p>
     </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
The community link on https://packagist.org/packages/submit points to https://getcomposer.org/doc/06-community.md (which leads to a 404). It should point to https://getcomposer.org/doc/07-community.md