### PR TITLE
Improve the way of php requirement on homepage

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/Web/index.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/index.html.twig
@@ -43,7 +43,7 @@
     "name": "your-vendor-name/package-name",
     "description": "A short description of what your package does",
     "require": {
-        "php": ">=5.3.0",
+        "php": "^5.3.3 || ^7.0",
         "another-vendor/package": "1.*"
     }
 }</code></pre>


### PR DESCRIPTION
Because it's not safe to require an unbound version, even if for PHP. :wink: 