### PR TITLE
Made a CORS path less restrictive

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -116,7 +116,7 @@ nelmio_cors:
         allow_headers: ['*']
         max_age: 600
     paths:
-        '^/packages/list\.json$':
+        '^/packages/list\.json':
             allow_methods: ['GET']
         '^/search\.json$':
             allow_methods: ['GET']


### PR DESCRIPTION
I'm using the CORS feature that you recently merged and everything works as expected ... except the URL that returns the packages published by a vendor, e.g. `https://packagist.org/packages/list.json?vendor=symfony`

This is the error I get with this URL:

![cors_error](https://cloud.githubusercontent.com/assets/73419/14307892/b6c64b36-fbd2-11e5-8227-d716a78539c9.png)
