### PR TITLE
Fixed repoUrl which links to stargazers, watchers and forks

### DIFF
--- a/src/Packagist/WebBundle/Entity/Package.php
+++ b/src/Packagist/WebBundle/Entity/Package.php
@@ -552,6 +552,10 @@ class Package
         }
 
         $repoUrl = preg_replace('{^git@github.com:}i', 'https://github.com/', $repoUrl);
+        $dotGitLength = -strlen('.git');
+        if (substr($repoUrl, -$dotGitLength, $dotGitLength) === '.git') {
+            $repoUrl = substr($repoUrl, 0, -$dotGitLength);
+        }
         $this->repository = $repoUrl;
 
         // avoid user@host URLs


### PR DESCRIPTION
I found out that the links on the package detail page sometimes lead to 404s:

https://packagist.org/packages/phpstan/phpstan:
- https://github.com/phpstan/phpstan.git/stargazers
- https://github.com/phpstan/phpstan.git/watchers

But sometimes the URL is right:

https://packagist.org/packages/composer/composer:
- https://github.com/composer/composer/stargazers
- https://github.com/composer/composer/watchers

I really don't know what's the underlying issue, if the URL reported by GitHub is inconsistent or what, so I tried to fix it with a conditional trimming of the `.git` from the end of the URL.
