### PR TITLE
Add php 5.5 to travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ services:
   - redis-server
 
 php:
+  - 5.5
   - 5.6
   - 7.0
 


### PR DESCRIPTION
Reason since that is the minium supported php version for this repo we should test against php 5.5 too.