### PR TITLE
Allow (optional) port number in repository URL

### DIFF
--- a/src/Packagist/WebBundle/Controller/ApiController.php
+++ b/src/Packagist/WebBundle/Controller/ApiController.php
@@ -111,7 +111,7 @@ class ApiController extends Controller
         }
 
         if (isset($payload['repository']['url'])) { // github/gitlab/anything hook
-            $urlRegex = '{^(?:ssh://git@|https?://|git://|git@)?(?P<host>[a-z0-9.-]+)[:/](?P<path>[\w.-]+/[\w.-]+?)(?:\.git)?$}i';
+            $urlRegex = '{^(?:ssh://git@|https?://|git://|git@)?(?P<host>[a-z0-9.-]+):(?:[0-9]+)?/(?P<path>[\w.-]+/[\w.-]+?)(?:\.git)?$}i';
             $url = $payload['repository']['url'];
         } elseif (isset($payload['repository']['links']['html']['href'])) { // bitbucket push event payload
             $urlRegex = '{^(?:https?://|git://|git@)?(?:api\.)?(?P<host>bitbucket\.org)[/:](?P<path>[\w.-]+/[\w.-]+?)(\.git)?/?$}i';

--- a/src/Packagist/WebBundle/Controller/ApiController.php
+++ b/src/Packagist/WebBundle/Controller/ApiController.php
@@ -111,7 +111,7 @@ class ApiController extends Controller
         }
 
         if (isset($payload['repository']['url'])) { // github/gitlab/anything hook
-            $urlRegex = '{^(?:ssh://git@|https?://|git://|git@)?(?P<host>[a-z0-9.-]+):(?:[0-9]+)?/(?P<path>[\w.-]+/[\w.-]+?)(?:\.git)?$}i';
+            $urlRegex = '{^(?:ssh://git@|https?://|git://|git@)?(?P<host>[a-z0-9.-]+)(?::[0-9]+/|[:/])(?P<path>[\w.-]+/[\w.-]+?)(?:\.git)?$}i';
             $url = $payload['repository']['url'];
         } elseif (isset($payload['repository']['links']['html']['href'])) { // bitbucket push event payload
             $urlRegex = '{^(?:https?://|git://|git@)?(?:api\.)?(?P<host>bitbucket\.org)[/:](?P<path>[\w.-]+/[\w.-]+?)(\.git)?/?$}i';

--- a/src/Packagist/WebBundle/Tests/Controller/ApiControllerTest.php
+++ b/src/Packagist/WebBundle/Tests/Controller/ApiControllerTest.php
@@ -118,6 +118,7 @@ class ApiControllerTest extends WebTestCase
             array('update-package', 'https://ghe.example.org/user/repository', true),
             array('update-package', 'https://gitlab.org/user/repository', true),
             array('update-package', 'ssh://git@stash.xxxxx.com/uuuuu/qqqqq.git', true),
+            array('update-package', 'ssh://git@stash.xxxxx.com:2222/uuuuu/qqqqq.git', true),
 
             // invalid URLs
             array('github', 'php://github.com/user/repository', false),


### PR DESCRIPTION
This allows us to create webhooks for URLs that have port numbers in them (specifically `ssh://` running under custom port).

I've added the test as well, but haven't run them, haven't set it up properly yet.