### PR TITLE
Replace type placeholder in the search

### DIFF
--- a/src/Packagist/WebBundle/Controller/WebController.php
+++ b/src/Packagist/WebBundle/Controller/WebController.php
@@ -75,7 +75,7 @@ class WebController extends Controller
 
         $this->computeSearchQuery($req, $filteredOrderBys);
 
-        $typeFilter = $req->query->get('type');
+        $typeFilter = str_replace('%type%', '', $req->query->get('type'));
         $tagsFilter = $req->query->get('tags');
 
         if ($req->query->has('search_query') || $typeFilter || $tagsFilter) {


### PR DESCRIPTION
This is a follow-up to #692.

When someone is not using the latest version of composer (which includes the type parameter for the search), then searching for a package includes the type parameter placeholder. E.G (`https://packagist.org/search.json?q=symfony&type=%type%`). So the placeholder needs to be removed from the type query string.