### PR TITLE
#656 Ctrl + Enter to open search result in new tab

### DIFF
--- a/src/Packagist/WebBundle/Resources/public/js/search.js
+++ b/src/Packagist/WebBundle/Resources/public/js/search.js
@@ -129,7 +129,13 @@
         }
 
         if (keymap.enter === event.which && currentSelected.data('url')) {
-            window.location = currentSelected.data('url');
+            var url = currentSelected.data('url');
+            if (event.ctrlKey) {
+                window.open(url);
+                return;
+            }
+
+            window.location = url;
             return;
         }
 


### PR DESCRIPTION
I'm not sure about Mac... Does it use Ctrl for opening links in a new tab? Does that flag `ctrlKey` too?