### PR TITLE
Make possible next runs of DumpPackagesCommand after SymlinkDumper's exceptions thrown

### DIFF
--- a/src/Packagist/WebBundle/Command/DumpPackagesCommand.php
+++ b/src/Packagist/WebBundle/Command/DumpPackagesCommand.php
@@ -86,8 +86,11 @@ class DumpPackagesCommand extends ContainerAwareCommand
             return;
         }
 
-        $result = $this->getContainer()->get('packagist.package_dumper')->dump($ids, $force, $verbose);
-        $lock->release();
+        try {
+             $result = $this->getContainer()->get('packagist.package_dumper')->dump($ids, $force, $verbose);
+        } finally {
+             $lock->release();
+        }
 
         return $result ? 0 : 1;
     }


### PR DESCRIPTION
Now if DumpPackagesCommand fails due to any kind of exception thrown inside SymlinkDumper (it can be caused by filesystem problems or mysql server connectivity issues for example), - the lock aquired before SymlinkDumper is executed stays unreleased. 
This causes impossibility of aquiring this lock during the next DumpPackagesCommand run. 

This patch releases lock regardless of whether dump process was successful or not.