### PR TITLE
Updated the way numbers are formatted

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -32,6 +32,10 @@ twig:
         - 'PackagistWebBundle::forms.html.twig'
     debug:            %kernel.debug%
     strict_variables: %kernel.debug%
+    number_format:
+        decimals: 0
+        decimal_point: '.'
+        thousands_separator: ','
     globals:
         google_analytics: %google_analytics%
         packagist_host: %packagist_host%

--- a/src/Packagist/WebBundle/Resources/views/Package/viewPackage.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/viewPackage.html.twig
@@ -149,12 +149,12 @@
                         </div>
 
                         <div class="facts col-xs-12 col-sm-6 col-md-12">
-                            <p><span><a href="{{ path('view_package_stats', {name: package.name}) }}" rel="nofollow">Installs</a>:</span> {% if downloads.total is defined %}{{ downloads.total|number_format(0, '.', '&#8201;')|raw }}{% else %}N/A{% endif %}</p>
-                            {% if dependents is defined %}<p><span><a href="{{ path('view_package_dependents', {name: package.name}) }}" rel="nofollow">Dependents</a>:</span> {{ dependents|number_format(0, '.', '&#8201;')|raw }}</p>{% endif %}
-                            {% if package.gitHubStars is not null %}<p><span>Stars:</span> {{ package.gitHubStars|number_format(0, '.', '&#8201;')|raw }}</p>{% endif %}
-                            {% if package.gitHubWatches is not null %}<p><span>Watchers:</span> {{ package.gitHubWatches|number_format(0, '.', '&#8201;')|raw }}</p>{% endif %}
-                            {% if package.gitHubForks is not null %}<p><span>Forks:</span> {{ package.gitHubForks|number_format(0, '.', '&#8201;')|raw }}</p>{% endif %}
-                            {% if package.gitHubOpenIssues is not null %}<p><span>Open Issues:</span> {{ package.gitHubOpenIssues|number_format(0, '.', '&#8201;')|raw }}</p>{% endif %}
+                            <p><span><a href="{{ path('view_package_stats', {name: package.name}) }}" rel="nofollow">Installs</a>:</span> {% if downloads.total is defined %}{{ downloads.total }}{% else %}N/A{% endif %}</p>
+                            {% if dependents is defined %}<p><span><a href="{{ path('view_package_dependents', {name: package.name}) }}" rel="nofollow">Dependents</a>:</span> {{ dependents }}</p>{% endif %}
+                            {% if package.gitHubStars is not null %}<p><span>Stars:</span> {{ package.gitHubStars }}</p>{% endif %}
+                            {% if package.gitHubWatches is not null %}<p><span>Watchers:</span> {{ package.gitHubWatches }}</p>{% endif %}
+                            {% if package.gitHubForks is not null %}<p><span>Forks:</span> {{ package.gitHubForks }}</p>{% endif %}
+                            {% if package.gitHubOpenIssues is not null %}<p><span>Open Issues:</span> {{ package.gitHubOpenIssues }}</p>{% endif %}
                             {% if package.language is not empty and package.language != 'PHP' %}<p><span>Language:</span> {{ package.language }}</p>{% endif %}
                             {% if package.type is not empty and package.type != 'library' %}<p><span>Type:</span> {{ package.type }}</p>{% endif %}
                         </div>


### PR DESCRIPTION
This PR proposes two changes:

**1)** The thousands separator (`&thinsp;`) is almost invisible. In my opinion this makes large numbers very hard to understand:

| Before | After
| --- | ---
| ![before](https://cloud.githubusercontent.com/assets/73419/13430751/9ac5a6a2-dfc6-11e5-9eb7-342670a6ae3c.png) | ![after](https://cloud.githubusercontent.com/assets/73419/13430753/9c5d299a-dfc6-11e5-88fb-78aa2e6de6b9.png)

**2)** There is no need to do the number formatting per number because Symfony allows to configure this globally. I've only updated a template fragment, but if this change is accepted, I can update the rest of the templates.

---

Note: I haven't tested these changes locally because I can't install Packagist application yet because of its requirements.