### PR TITLE
Improved the styles of tables included in the README file

### DIFF
--- a/src/Packagist/WebBundle/Resources/public/css/main.css
+++ b/src/Packagist/WebBundle/Resources/public/css/main.css
@@ -991,6 +991,21 @@ ul.packages .metadata-block:last-child {
   line-height: 100%;
 }
 
+.wrapper .content .package .readme table {
+  margin: 0 0 15px;
+}
+.wrapper .content .package .readme th,
+.wrapper .content .package .readme td {
+  border: 1px solid #CCC;
+  padding: 5px 10px;
+}
+.wrapper .content .package .readme th {
+  background: #EEE;
+}
+.wrapper .content .package .readme table code {
+  font-size: 13px;
+}
+
 .package .package-aside {
   border-top: 1px solid #f28d1a;
   border-radius: 0;


### PR DESCRIPTION
I tried to fix #614. Please let me know what you think about it or the changes I need to make. Thanks!

### Before

![table_before](https://cloud.githubusercontent.com/assets/73419/13393189/1162093c-dee0-11e5-8943-544fa645c5cf.png)

### After

![table_after](https://cloud.githubusercontent.com/assets/73419/13393191/1373d5de-dee0-11e5-889e-7c39a9e2f286.png)
