### PR TITLE
Make index names unique

### DIFF
--- a/src/Packagist/WebBundle/Entity/DevRequireLink.php
+++ b/src/Packagist/WebBundle/Entity/DevRequireLink.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity
  * @ORM\Table(name="link_require_dev", indexes={
- *     @ORM\Index(name="package_name_idx",columns={"version_id", "packageName"})
+ *     @ORM\Index(name="link_require_dev_package_name_idx",columns={"version_id", "packageName"})
  * })
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */

--- a/src/Packagist/WebBundle/Entity/Package.php
+++ b/src/Packagist/WebBundle/Entity/Package.php
@@ -24,7 +24,7 @@ use Symfony\Component\Validator\ExecutionContextInterface;
  * @ORM\Entity(repositoryClass="Packagist\WebBundle\Entity\PackageRepository")
  * @ORM\Table(
  *     name="package",
- *     uniqueConstraints={@ORM\UniqueConstraint(name="name_idx", columns={"name"})},
+ *     uniqueConstraints={@ORM\UniqueConstraint(name="package_name_idx", columns={"name"})},
  *     indexes={
  *         @ORM\Index(name="indexed_idx",columns={"indexedAt"}),
  *         @ORM\Index(name="crawled_idx",columns={"crawledAt"}),

--- a/src/Packagist/WebBundle/Entity/RequireLink.php
+++ b/src/Packagist/WebBundle/Entity/RequireLink.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity
  * @ORM\Table(name="link_require", indexes={
- *     @ORM\Index(name="package_name_idx",columns={"version_id", "packageName"})
+ *     @ORM\Index(name="link_require_package_name_idx",columns={"version_id", "packageName"})
  * })
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */

--- a/src/Packagist/WebBundle/Entity/Tag.php
+++ b/src/Packagist/WebBundle/Entity/Tag.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @ORM\Entity
  * @ORM\Table(
  *     name="tag",
- *     uniqueConstraints={@ORM\UniqueConstraint(name="name_idx", columns={"name"})}
+ *     uniqueConstraints={@ORM\UniqueConstraint(name="tag_name_idx", columns={"name"})}
  * )
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */


### PR DESCRIPTION
If the names are not unique, SQLITE will throw a fit and refuse to create the schema, e.g.:

```
$ app/console doctrine:schema:create
ATTENTION: This operation should not be executed in a production environment.

Creating database schema...

  [Doctrine\ORM\Tools\ToolsException]
  Schema-Tool failed with Error 'An exception occurred while executing 'CREATE INDEX package_name_idx ON link_require (version_id, packageName)':
  SQLSTATE[HY000]: General error: 1 index package_name_idx already exists' while executing DDL: CREATE INDEX package_name_idx ON link_require (version_id, packageName)

  [Doctrine\DBAL\Exception\TableExistsException]
  An exception occurred while executing 'CREATE INDEX package_name_idx ON link_require (version_id, packageName)':
  SQLSTATE[HY000]: General error: 1 index package_name_idx already exists

  [Doctrine\DBAL\Driver\PDOException]
  SQLSTATE[HY000]: General error: 1 index package_name_idx already exists

  [PDOException]
  SQLSTATE[HY000]: General error: 1 index package_name_idx already exists
```

Making them unique solves this.