### PR TITLE
Redirect to package detail from search when only one package was found

### DIFF
--- a/src/Packagist/WebBundle/Controller/WebController.php
+++ b/src/Packagist/WebBundle/Controller/WebController.php
@@ -224,10 +224,16 @@ class WebController extends Controller
                 }
             }
 
+            if ($paginator->count() === 1) {
+                $package = $paginator->getIterator()->current();
+                return $this->redirect($this->generateUrl('view_package', array('name' => $package['name'])));
+            }
+
             return $this->render('PackagistWebBundle:Web:search.html.twig', array(
                 'packages' => $paginator,
                 'meta' => $metadata,
             ));
+
         } elseif ($req->getRequestFormat() === 'json') {
             return JsonResponse::create(array(
                 'error' => 'Missing search query, example: ?q=example'


### PR DESCRIPTION
This is a PR in a "RFC state" - I was't able to test it properly as it would require Solr.

It is also possible that this would be confusing to users when found package is just very similar by name - so some query/found package name matching could be appropriate.