### PR TITLE
Avoid creating a useless prototype for the search ordering form

### DIFF
--- a/src/Packagist/WebBundle/Form/Type/SearchQueryType.php
+++ b/src/Packagist/WebBundle/Form/Type/SearchQueryType.php
@@ -27,7 +27,8 @@ class SearchQueryType extends AbstractType
         $builder->add('orderBys', 'collection', array(
             'type' => new OrderByType(),
             'allow_add' => true,
-            'allow_delete' => true
+            'allow_delete' => true,
+            'prototype' => false,
         ));
     }
 


### PR DESCRIPTION
There is no JS code reading the prototype to add elements in the collection. The UI hides the fields and builds links separately.