### PR TITLE
Add HTML5 autofocus to search box

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/Web/searchForm.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/searchForm.html.twig
@@ -2,7 +2,7 @@
     <div class="{% if orderBys is defined %}sortable{% endif %} row">
         <div class="hidden">{{ form_errors(searchForm.query) }}</div>
         <div class="{% if searchForm.vars.value.query is empty %}col-xs-12{% else %}col-xs-8{% endif %} js-search-field-wrapper col-md-9">
-            {{ form_widget(searchForm.query, {'attr': {'autocomplete': 'off', 'placeholder': 'Search packages...', 'tabindex': 1}}) }}
+            {{ form_widget(searchForm.query, {'attr': {'autocomplete': 'off', 'placeholder': 'Search packages...', 'tabindex': 1, 'autofocus': 'autofocus'}}) }}
         </div>
 
         {% set hasActiveOrderBy = false %}


### PR DESCRIPTION
Adds a HTML5 autofocus attribute to the search box. This allows the autofocus to work without JS enabled on supported browsers.

I recently added the same thing to crates.io, the main Rust package repository: https://github.com/rust-lang/crates.io/pull/293