### PR TITLE
Add a warning in the package view if no license was found for the current version

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/Package/versionDetails.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/versionDetails.html.twig
@@ -8,7 +8,7 @@
     </span>
 
     <span class="release-date">{{ version.releasedAt|date("Y-m-d H:i") }} UTC</span>
-</div class="version-number">
+</div>
 
 <div class="clearfix package-links">
     {% for types in [["require", "devRequire", "suggest", "provide", "conflict", "replace"]] %}

--- a/src/Packagist/WebBundle/Resources/views/Package/viewPackage.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/viewPackage.html.twig
@@ -68,6 +68,10 @@
                         <div class="alert alert-danger">This package is in a broken state and will not update anymore. Some branches contain invalid data and until you fix them the entire package is frozen. Click "Force Update" above to see details.</div>
                     {% endif %}
 
+                    {% if expandedVersion and not expandedVersion.license %}
+                        <div class="alert alert-danger">There is no license information available for the current version ({{ expandedVersion.version }}) of this package. Please contact the maintainer for more information.</div>
+                    {% endif %}
+
                     <p class="description">{{ package.description }}</p>
 
                     {% if hasActions %}


### PR DESCRIPTION
Fixes #577 

This PR checks if the `expandedVersion` has a license, and if not, displays a warning.

I'm not sure about the exact wording, any wishes/ideas?

<img width="875" alt="screen shot 2015-10-03 at 19 02 12" src="https://cloud.githubusercontent.com/assets/502368/10264013/7264bd6e-6a01-11e5-9644-32e0a63b7f2f.png">
