### PR TITLE
Create endpoint for API

### DIFF
--- a/src/Packagist/WebBundle/Controller/ApiController.php
+++ b/src/Packagist/WebBundle/Controller/ApiController.php
@@ -82,7 +82,16 @@ class ApiController extends Controller
             return new JsonResponse(array('status' => 'error', 'message' => 'Missing or invalid payload'), 406);
         }
 
-        return $this->receivePost($request, $url, $urlRegex);
+        
+        $package = new Package;
+        $package->setEntityRepository($this->getDoctrine()->getRepository('PackagistWebBundle:Package'));
+        $package->setRouter($this->get('router'));
+        $user = $this->findUser($request);
+        $package->addMaintainer($user);
+        $package->repository = $url;
+        $em = $this->getDoctrine()->getManager();
+        $em->persist($package);
+        $em->flush();
     }
 
     /**

--- a/src/Packagist/WebBundle/Controller/ApiController.php
+++ b/src/Packagist/WebBundle/Controller/ApiController.php
@@ -82,7 +82,6 @@ class ApiController extends Controller
             return new JsonResponse(array('status' => 'error', 'message' => 'Missing or invalid payload'), 406);
         }
 
-        
         $package = new Package;
         $package->setEntityRepository($this->getDoctrine()->getRepository('PackagistWebBundle:Package'));
         $package->setRouter($this->get('router'));

--- a/src/Packagist/WebBundle/Controller/ApiController.php
+++ b/src/Packagist/WebBundle/Controller/ApiController.php
@@ -62,7 +62,6 @@ class ApiController extends Controller
      */
     public function createPackageAction(Request $request)
     {
-
         $payload = json_decode($request->getContent(), true);
         if (!$payload) {
             return new JsonResponse(array('status' => 'error', 'message' => 'Missing payload parameter'), 406);
@@ -76,7 +75,7 @@ class ApiController extends Controller
         $package->repository = $url;
         $errors = $this->get('validator')->validate($package)
         if (count($errors) > 0) {
-            foreach( $errors as $error ) {
+            foreach($errors as $error) {
                 $errorArray[$error->getPropertyPath()] =  $error->getMessage();
             }
             return new JsonResponse(array('status' => 'error', 'message' => $errorArray), 406); 

--- a/src/Packagist/WebBundle/Controller/ApiController.php
+++ b/src/Packagist/WebBundle/Controller/ApiController.php
@@ -83,7 +83,7 @@ class ApiController extends Controller
             $em->flush();
         } catch (\Exception $e) {
             $this->get('logger')->crit($e->getMessage(), array('exception', $e));
-            return new JsonResponse(array('status' => 'error', 'message' => $e->getMessage()), 406); 
+            return new JsonResponse(array('status' => 'error', 'message' => 'Error saving package'), 500); 
         }
 
         return new JsonResponse(array('status' => 'success'), 202);

--- a/src/Packagist/WebBundle/Controller/ApiController.php
+++ b/src/Packagist/WebBundle/Controller/ApiController.php
@@ -76,8 +76,10 @@ class ApiController extends Controller
         $package->repository = $url;
         $errors = $this->get('validator')->validate($package)
         if (count($errors) > 0) {
-            $errorsString = (string) $errors;
-            return new JsonResponse(array('status' => 'error', 'message' => $errorsString), 406); 
+            foreach( $errors as $error ) {
+                $errorArray[$error->getPropertyPath()] =  $error->getMessage();
+            }
+            return new JsonResponse(array('status' => 'error', 'message' => $errorArray), 406); 
         }
         try {
             $em = $this->getDoctrine()->getManager();

--- a/src/Packagist/WebBundle/Controller/ApiController.php
+++ b/src/Packagist/WebBundle/Controller/ApiController.php
@@ -75,7 +75,7 @@ class ApiController extends Controller
         $package->repository = $url;
         $errors = $this->get('validator')->validate($package)
         if (count($errors) > 0) {
-            foreach($errors as $error) {
+            foreach ($errors as $error) {
                 $errorArray[$error->getPropertyPath()] =  $error->getMessage();
             }
             return new JsonResponse(array('status' => 'error', 'message' => $errorArray), 406); 

--- a/src/Packagist/WebBundle/Controller/ApiController.php
+++ b/src/Packagist/WebBundle/Controller/ApiController.php
@@ -74,8 +74,10 @@ class ApiController extends Controller
         $user = $this->findUser($request);
         $package->addMaintainer($user);
         $package->repository = $url;
-        if ($this->get('validator')->validate($package)) {
-            return new JsonResponse(array('status' => 'error', 'message' => 'Invalid package'), 406); 
+        $errors = $this->get('validator')->validate($package)
+        if (count($errors) > 0) {
+            $errorsString = (string) $errors;
+            return new JsonResponse(array('status' => 'error', 'message' => $errorsString), 406); 
         }
         try {
             $em = $this->getDoctrine()->getManager();

--- a/src/Packagist/WebBundle/Controller/ApiController.php
+++ b/src/Packagist/WebBundle/Controller/ApiController.php
@@ -83,7 +83,10 @@ class ApiController extends Controller
             $em->flush();
         } catch (\Exception $e) {
             $this->get('logger')->crit($e->getMessage(), array('exception', $e));
+            return new JsonResponse(array('status' => 'error', 'message' => $e->getMessage()), 406); 
         }
+
+        return new JsonResponse(array('status' => 'success'), 202);
     }
 
     /**

--- a/src/Packagist/WebBundle/Controller/ApiController.php
+++ b/src/Packagist/WebBundle/Controller/ApiController.php
@@ -89,9 +89,13 @@ class ApiController extends Controller
         $user = $this->findUser($request);
         $package->addMaintainer($user);
         $package->repository = $url;
-        $em = $this->getDoctrine()->getManager();
-        $em->persist($package);
-        $em->flush();
+        try {
+            $em = $this->getDoctrine()->getManager();
+            $em->persist($package);
+            $em->flush();
+        } catch (\Exception $e) {
+            $this->get('logger')->crit($e->getMessage(), array('exception', $e));
+        }
     }
 
     /**


### PR DESCRIPTION
I was speaking to @alcohol on IRC today and he confirmed my thought that there is no way to programatically add packages packagist. So I'm starting the effort towards a PR to add this functionality.

The use case is Drupal. I'm trying to look for a way that as soon as a new module is added to drupal.org it also gets added to packagist under the drupal namespace. I believe @dbuytaert owns the drupal namespace, drupal.org could use his API key to create the packages, then even add the module maintainer as a maintainer on packagist if we store packagist usernames as part of the drupal.org profiles.

We already have an endpoint in the packagist API for updating packages, which is awesome, but many packages are not already there so we need an automated way to add them.