### PR TITLE
Show the package type in the package view

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/Package/viewPackage.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/viewPackage.html.twig
@@ -152,6 +152,7 @@
                             {% if package.gitHubForks is not null %}<p><span>Forks:</span> {{ package.gitHubForks|number_format(0, '.', '&#8201;')|raw }}</p>{% endif %}
                             {% if package.gitHubOpenIssues is not null %}<p><span>Open Issues:</span> {{ package.gitHubOpenIssues|number_format(0, '.', '&#8201;')|raw }}</p>{% endif %}
                             {% if package.language is not empty %}<p><span>Language:</span> {{ package.language }}</p>{% endif %}
+                            {% if package.type is not empty %}<p><span>Type:</span> {{ package.type }}</p>{% endif %}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Fixes #382 

This will show the package type below the `Language:` info.

<img width="403" alt="screen shot 2015-10-03 at 18 42 37" src="https://cloud.githubusercontent.com/assets/502368/10263930/d831dd0a-69fe-11e5-8eb8-07fa2131d47d.png">
