### PR TITLE
Better monospaced font for box drawing

### DIFF
--- a/src/Packagist/WebBundle/Resources/public/css/main.css
+++ b/src/Packagist/WebBundle/Resources/public/css/main.css
@@ -29,7 +29,7 @@ html, body {
 
 pre, code {
     background: #fff;
-    font-family: Consolas, "Courier New", Courier, monospace;
+    font-family: Menlo, Consolas, "Courier New", Courier, monospace;
     border-radius: 0;
     border: none;
     color: #2d2d32;


### PR DESCRIPTION
Consider this the lowest of the low in priority. :smile: 

Most of the current fonts used in `<pre>` do not have monospaced support [box drawing characters](https://en.wikipedia.org/wiki/Box-drawing_character)

This can lead to deformities for people who try to be too smart for their own good, like myself.

Example:
[https://packagist.org/packages/foundry/masonry](https://packagist.org/packages/foundry/masonry)

The fonts in play are.

In [`pre, code`](https://github.com/composer/packagist/blob/d8ccd79956b4bc7d7d27de00419341c28c36b64b/src/Packagist/WebBundle/Resources/public/css/main.css#L30-L36):
 * Consolas :x:
 * Courier New :x:
 * Courier :x:
 * monospace :x:

In [`code`](https://github.com/composer/packagist/blob/master/web/libs/bootstrap-3.3.5/css/bootstrap.min.css) (imported from bootstrap):
 * Menlo  :white_check_mark:
 * Monaco :x:
 * Consolas :x:
 * Courier New :x:
 * monospace :x:

This pull request adds Menlo to the front of the `pre, code`, which is a quick fix and to me, hardly noticable in style.