### PR TITLE
changes i.e. to e.g.

### DIFF
--- a/src/Packagist/WebBundle/Form/Type/PackageType.php
+++ b/src/Packagist/WebBundle/Form/Type/PackageType.php
@@ -28,7 +28,7 @@ class PackageType extends AbstractType
         $builder->add('repository', TextType::class, array(
             'label' => 'Repository URL (Git/Svn/Hg)',
             'attr'  => array(
-                'placeholder' => 'i.e.: https://github.com/composer/composer',
+                'placeholder' => 'e.g.: https://github.com/composer/composer',
             )
         ));
     }


### PR DESCRIPTION
This should be e.g. ("for example") rather than i.e. ("in other words"). See [this very serious grammar reference](http://theoatmeal.com/comics/ie) for more information.

Context: https://packagist.org/packages/submit