### PR TITLE
Increase the visibility of "No packages found."

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/Web/list.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/list.html.twig
@@ -9,7 +9,9 @@
         {% if packages|length %}
             {{ macros.listPackages(packages, paginate is not defined or paginate, showAutoUpdateWarning|default(false), meta|default(null)) }}
         {% else %}
-            <p>No packages found.</p>
+            <div class="alert alert-danger">
+                <p>No packages found.</p>
+            </div>
         {% endif %}
     {% endblock %}
 {% endblock %}


### PR DESCRIPTION
The existing "No packages found" message seems a bit too subtle - this Bootstrap alert CSS should help boost its visibility.
<img width="449" alt="screen shot 2015-10-18 at 9 11 04 am" src="https://cloud.githubusercontent.com/assets/602491/10564883/36b6979c-7578-11e5-910a-084bb6b883c9.png">
