### PR TITLE
Made the steps to set up the hook more readable

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/About/about.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/About/about.html.twig
@@ -102,7 +102,16 @@ v2.0.4-p1</code></pre>
     <section class="row">
         <section class="col-md-6">
             <h3>GitHub Service Hook</h3>
-            <p>Enabling the Packagist service hook ensures that your package will always be updated instantly when you push to GitHub. To do so you can go to your GitHub repository, click the "Settings" button, then "Webhooks &amp; Services". Add a "Packagist" service, and configure it with your API token, plus your Packagist username. Check the "Active" box and submit the form. You can then hit the "Test Service" button to trigger it and check if Packagist removes the warning about the package not being auto-updated.</p>
+            <p>Enabling the Packagist service hook ensures that your package will always be updated instantly when you push to GitHub.</p>
+            <p>To do so you can:</p>
+            <ul>
+                <li>Go to your GitHub repository</li>
+                <li>Click the "Settings" button</li>
+                <li>Click "Webhooks &amp; Services"</li>
+                <li>Add a "Packagist" service, and configure it with your API token, plus your Packagist username</li>
+                <li>Check the "Active" box and submit the form</li>
+            </ul>
+            <p>You can then hit the "Test Service" button to trigger it and check if Packagist removes the warning about the package not being auto-updated.</p>
         </section>
 
         <section class="col-md-6">


### PR DESCRIPTION
I've changed the long paragraph to a list with bullets so that the steps to set up the hook are more readable.

**Before this PR**

![packagist-before](https://cloud.githubusercontent.com/assets/1330296/15984887/eb024580-2fda-11e6-815b-0b162d9da1c2.png)

**After this PR**

![packagist-after](https://cloud.githubusercontent.com/assets/1330296/15984889/f1cc6184-2fda-11e6-98d6-af535d07901a.png)
