### PR TITLE
exclude Tests from classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     },
     "autoload": {
         "psr-4": { "Packagist\\": "src/Packagist/" },
-        "classmap": [ "app/AppKernel.php", "app/AppCache.php" ]
+        "classmap": [ "app/AppKernel.php", "app/AppCache.php" ],
+        "exclude-from-classmap": [ "**/Tests/" ]
     },
     "require": {
         "php": ">=5.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "9c11b9876532f8014cabcf63771565cb",
+    "hash": "5df3bce7dc855c856f952612c9b1c372",
     "content-hash": "ca089bd944842e20cdbdf556dad7c4f0",
     "packages": [
         {


### PR DESCRIPTION
by excluding Tests from autoload classmap, it reduce about 371 lines.

and when i run composer validate it show warning
name : The property name is required
The property _comment is not defined and the definition does not allow additional properties

and i think its @Seldaek will solve the warning.