### PR TITLE
Show deps count on dependents page

### DIFF
--- a/src/Packagist/WebBundle/Controller/PackageController.php
+++ b/src/Packagist/WebBundle/Controller/PackageController.php
@@ -916,6 +916,7 @@ class PackageController extends Controller
         $paginator->setCurrentPage($page, false, true);
 
         $data['packages'] = $paginator;
+        $data['count'] = $depCount;
 
         $data['meta'] = $this->getPackagesMetadata($data['packages']);
         $data['name'] = $name;

--- a/src/Packagist/WebBundle/Resources/public/css/main.css
+++ b/src/Packagist/WebBundle/Resources/public/css/main.css
@@ -577,6 +577,10 @@ input:focus:invalid:focus, textarea:focus:invalid:focus, select:focus:invalid:fo
     color: rgb(82, 168, 236);
 }
 
+ul.packages {
+    margin-top: 20px;
+}
+
 ul.packages h1 {
   font-family: Verdana;
   font-size: 22px;

--- a/src/Packagist/WebBundle/Resources/views/Package/dependents.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/dependents.html.twig
@@ -12,6 +12,7 @@
             <div class="package-header">
                 <h2 class="title">
                     <a href="{{ path("view_package", {name: name}) }}">{{ name }}</a> dependents
+                    <small>({{ count }})</small>
                 </h2>
             </div>
         </div>


### PR DESCRIPTION
Just added a counter on dependents page.

I also made a quick-fix on CSS for package list that hide the title line.

Before:

![selection_553](https://cloud.githubusercontent.com/assets/1698357/11532421/fd3b1592-9903-11e5-9c36-aa55d06c7f32.png)

After:

![selection_555](https://cloud.githubusercontent.com/assets/1698357/11532446/1eb3dcae-9904-11e5-8068-34a544bd827a.png)
