### PR TITLE
Use localized strings in page views and templates

### DIFF
--- a/app/Resources/FOSUserBundle/views/Profile/edit_content.html.twig
+++ b/app/Resources/FOSUserBundle/views/Profile/edit_content.html.twig
@@ -32,7 +32,7 @@
         {{ form_errors(form.failureNotifications) }}
         <label>
             {{ form_widget(form.failureNotifications) }}
-            Notify me of package update failures
+            {{ 'profile.notify_on_failure'|trans }}
         </label>
     </div>
 
@@ -46,7 +46,7 @@
 
     <a href="{{ app.user.githubId ? '#' : hwi_oauth_login_url('github') }}" class="btn btn-block btn-github btn-lg {{ app.user.githubId ? 'disabled' : 'btn-primary' }}">
         <span class="icon-github"></span>
-        {{ app.user.githubId ? 'Accounts connected' : 'Connect accounts' }}
+        {{ (app.user.githubId ? 'profile.accounts_connected' : 'profile.connect_accounts')|trans }}
     </a>
 </form>
 

--- a/app/Resources/FOSUserBundle/views/Profile/show.html.twig
+++ b/app/Resources/FOSUserBundle/views/Profile/show.html.twig
@@ -14,7 +14,7 @@
             </span>
         </div>
 
-        <p>{{ 'profile.api_token_explain'|trans({ _path_about_:path('about') })|raw }}</p>
+        <p>{{ 'profile.api_token_explain'|trans({ '%path_about%':path('about') })|raw }}</p>
 
         <hr>
     {%- endif %}

--- a/app/Resources/FOSUserBundle/views/Profile/show.html.twig
+++ b/app/Resources/FOSUserBundle/views/Profile/show.html.twig
@@ -5,23 +5,23 @@
 {% block fos_user_content %}
 <section class="col-md-9">
     {%- if app.user.apiToken %}
-        <h3 class="font-normal profile-title">Your API Token</h3>
+        <h3 class="font-normal profile-title">{{ 'profile.your_api_token'|trans }}</h3>
 
         <div class="input-group api-token-group clearfix">
             <input id="api-token" type="text" class="form-control" value="" data-api-token="{{ app.user.apiToken }}" readonly="readonly">
             <span class="input-group">
-                <button class="btn btn-success btn-show-api-token" type="button">Show API Token</button>
+                <button class="btn btn-success btn-show-api-token" type="button">{{ 'profile.show_api_token'|trans }}</button>
             </span>
         </div>
 
-        <p>You can use your API token to interact with the Packagist API, see details in <a href="{{ path('about') }}#how-to-update-packages">the docs</a>.</p>
+        <p>{{ 'profile.api_token_explain'|trans({ _path_about_:path('about') })|raw }}</p>
 
         <hr>
     {%- endif %}
 
     {% embed "PackagistWebBundle:Web:list.html.twig" with {noLayout: 'true', showAutoUpdateWarning: true} %}
         {% block content_title %}
-            <h3 class="font-normal">Your packages</h3>
+            <h3 class="font-normal">{{ 'packages.yours'|trans }}</h3>
         {% endblock %}
     {% endembed %}
 </section>

--- a/src/Packagist/WebBundle/Menu/MenuBuilder.php
+++ b/src/Packagist/WebBundle/Menu/MenuBuilder.php
@@ -4,6 +4,7 @@ namespace Packagist\WebBundle\Menu;
 
 use Knp\Menu\FactoryInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class MenuBuilder
 {
@@ -13,10 +14,12 @@ class MenuBuilder
     /**
      * @param FactoryInterface      $factory
      * @param TokenStorageInterface $tokenStorage
+     * @param TranslatorInterface   $translator
      */
-    public function __construct(FactoryInterface $factory, TokenStorageInterface $tokenStorage)
+    public function __construct(FactoryInterface $factory, TokenStorageInterface $tokenStorage, TranslatorInterface $translator)
     {
         $this->factory = $factory;
+        $this->translator = $translator;
 
         if ($tokenStorage->getToken() && $tokenStorage->getToken()->getUser()) {
             $this->username = $tokenStorage->getToken()->getUser()->getUsername();
@@ -30,7 +33,7 @@ class MenuBuilder
 
         $this->addProfileMenu($menu);
         $menu->addChild('hr', array('label' => '<hr>', 'labelAttributes' => array('class' => 'normal'), 'extras' => array('safe_label' => true)));
-        $menu->addChild('Logout', array('label' => '<span class="icon-off"></span>Logout', 'route' => 'logout', 'extras' => array('safe_label' => true)));
+        $menu->addChild($this->translator->trans('menu.logout'), array('label' => '<span class="icon-off"></span>' . $this->translator->trans('menu.logout'), 'route' => 'logout', 'extras' => array('safe_label' => true)));
 
         return $menu;
     }
@@ -47,10 +50,10 @@ class MenuBuilder
 
     private function addProfileMenu($menu)
     {
-        $menu->addChild('Profile', array('label' => '<span class="icon-vcard"></span>Profile', 'route' => 'fos_user_profile_show', 'extras' => array('safe_label' => true)));
-        $menu->addChild('Settings', array('label' => '<span class="icon-tools"></span>Settings', 'route' => 'fos_user_profile_edit', 'extras' => array('safe_label' => true)));
-        $menu->addChild('Change password', array('label' => '<span class="icon-key"></span>Change password', 'route' => 'fos_user_change_password', 'extras' => array('safe_label' => true)));
-        $menu->addChild('My packages', array('label' => '<span class="icon-box"></span>My packages', 'route' => 'user_packages', 'routeParameters' => array('name' => $this->username), 'extras' => array('safe_label' => true)));
-        $menu->addChild('My favorites', array('label' => '<span class="icon-leaf"></span>My favorites', 'route' => 'user_favorites', 'routeParameters' => array('name' => $this->username), 'extras' => array('safe_label' => true)));
+        $menu->addChild($this->translator->trans('menu.profile'), array('label' => '<span class="icon-vcard"></span>' . $this->translator->trans('menu.profile'), 'route' => 'fos_user_profile_show', 'extras' => array('safe_label' => true)));
+        $menu->addChild($this->translator->trans('menu.settings'), array('label' => '<span class="icon-tools"></span>' . $this->translator->trans('menu.settings'), 'route' => 'fos_user_profile_edit', 'extras' => array('safe_label' => true)));
+        $menu->addChild($this->translator->trans('menu.change_password'), array('label' => '<span class="icon-key"></span>' . $this->translator->trans('menu.change_password'), 'route' => 'fos_user_change_password', 'extras' => array('safe_label' => true)));
+        $menu->addChild($this->translator->trans('menu.my_packages'), array('label' => '<span class="icon-box"></span>' . $this->translator->trans('menu.my_packages'), 'route' => 'user_packages', 'routeParameters' => array('name' => $this->username), 'extras' => array('safe_label' => true)));
+        $menu->addChild($this->translator->trans('menu.my_favorites'), array('label' => '<span class="icon-leaf"></span>' . $this->translator->trans('menu.my_favorites'), 'route' => 'user_favorites', 'routeParameters' => array('name' => $this->username), 'extras' => array('safe_label' => true)));
     }
 }

--- a/src/Packagist/WebBundle/Resources/config/services.yml
+++ b/src/Packagist/WebBundle/Resources/config/services.yml
@@ -105,7 +105,7 @@ services:
 
     packagist.menu_builder:
         class: Packagist\WebBundle\Menu\MenuBuilder
-        arguments: ['@knp_menu.factory', '@security.token_storage']
+        arguments: ['@knp_menu.factory', '@security.token_storage', '@translator']
 
     packagist.menu.user:
         class: Knp\Menu\MenuItem

--- a/src/Packagist/WebBundle/Resources/translations/messages.en.yml
+++ b/src/Packagist/WebBundle/Resources/translations/messages.en.yml
@@ -53,24 +53,28 @@ search:
 packages:
     mine: My packages
     yours: Your packages
-    maintained_by: Packages maintained by _user
+    maintained_by: Packages maintained by %user%
     my_favorites: My favorite packages
-    users_favorites: _user's favorite packages
+    users_favorites: %user%'s favorite packages
     dependent_title: Dependent Packages
     dependents: dependents
-    providers_title: The following packages provide _name_
+    providers_title: The following packages provide %name%
     suggesters: suggesters
     suggesters_title: Suggesters Packages
-    from: Packages from _vendor_
+    from: Packages from %vendor%
 
 browse:
     packages: Packages
+    of_type: of type %type%
+    with_tag: tagged with %tag%
+    join_and: ' and '
+    join_or: ' or '
 
 submit:
     title: Submit package
     submit: Submit
     guide: |
-        <p>Please make sure you have read the package <a href="_path_about_#naming-your-package">naming conventions</a> before submitting your package. The authoritative name of your package will be taken from the composer.json file inside the master branch or trunk of your repository, and it can not be changed after that.</p>
+        <p>Please make sure you have read the package <a href="%path_about%#naming-your-package">naming conventions</a> before submitting your package. The authoritative name of your package will be taken from the composer.json file inside the master branch or trunk of your repository, and it can not be changed after that.</p>
         <p><strong>Do not submit forks of existing packages.</strong> If you need to test changes to a package that you forked to patch, use <a href="https://getcomposer.org/doc/05-repositories.md#vcs">VCS Repositories</a> instead. If however it is a real long-term fork you intend on maintaining feel free to submit it.</p>
         <p>If you need help or if you have any questions please get in touch with the Composer <a href="https://getcomposer.org/doc/07-community.md">community</a>.</p>
 
@@ -83,8 +87,8 @@ abandon:
             will be tagged as abandoned and a replacement can be added later.</p>
 
 edit:
-    page_title: Edit Package _name
-    title: Edit _name
+    page_title: Edit Package %name%
+    title: Edit %name%
     submit: Update
 
 profile:
@@ -94,7 +98,7 @@ profile:
     connect_accounts: Connect accounts
     notify_on_failure: Notify me of package update failures
     api_token_explain: |
-        You can use your API token to interact with the Packagist API, see details in <a href="_path_about_#how-to-update-packages">the docs</a>.
+        You can use your API token to interact with the Packagist API, see details in <a href="%path_about%#how-to-update-packages">the docs</a>.
 
 stats:
     title: Install Statistics
@@ -106,7 +110,7 @@ stats:
     since_midnight: "since midnight, UTC"
     daily: Daily installs
     daily_per_version: Daily installs per version
-    averaged: averaged _avg_
+    averaged: averaged %avg%
 
 statistics:
     title: Statistics
@@ -143,7 +147,7 @@ api_doc:
 
 user:
     member_since: member since
-    packages: _username_'s packages
+    packages: %username%'s packages
 
 'Search packages...': 'Search packages...'
 brandname: Packagist

--- a/src/Packagist/WebBundle/Resources/translations/messages.en.yml
+++ b/src/Packagist/WebBundle/Resources/translations/messages.en.yml
@@ -13,6 +13,18 @@ menu:
     contact: Contact
     stats: Statistics
     api_doc: API
+    browse: Browse
+    submit: Submit
+    togglenav: Toggle navigation
+    create_account: Create account
+    sign_in: Sign in
+    settings: Settings
+    change_password: Change password
+    my_packages: My packages
+    my_favorites: My favorites
+
+signinbox:
+     register: No account yet? Create one now!
 
 link_type:
     require: Requires
@@ -22,7 +34,120 @@ link_type:
     replace: Replaces
     provide: Provides
 
+listing:
+    title: Packages
+    nopackages: No packages found.
+    viewall: View All
+
+explore:
+    title: Packages
+    newreleases: New Releases
+    newpackages: New Packages
+    popularpackages: Popular Packages
+    randompackages: Random Packages
+
+search:
+    claim_html: |
+        Packagist is the main <a href="https://getcomposer.org/">Composer</a> repository. It aggregates public PHP packages installable with Composer.
+
+packages:
+    mine: My packages
+    yours: Your packages
+    maintained_by: Packages maintained by _user
+    my_favorites: My favorite packages
+    users_favorites: _user's favorite packages
+    dependent_title: Dependent Packages
+    dependents: dependents
+    providers_title: The following packages provide _name_
+    suggesters: suggesters
+    suggesters_title: Suggesters Packages
+    from: Packages from _vendor_
+
+browse:
+    packages: Packages
+
+submit:
+    title: Submit package
+    submit: Submit
+    guide: |
+        <p>Please make sure you have read the package <a href="_path_about_#naming-your-package">naming conventions</a> before submitting your package. The authoritative name of your package will be taken from the composer.json file inside the master branch or trunk of your repository, and it can not be changed after that.</p>
+        <p><strong>Do not submit forks of existing packages.</strong> If you need to test changes to a package that you forked to patch, use <a href="https://getcomposer.org/doc/05-repositories.md#vcs">VCS Repositories</a> instead. If however it is a real long-term fork you intend on maintaining feel free to submit it.</p>
+        <p>If you need help or if you have any questions please get in touch with the Composer <a href="https://getcomposer.org/doc/07-community.md">community</a>.</p>
+
+abandon:
+    submit: Abandon Package
+    warning: |
+        <p>You are about to mark this package as abandoned. This will alert users that this package will no longer be maintained.</p>
+        <p>If you are handing this project over to a new maintainer or know of a package that replaces it, please use
+            the field below to point users to the new package. In case you cannot point them to a new package, this one
+            will be tagged as abandoned and a replacement can be added later.</p>
+
+edit:
+    page_title: Edit Package _name
+    title: Edit _name
+    submit: Update
+
+profile:
+    your_api_token: Your API Token
+    show_api_token: Show API Token
+    accounts_connected: Accounts connected
+    connect_accounts: Connect accounts
+    notify_on_failure: Notify me of package update failures
+    api_token_explain: |
+        You can use your API token to interact with the Packagist API, see details in <a href="_path_about_#how-to-update-packages">the docs</a>.
+
+stats:
+    title: Install Statistics
+    subtitle: install statistics
+    installs: Installs
+    overall: Overall
+    lastmonth: Last 30 days
+    today: Today
+    since_midnight: "since midnight, UTC"
+    daily: Daily installs
+    daily_per_version: Daily installs per version
+    averaged: averaged _avg_
+
+statistics:
+    title: Statistics
+    over_time: Packages/versions over time
+    last_partial: The last data point is for the current month and shows partial data.
+    last_month: Packages installed in the last 30 days
+    monthly: Packages installed per month
+    packages: Packages
+    installs: Installs
+    registered: Packages registered
+    installed: Packages installed
+    versions: Versions available
+    versions_avail: Versions available
+    totals: Totals
+    since: since
+
+api_doc:
+    title: API documentation
+    intro: Packagist has a public API to consume data. See bellow the most important URIs:
+    listing_names: Listing package names
+    all_packages: All packages
+    by_organization: By organization
+    by_name: By name
+    by_type: By type
+    by_tag: By tag
+    list_by_organization: List packages by organization
+    list_by_type: List packages by type
+    searching: Searching for packages
+    search_by_name: Search packages by name
+    search_by_tag: Search packages by tag
+    search_by_type: Search packages by type
+    get_by_name: Get a package by name
+    get_package_data: Getting package data
+
+user:
+    member_since: member since
+    packages: _username_'s packages
+
 'Search packages...': 'Search packages...'
+brandname: Packagist
+navclaim: The PHP Package Repository
 Sort: 'Sort'
 Order: 'Order'
 Username: 'Username'

--- a/src/Packagist/WebBundle/Resources/views/ApiDoc/index.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/ApiDoc/index.html.twig
@@ -1,32 +1,32 @@
 {% extends "PackagistWebBundle::layout.html.twig" %}
 {% block content %}
 
-<h2 class="title">API documentation</h2>
+<h2 class="title">{{ 'api_doc.title'|trans }}</h2>
 
 <ul class="toc">
-  <li><a href="#list-packages">Listing package names</a>
+  <li><a href="#list-packages">{{ 'api_doc.listing_names'|trans }}</a>
     <ul>
-      <li><a href="#list-packages-all">All packages</a></li>
-      <li><a href="#list-packages-by-organization">By organization</a></li>
-      <li><a href="#list-packages-by-type">By type</a></li>
+      <li><a href="#list-packages-all">{{ 'api_doc.all_packages'|trans }}</a></li>
+      <li><a href="#list-packages-by-organization">{{ 'api_doc.by_organization'|trans }}</a></li>
+      <li><a href="#list-packages-by-type">{{ 'api_doc.by_type'|trans }}</a></li>
     </ul>
   </li>
-  <li><a href="#search-packages">Searching for packages</a>
+  <li><a href="#search-packages">{{ 'api_doc.searching'|trans }}</a>
     <ul>
-      <li><a href="#search-packages-by-tag">By tag</a></li>
-      <li><a href="#search-packages-by-name">By name</a></li>
-      <li><a href="#search-packages-by-type">By type</a></li>
+      <li><a href="#search-packages-by-tag">{{ 'api_doc.by_tag'|trans }}</a></li>
+      <li><a href="#search-packages-by-name">{{ 'api_doc.by_name'|trans }}</a></li>
+      <li><a href="#search-packages-by-type">{{ 'api_doc.by_type'|trans }}</a></li>
     </ul>
   </li>
-  <li><a href="#get-package-data">Getting package data</a></li>
+  <li><a href="#get-package-data">{{ 'api_doc.get_package_data'|trans }}</a></li>
 </ul>
 
 
 <section class="col-d-12">
-<h3 id="list-packages">Listing package names</h3>
-<h4 id="list-packages-all">List all packages</h4>
+<h3 id="list-packages">{{ 'api_doc.listing_names'|trans }}</h3>
+<h4 id="list-packages-all">{{ 'api_doc.all_packages'|trans }}</h4>
 <pre>
-GET https://packagist.org/packages/list.json
+GET https://{{ packagist_host }}/packages/list.json
 <code>
 {
   "packageNames": [
@@ -35,11 +35,11 @@ GET https://packagist.org/packages/list.json
   ]
 }
 </code></pre>
-<p>Working example: <code><a href="https://packagist.org/packages/list.json">https://packagist.org/packages/list.json</a></code></p>
+<p>Working example: <code><a href="https://{{ packagist_host }}/packages/list.json">https://{{ packagist_host }}/packages/list.json</a></code></p>
 
-<h4 id="list-packages-by-organization">List packages by organization</h4>
+<h4 id="list-packages-by-organization">{{ 'api_doc.list_by_organization'|trans }}</h4>
 <pre>
-GET https://packagist.org/packages/list.json?vendor=[vendor]
+GET https://{{ packagist_host }}/packages/list.json?vendor=[vendor]
 <code>
 {
   "packageNames": [
@@ -48,11 +48,11 @@ GET https://packagist.org/packages/list.json?vendor=[vendor]
   ]
 }
 </code></pre>
-<p>Working example: <code><a href="https://packagist.org/packages/list.json?vendor=composer">https://packagist.org/packages/list.json?vendor=composer</a></code></p>
+<p>Working example: <code><a href="https://{{ packagist_host }}/packages/list.json?vendor=composer">https://{{ packagist_host }}/packages/list.json?vendor=composer</a></code></p>
 
-<h4 id="list-packages-by-type">List packages by type</h4>
+<h4 id="list-packages-by-type">{{ 'api_doc.list_by_type'|trans }}</h4>
 <pre>
-GET https://packagist.org/packages/list.json?type=[type]
+GET https://{{ packagist_host }}/packages/list.json?type=[type]
 <code>
 {
   "packageNames": [
@@ -61,26 +61,26 @@ GET https://packagist.org/packages/list.json?type=[type]
   ]
 }
 </code></pre>
-<p>Working example: <code><a href="https://packagist.org/packages/list.json?type=composer-plugin">https://packagist.org/packages/list.json?type=composer-plugin</a></code></p>
+<p>Working example: <code><a href="https://{{ packagist_host }}/packages/list.json?type=composer-plugin">https://{{ packagist_host }}/packages/list.json?type=composer-plugin</a></code></p>
 
 </section>
 
 
 <section class="col-d-12">
-<h3 id="search-packages">Search packages</h3>
+<h3 id="search-packages">{{ 'api_doc.searching'|trans }}</h3>
 
-<p>Search results are paginated and you can change the pagination step by using the per_page parameter. For example <code>https://packagist.org/search.json?q=[query]&amp;per_page=5</code></p>
+<p>Search results are paginated and you can change the pagination step by using the per_page parameter. For example <code>https://{{ packagist_host }}/search.json?q=[query]&amp;per_page=5</code></p>
 
-<h4 id="search-packages-by-name">Search packages by name</h4>
+<h4 id="search-packages-by-name">{{ 'api_doc.search_by_name'|trans }}</h4>
 <pre>
-GET https://packagist.org/search.json?q=[query]
+GET https://{{ packagist_host }}/search.json?q=[query]
 <code>
 {
   "results" : [
     {
       "name": "[vendor]/[package]",
       "description": "[description]",
-      "url": "https://packagist.org/packages/[vendor]/[package]",
+      "url": "https://{{ packagist_host }}/packages/[vendor]/[package]",
       "repository": [repository url],
       "downloads": [number of downloads],
       "favers": [number of favers]
@@ -88,21 +88,21 @@ GET https://packagist.org/search.json?q=[query]
     ...
   ],
   "total": [number of results],
-  "next": "https://packagist.org/search.json?q=[query]&amp;page=[next page number]"
+  "next": "https://{{ packagist_host }}/search.json?q=[query]&amp;page=[next page number]"
 }
 </code></pre>
-<p>Working example: <code><a href="https://packagist.org/search.json?q=monolog">https://packagist.org/search.json?q=monolog</a></code></p>
+<p>Working example: <code><a href="https://{{ packagist_host }}/search.json?q=monolog">https://{{ packagist_host }}/search.json?q=monolog</a></code></p>
 
-<h4 id="search-packages-by-tag">Search packages by tag</h4>
+<h4 id="search-packages-by-tag">{{ 'api_doc.search_by_tag'|trans }}</h4>
 <pre>
-GET https://packagist.org/search.json?tags=[tag]
+GET https://{{ packagist_host }}/search.json?tags=[tag]
 <code>
 {
   "results": [
     {
       "name": "[vendor]/[package]",
       "description": "[description]",
-      "url": "https://packagist.org/packages/[vendor]/[package]",
+      "url": "https://{{ packagist_host }}/packages/[vendor]/[package]",
       "repository": "[repository url]",
       "downloads": [number of downloads],
       "favers": [number of favers]
@@ -112,18 +112,18 @@ GET https://packagist.org/search.json?tags=[tag]
   "total": [numbers of results]
 }
 </code></pre>
-<p>Working example: <code><a href="https://packagist.org/search.json?q=monolog&amp;tags=psr-3">https://packagist.org/search.json?q=monolog&amp;tags=psr-3</a></code></p>
+<p>Working example: <code><a href="https://{{ packagist_host }}/search.json?q=monolog&amp;tags=psr-3">https://{{ packagist_host }}/search.json?q=monolog&amp;tags=psr-3</a></code></p>
 
-<h4 id="search-packages-by-type">Search packages by type</h4>
+<h4 id="search-packages-by-type">{{ 'api_doc.search_by_type'|trans }}</h4>
 <pre>
-GET https://packagist.org/search.json?q=[query]&amp;type=symfony-bundle
+GET https://{{ packagist_host }}/search.json?q=[query]&amp;type=symfony-bundle
 <code>
 {
   "results" : [
     {
       "name": "[vendor]/[package]",
       "description": "[description]",
-      "url": "https://packagist.org/packages/[vendor]/[package]",
+      "url": "https://{{ packagist_host }}/packages/[vendor]/[package]",
       "repository": [repository url],
       "downloads": [number of downloads],
       "favers": [number of favers]
@@ -131,15 +131,15 @@ GET https://packagist.org/search.json?q=[query]&amp;type=symfony-bundle
     ...
   ],
   "total": [number of results],
-  "next": "https://packagist.org/search.json?q=[query]&amp;page=[next page number]"
+  "next": "https://{{ packagist_host }}/search.json?q=[query]&amp;page=[next page number]"
 }
 </code></pre>
-<p>Working example: <code><a href="https://packagist.org/search.json?q=monolog&amp;type=symfony-bundle">https://packagist.org/search.json?q=monolog&amp;type=symfony-bundle</a></code></p>
+<p>Working example: <code><a href="https://{{ packagist_host }}/search.json?q=monolog&amp;type=symfony-bundle">https://{{ packagist_host }}/search.json?q=monolog&amp;type=symfony-bundle</a></code></p>
 </section>
 
 
 <section class="col-d-12">
-<h3 id="get-package-data">Getting package data</h3>
+<h3 id="get-package-data">{{ 'api_doc.get_package_data'|trans }}</h3>
 
 <h4 id="get-package-by-name">Using the Composer metadata</h4>
 
@@ -156,7 +156,7 @@ GET https://packagist.org/search.json?q=[query]&amp;type=symfony-bundle
 </p>
 
 <pre>
-GET https://packagist.org/p/[vendor]/[package].json
+GET https://{{ packagist_host }}/p/[vendor]/[package].json
 <code>
 {
   "packages": {
@@ -174,14 +174,14 @@ GET https://packagist.org/p/[vendor]/[package].json
   }
 }
 </code></pre>
-<p>Working example: <code><a href="https://packagist.org/p/monolog/monolog.json">https://packagist.org/p/monolog/monolog.json</a></code></p>
+<p>Working example: <code><a href="https://{{ packagist_host }}/p/monolog/monolog.json">https://{{ packagist_host }}/p/monolog/monolog.json</a></code></p>
 
 <h4 id="get-package-by-name">Using the API</h4>
 
 <p>The JSON API for packages gives you all the infos we have including downloads, dependents count, github info, etc. However it is generated dynamically so for performance reason we cache the responses for one hour. As such if the static file endpoint described above is enough please use it instead.</p>
 
 <pre>
-GET https://packagist.org/packages/[vendor]/[package].json
+GET https://{{ packagist_host }}/packages/[vendor]/[package].json
 <code>
 {
   "package": {
@@ -201,7 +201,7 @@ GET https://packagist.org/packages/[vendor]/[package].json
   }
 }
 </code></pre>
-<p>Working example: <code><a href="https://packagist.org/packages/monolog/monolog.json">https://packagist.org/packages/monolog/monolog.json</a></code></p>
+<p>Working example: <code><a href="https://{{ packagist_host }}/packages/monolog/monolog.json">https://{{ packagist_host }}/packages/monolog/monolog.json</a></code></p>
 
 </section>
 

--- a/src/Packagist/WebBundle/Resources/views/Explore/explore.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Explore/explore.html.twig
@@ -3,17 +3,17 @@
 {% import "PackagistWebBundle::macros.html.twig" as macros %}
 
 {% block content %}
-    {% block content_title %}<h2 class="title">Packages</h2>{% endblock %}
+    {% block content_title %}<h2 class="title">{{ 'explore.title'|trans }}</h2>{% endblock %}
     {% block lists %}
     <section class="row">
         <section class="packages-short col-lg-6">
-            <h3>New Releases <a href="{{ url('feed_releases', {_format: 'rss'}) }}">RSS</a></h3>
+            <h3>{{ 'explore.newreleases'|trans }} <a href="{{ url('feed_releases', {_format: 'rss'}) }}">RSS</a></h3>
 
             {{ macros.listPackagesShort(newlyReleased, true) }}
         </section>
 
         <section class="packages-short col-lg-6">
-            <h3>New Packages <a href="{{ url('feed_packages', {_format: 'rss'}) }}">RSS</a></h3>
+            <h3>{{ 'explore.newpackages'|trans }} <a href="{{ url('feed_packages', {_format: 'rss'}) }}">RSS</a></h3>
 
             {{ macros.listPackagesShort(newlySubmitted) }}
         </section>
@@ -21,13 +21,13 @@
         <div class="clearfix visible-lg-block"></div>
 
         <section class="packages-short col-lg-6">
-            <h3>Popular Packages <a href="{{ path('browse_popular') }}">View All</a></h3>
+            <h3>{{ 'explore.popularpackages'|trans }} <a href="{{ path('browse_popular') }}">{{ 'listing.viewall'|trans }}</a></h3>
 
             {{ macros.listPackagesShort(popular, false, true) }}
         </section>
 
         <section class="packages-short col-lg-6">
-            <h3>Random Packages</h3>
+            <h3>{{ 'explore.randompackages'|trans }}</h3>
 
             {{ macros.listPackagesShort(random) }}
         </section>

--- a/src/Packagist/WebBundle/Resources/views/Explore/popular.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Explore/popular.html.twig
@@ -1,5 +1,5 @@
 {% embed "PackagistWebBundle:Web:list.html.twig" %}
     {% block content_title %}
-        <h2 class="title">Popular Packages</h2>
+        <h2 class="title">{{ 'explore.popularpackages'|trans }}</h2>
     {% endblock %}
 {% endembed %}

--- a/src/Packagist/WebBundle/Resources/views/Package/abandon.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/abandon.html.twig
@@ -11,14 +11,11 @@
     {{ form_start(form, { attr: { class: 'col-sm-6' } }) }}
         {{ form_widget(form) }}
 
-        <input class="btn btn-block btn-default btn-lg" type="submit" value="Abandon Package" />
+        <input class="btn btn-block btn-default btn-lg" type="submit" value="{{ 'abandon.submit'|trans }}" />
     {{ form_end(form) }}
 
     <div class="col-sm-6">
-        <p>You are about to mark this package as abandoned. This will alert users that this package will no longer be maintained.</p>
-        <p>If you are handing this project over to a new maintainer or know of a package that replaces it, please use
-            the field below to point users to the new package. In case you cannot point them to a new package, this one
-            will be tagged as abandoned and a replacement can be added later.</p>
+        {{ 'abandon.warning'|trans|raw }}
     </div>
 </section>
 {% endblock %}

--- a/src/Packagist/WebBundle/Resources/views/Package/browse.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/browse.html.twig
@@ -6,7 +6,7 @@
 {% if tag %}{% set filters = filters|merge(["tagged with #{tag|join(' or ')}"]) %}{% endif %}
 
 {% block content_title %}
-    <h1>Packages {{ filters|join(' and ') }}</h1>
+    <h1>{{ 'browse.packages'|trans }} {{ filters|join(' and ') }}</h1>
 {% endblock %}
 
 {# TODO:

--- a/src/Packagist/WebBundle/Resources/views/Package/browse.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/browse.html.twig
@@ -2,11 +2,11 @@
 
 {% set filters = [] %}
 
-{% if type %}{% set filters = filters|merge(["of type #{type|join(' or ')}"]) %}{% endif %}
-{% if tag %}{% set filters = filters|merge(["tagged with #{tag|join(' or ')}"]) %}{% endif %}
+{% if type %}{% set filters = filters|merge(['browse.of_type'|trans({ '%type%': type|join('browse.join_or'|trans)})]) %}{% endif %}
+{% if tag %}{% set filters = filters|merge(['browse.with_tag'|trans({ '%tag%': tag|join('browse.join_or'|trans)})]) %}{% endif %}
 
 {% block content_title %}
-    <h1>{{ 'browse.packages'|trans }} {{ filters|join(' and ') }}</h1>
+    <h1>{{ 'browse.packages'|trans }} {{ filters|join('browse.join_and'|trans) }}</h1>
 {% endblock %}
 
 {# TODO:

--- a/src/Packagist/WebBundle/Resources/views/Package/dependents.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/dependents.html.twig
@@ -4,14 +4,14 @@
 
 {% block head_additions %}<meta name="robots" content="noindex, nofollow">{% endblock %}
 
-{% block title %}Dependent Packages - {{ name }} - {{ parent() }}{% endblock %}
+{% block title %}{{ 'packages.dependent_title'|trans }} - {{ name }} - {{ parent() }}{% endblock %}
 
 {% block content %}
     <div class="row">
         <div class="col-xs-12 package">
             <div class="package-header">
                 <h2 class="title">
-                    <a href="{{ path("view_package", {name: name}) }}">{{ name }}</a> dependents
+                    <a href="{{ path("view_package", {name: name}) }}">{{ name }}</a> {{ 'packages.dependents'|trans }}
                     <small>({{ count }})</small>
                 </h2>
             </div>

--- a/src/Packagist/WebBundle/Resources/views/Package/edit.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/edit.html.twig
@@ -1,11 +1,11 @@
 {% extends "PackagistWebBundle::layout.html.twig" %}
 
 {% block title %}
-    {{ 'edit.page_title'|trans({ _name:package.name }) }}
+    {{ 'edit.page_title'|trans({ '%name%':package.name }) }}
 {% endblock %}
 
 {% block content %}
-<h2 class="title">{{ 'edit.title'|trans({ _name:package.name }) }}</h2>
+<h2 class="title">{{ 'edit.title'|trans({ '%name%':package.name }) }}</h2>
 
 <section class="row">
     {{ form_start(form, { attr: { class: 'col-md-6' } }) }}

--- a/src/Packagist/WebBundle/Resources/views/Package/edit.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/edit.html.twig
@@ -1,17 +1,17 @@
 {% extends "PackagistWebBundle::layout.html.twig" %}
 
 {% block title %}
-    Edit Package {{ package.name }}
+    {{ 'edit.page_title'|trans({ _name:package.name }) }}
 {% endblock %}
 
 {% block content %}
-<h2 class="title">Edit {{ package.name }}</h2>
+<h2 class="title">{{ 'edit.title'|trans({ _name:package.name }) }}</h2>
 
 <section class="row">
     {{ form_start(form, { attr: { class: 'col-md-6' } }) }}
         {{ form_widget(form) }}
 
-        <input class="btn btn-block btn-primary btn-lg" id="submit" type="submit" value="Update" />
+        <input class="btn btn-block btn-primary btn-lg" id="submit" type="submit" value="{{ 'edit.submit'|trans }}" />
     {{ form_end(form) }}
 </section>
 {% endblock %}

--- a/src/Packagist/WebBundle/Resources/views/Package/providers.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/providers.html.twig
@@ -1,3 +1,3 @@
 {% extends "PackagistWebBundle:Web:list.html.twig" %}
 
-{% block content_title %}<h1>The following packages provide {{ name }}</h1>{% endblock %}
+{% block content_title %}<h1>{{ 'packages.providers_title'|trans({ _name_: name }) }}</h1>{% endblock %}

--- a/src/Packagist/WebBundle/Resources/views/Package/providers.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/providers.html.twig
@@ -1,3 +1,3 @@
 {% extends "PackagistWebBundle:Web:list.html.twig" %}
 
-{% block content_title %}<h1>{{ 'packages.providers_title'|trans({ _name_: name }) }}</h1>{% endblock %}
+{% block content_title %}<h1>{{ 'packages.providers_title'|trans({ '%name%': name }) }}</h1>{% endblock %}

--- a/src/Packagist/WebBundle/Resources/views/Package/stats.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/stats.html.twig
@@ -4,14 +4,14 @@
 
 {% block head_additions %}<meta name="robots" content="noindex, nofollow">{% endblock %}
 
-{% block title %}Install Statistics - {{ package.name }} - {{ parent() }}{% endblock %}
+{% block title %}{{ 'stats.title'|trans }} - {{ package.name }} - {{ parent() }}{% endblock %}
 
 {% block content %}
     <div class="row">
         <div class="col-xs-12 package">
             <div class="package-header">
                 <h2 class="title">
-                    <a href="{{ path("view_package", {name: package.name}) }}">{{ package.name }}</a> install statistics
+                    <a href="{{ path("view_package", {name: package.name}) }}">{{ package.name }}</a> {{ 'stats.subtitle'|trans }}
                 </h2>
             </div>
         </div>
@@ -19,30 +19,30 @@
 
     <section class="row package-installs">
         <div class="col-lg-12">
-            <h3>Installs</h3>
+            <h3>{{ 'stats.installs'|trans }}</h3>
 
             <div class="row">
                 <div class="col-md-4 col-xs-12">
                     <dl class="dl-horizontal">
-                        <dt class="font-normal">Overall</dt>
+                        <dt class="font-normal">{{ 'stats.overall'|trans }}</dt>
                         <dd class="font-normal">{{ downloads.total|number_format(0, '.', '&#8201;')|raw }}</dd>
                     </dl>
                 </div>
                 <div class="col-md-4 col-xs-12">
                     <dl class="dl-horizontal">
-                        <dt class="font-normal">Last 30 days</dt>
+                        <dt class="font-normal">{{ 'stats.lastmonth'|trans }}</dt>
                         <dd class="font-normal">{{ downloads.monthly|number_format(0, '.', '&#8201;')|raw }}</dd>
                     </dl>
                 </div>
                 <div class="col-md-4 col-xs-12">
                     <dl class="dl-horizontal">
-                        <dt class="font-normal">Today<br><small>(since midnight, UTC)</small></dt>
+                        <dt class="font-normal">{{ 'stats.today'|trans }}<br><small>({{ 'stats.since_midnight'|trans }})</small></dt>
                         <dd class="font-normal">{{ downloads.daily|number_format(0, '.', '&#8201;')|raw }}</dd>
                     </dl>
                 </div>
             </div>
 
-            <h3>Daily installs{% if average != 'daily' %}, averaged {{ average }}{% endif %}</h3>
+            <h3>{{ 'stats.daily'|trans }}{% if average != 'daily' %}, {{ 'stats.averaged'|trans({ _avg_:average }) }}{% endif %}</h3>
             <div class="row">
                 <div class="col-xs-12">
                     <svg class="chart js-all-dls" width="500" height="200">
@@ -52,7 +52,7 @@
             </div>
 
             <br>
-            <h3>Daily installs per version{% if average != 'daily' %}, averaged {{ average }}{% endif %}</h3>
+            <h3>{{ 'stats.daily_per_version'|trans }}{% if average != 'daily' %}, {{ 'stats.averaged'|trans({ _avg_:average }) }}{% endif %}</h3>
             <div class="row package version-stats">
                 <div class="col-xs-12 col-md-9 version-stats-chart">
                     <div style="position: relative">

--- a/src/Packagist/WebBundle/Resources/views/Package/stats.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/stats.html.twig
@@ -42,7 +42,7 @@
                 </div>
             </div>
 
-            <h3>{{ 'stats.daily'|trans }}{% if average != 'daily' %}, {{ 'stats.averaged'|trans({ _avg_:average }) }}{% endif %}</h3>
+            <h3>{{ 'stats.daily'|trans }}{% if average != 'daily' %}, {{ 'stats.averaged'|trans({ '%avg%':average }) }}{% endif %}</h3>
             <div class="row">
                 <div class="col-xs-12">
                     <svg class="chart js-all-dls" width="500" height="200">
@@ -52,7 +52,7 @@
             </div>
 
             <br>
-            <h3>{{ 'stats.daily_per_version'|trans }}{% if average != 'daily' %}, {{ 'stats.averaged'|trans({ _avg_:average }) }}{% endif %}</h3>
+            <h3>{{ 'stats.daily_per_version'|trans }}{% if average != 'daily' %}, {{ 'stats.averaged'|trans({ '%avg%':average }) }}{% endif %}</h3>
             <div class="row package version-stats">
                 <div class="col-xs-12 col-md-9 version-stats-chart">
                     <div style="position: relative">

--- a/src/Packagist/WebBundle/Resources/views/Package/submitPackage.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/submitPackage.html.twig
@@ -7,7 +7,7 @@
 {% set showSearchDesc = 'hide' %}
 
 {% block content %}
-<h2 class="title">Submit package</h2>
+<h2 class="title">{{ 'submit.title'|trans }}</h2>
 
 <section class="row">
     {{ form_start(form, { attr: { class: 'col-md-6', 'data-check-url': path('submit.fetch_info'), id: 'submit-package-form' } }) }}
@@ -15,13 +15,11 @@
 
         {{ form_rest(form) }}
 
-        <input class="btn btn-block btn-success btn-lg" id="submit" type="submit" value="Submit" />
+        <input class="btn btn-block btn-success btn-lg" id="submit" type="submit" value="{{ 'submit.submit'|trans }}" />
     {{ form_end(form) }}
 
     <div class="col-md-6">
-        <p>Please make sure you have read the package <a href="{{ path('about') }}#naming-your-package">naming conventions</a> before submitting your package. The authoritative name of your package will be taken from the composer.json file inside the master branch or trunk of your repository, and it can not be changed after that.</p>
-        <p><strong>Do not submit forks of existing packages.</strong> If you need to test changes to a package that you forked to patch, use <a href="https://getcomposer.org/doc/05-repositories.md#vcs">VCS Repositories</a> instead. If however it is a real long-term fork you intend on maintaining feel free to submit it.</p>
-        <p>If you need help or if you have any questions please get in touch with the Composer <a href="https://getcomposer.org/doc/07-community.md">community</a>.</p>
+        {{ 'submit.guide'|trans({ _path_about_: path('about') })|raw }}
     </div>
 </section>
 {% endblock %}

--- a/src/Packagist/WebBundle/Resources/views/Package/submitPackage.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/submitPackage.html.twig
@@ -19,7 +19,7 @@
     {{ form_end(form) }}
 
     <div class="col-md-6">
-        {{ 'submit.guide'|trans({ _path_about_: path('about') })|raw }}
+        {{ 'submit.guide'|trans({ '%path_about%': path('about') })|raw }}
     </div>
 </section>
 {% endblock %}

--- a/src/Packagist/WebBundle/Resources/views/Package/suggesters.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/suggesters.html.twig
@@ -4,14 +4,14 @@
 
 {% block head_additions %}<meta name="robots" content="noindex, nofollow">{% endblock %}
 
-{% block title %}Suggesters Packages - {{ name }} - {{ parent() }}{% endblock %}
+{% block title %}{{ 'packages.suggesters_title'|trans }} - {{ name }} - {{ parent() }}{% endblock %}
 
 {% block content %}
     <div class="row">
         <div class="col-xs-12 package">
             <div class="package-header">
                 <h2 class="title">
-                    <a href="{{ path("view_package", {name: name}) }}">{{ name }}</a> suggesters
+                    <a href="{{ path("view_package", {name: name}) }}">{{ name }}</a> {{ 'packages.suggesters'|trans }}
                     <small>({{ count }})</small>
                 </h2>
             </div>

--- a/src/Packagist/WebBundle/Resources/views/Package/viewVendor.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/viewVendor.html.twig
@@ -5,4 +5,4 @@
     {{ parent() }}
 {% endblock %}
 
-{% block content_title %}<h1>{{ 'packages.from'|trans({ _vendor_:vendor }) }}</h1>{% endblock %}
+{% block content_title %}<h1>{{ 'packages.from'|trans({ '%vendor%':vendor }) }}</h1>{% endblock %}

--- a/src/Packagist/WebBundle/Resources/views/Package/viewVendor.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/viewVendor.html.twig
@@ -5,4 +5,4 @@
     {{ parent() }}
 {% endblock %}
 
-{% block content_title %}<h1>Packages from {{ vendor }}</h1>{% endblock %}
+{% block content_title %}<h1>{{ 'packages.from'|trans({ _vendor_:vendor }) }}</h1>{% endblock %}

--- a/src/Packagist/WebBundle/Resources/views/User/favorites.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/User/favorites.html.twig
@@ -27,7 +27,7 @@
     <section class="{{ isActualUser ? 'col-md-9' : 'col-md-12' }}">
         {% embed "PackagistWebBundle:Web:list.html.twig" with {noLayout: 'true', showAutoUpdateWarning: isActualUser} %}
             {% block content_title %}
-                <h3 class="font-normal profile-title">{{ (isActualUser ? 'packages.my_favorites' : 'packages.users_favorites')|trans({ _user: user.username }) }}</h3>
+                <h3 class="font-normal profile-title">{{ (isActualUser ? 'packages.my_favorites' : 'packages.users_favorites')|trans({ '%user%': user.username }) }}</h3>
             {% endblock %}
         {% endembed %}
     </section>

--- a/src/Packagist/WebBundle/Resources/views/User/favorites.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/User/favorites.html.twig
@@ -27,7 +27,7 @@
     <section class="{{ isActualUser ? 'col-md-9' : 'col-md-12' }}">
         {% embed "PackagistWebBundle:Web:list.html.twig" with {noLayout: 'true', showAutoUpdateWarning: isActualUser} %}
             {% block content_title %}
-                <h3 class="font-normal profile-title">{{ isActualUser ? 'My' : user.username~'\'s' }} favorite packages</h3>
+                <h3 class="font-normal profile-title">{{ (isActualUser ? 'packages.my_favorites' : 'packages.users_favorites')|trans({ _user: user.username }) }}</h3>
             {% endblock %}
         {% endembed %}
     </section>

--- a/src/Packagist/WebBundle/Resources/views/User/packages.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/User/packages.html.twig
@@ -27,7 +27,7 @@
     <section class="{{ isActualUser ? 'col-md-9' : 'col-md-12' }}">
         {% embed "PackagistWebBundle:Web:list.html.twig" with {noLayout: 'true', showAutoUpdateWarning: isActualUser} %}
             {% block content_title %}
-                <h3 class="font-normal profile-title">{{ isActualUser ? 'My packages' : 'Packages maintained by ' ~ user.username }}</h3>
+                <h3 class="font-normal profile-title">{{ (isActualUser ? 'packages.mine' : 'packages.maintained:by')|trans({ _user: user.username }) }}</h3>
             {% endblock %}
         {% endembed %}
     </section>

--- a/src/Packagist/WebBundle/Resources/views/User/packages.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/User/packages.html.twig
@@ -27,7 +27,7 @@
     <section class="{{ isActualUser ? 'col-md-9' : 'col-md-12' }}">
         {% embed "PackagistWebBundle:Web:list.html.twig" with {noLayout: 'true', showAutoUpdateWarning: isActualUser} %}
             {% block content_title %}
-                <h3 class="font-normal profile-title">{{ (isActualUser ? 'packages.mine' : 'packages.maintained:by')|trans({ _user: user.username }) }}</h3>
+                <h3 class="font-normal profile-title">{{ (isActualUser ? 'packages.mine' : 'packages.maintained_by')|trans({ '%user%': user.username }) }}</h3>
             {% endblock %}
         {% endembed %}
     </section>

--- a/src/Packagist/WebBundle/Resources/views/User/profile.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/User/profile.html.twig
@@ -8,7 +8,7 @@
 <h2 class="title">
     {{ user.username }}
     <small>
-        member since: {{ user.createdAt|date('M d, Y') }}
+        {{ 'user.member_since'|trans }}: {{ user.createdAt|date('M d, Y') }}
         {%- if is_granted('ROLE_ADMIN') %}
             <a href="mailto:{{ user.email }}">{{ user.email }}</a>
         {%- endif %}
@@ -19,7 +19,7 @@
     <section class="col-md-12">
         {% embed "PackagistWebBundle:Web:list.html.twig" with {noLayout: 'true', showAutoUpdateWarning: isActualUser} %}
             {% block content_title %}
-                <h3 class="font-normal profile-title">{{ user.username }}'s packages</h3>
+                <h3 class="font-normal profile-title">{{ 'user.packages'|trans({ _username_:user.username }) }}</h3>
             {% endblock %}
         {% endembed %}
     </section>

--- a/src/Packagist/WebBundle/Resources/views/User/profile.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/User/profile.html.twig
@@ -19,7 +19,7 @@
     <section class="col-md-12">
         {% embed "PackagistWebBundle:Web:list.html.twig" with {noLayout: 'true', showAutoUpdateWarning: isActualUser} %}
             {% block content_title %}
-                <h3 class="font-normal profile-title">{{ 'user.packages'|trans({ _username_:user.username }) }}</h3>
+                <h3 class="font-normal profile-title">{{ 'user.packages'|trans({ '%username%':user.username }) }}</h3>
             {% endblock %}
         {% endembed %}
     </section>

--- a/src/Packagist/WebBundle/Resources/views/Web/list.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/list.html.twig
@@ -3,14 +3,14 @@
 {% import "PackagistWebBundle::macros.html.twig" as macros %}
 
 {% block content %}
-    {% block content_title %}<h3 class="title">Packages</h3>{% endblock %}
+    {% block content_title %}<h3 class="title">{{ 'listing.title'|trans }}</h3>{% endblock %}
 
     {% block list %}
         {% if packages|length %}
             {{ macros.listPackages(packages, paginate is not defined or paginate, showAutoUpdateWarning|default(false), meta|default(null)) }}
         {% else %}
             <div class="alert alert-danger">
-                <p>No packages found.</p>
+                <p>{{ 'listing.nopackages'|trans }}</p>
             </div>
         {% endif %}
     {% endblock %}

--- a/src/Packagist/WebBundle/Resources/views/Web/searchSection.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/searchSection.html.twig
@@ -6,7 +6,7 @@
         <div class="row">
             <div class="col-sm-9 hidden-xs">
                 <img src="{{ asset('bundles/packagistweb/img/logo-small.png') }}" class="logo">
-                <p>Packagist is the main <a href="https://getcomposer.org/">Composer</a> repository. It aggregates public PHP packages installable with Composer.</p>
+                <p>{{ 'search.claim_html'|trans|raw }}</p>
             </div>
         </div>
         {%- endif %}

--- a/src/Packagist/WebBundle/Resources/views/Web/stats.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/stats.html.twig
@@ -5,46 +5,46 @@
 {% block content %}
     {% set packageCount = 0 %}
 
-    <h2 class="title">Statistics</h2>
+    <h2 class="title">{{ 'statistics.title'|trans }}</h2>
 
     <section class="row">
         <div class="col-lg-12">
-            <h3>Packages/versions over time</h3>
+            <h3>{{ 'statistics.over_time'|trans }}</h3>
 
             <p class="row">
-                <svg class="chart col-xs-12" width="500" height="200" data-labels="{{ chart.months|join(',') }}" data-scale="1000" data-values="Versions:{{ chart.versions|join(',') }}|Packages:{{ chart.packages|join(',') }}">
+                <svg class="chart col-xs-12" width="500" height="200" data-labels="{{ chart.months|join(',') }}" data-scale="1000" data-values="{{ 'statistics.versions'|trans }}:{{ chart.versions|join(',') }}|{{ 'statistics.packages'|trans }}:{{ chart.packages|join(',') }}">
                     Sorry, the graph can't be displayed because your browser doesn't support &lt;svg&gt; html element.
                 </svg>
             </p>
-            <p>The last data point is for the current month and shows partial data.</p>
+            <p>{{ 'statistics.last_partial'|trans }}</p>
 
             {% if downloadsChart %}
-                <h3>Packages installed in the last 30 days</h3>
+                <h3>{{ 'statistics.last_month'|trans }}</h3>
                 <p class="row">
-                    <svg class="chart col-xs-12" width="500" height="200" data-labels="{{ downloadsChart.labels|join(',') }}" data-scale="1000" data-values="Installs:{{ downloadsChart.values|join(',') }}">
+                    <svg class="chart col-xs-12" width="500" height="200" data-labels="{{ downloadsChart.labels|join(',') }}" data-scale="1000" data-values="{{ 'statistics.installs'|trans }}:{{ downloadsChart.values|join(',') }}">
                         Sorry, the graph can't be displayed because your browser doesn't support &lt;svg&gt; html element.
                     </svg>
                 </p>
             {% endif %}
             {% if downloadsChartMonthly %}
-                <h3>Packages installed per month</h3>
+                <h3>{{ 'statistics.monthly'|trans }}</h3>
                 <p class="row">
-                    <svg class="chart col-xs-12" width="500" height="200" data-labels="{{ downloadsChartMonthly.labels|join(',') }}" data-scale="1000000" data-values="Installs:{{ downloadsChartMonthly.values|join(',') }}">
+                    <svg class="chart col-xs-12" width="500" height="200" data-labels="{{ downloadsChartMonthly.labels|join(',') }}" data-scale="1000000" data-values="{{ 'statistics.installs'|trans }}:{{ downloadsChartMonthly.values|join(',') }}">
                         Sorry, the graph can't be displayed because your browser doesn't support &lt;svg&gt; html element.
                     </svg>
                 </p>
-                <p>The last data point is for the current month and shows partial data.</p>
+                <p>{{ 'statistics.last_partial'|trans }}</p>
             {% endif %}
 
-            <h3>Totals</h3>
+            <h3>{{ 'statistics.totals'|trans }}</h3>
             <dl class="dl-horizontal">
-                <dt class="font-normal">Packages registered</dt>
+                <dt class="font-normal">{{ 'statistics.registered'|trans }}</dt>
                 <dd class="font-normal">{{ packages|number_format(0, '.', "&#8201;")|raw }}</dd>
 
-                <dt class="font-normal">Versions available</dt>
+                <dt class="font-normal">{{ 'statistics.versions_avail'|trans }}</dt>
                 <dd class="font-normal">{{ versions|number_format(0, '.', "&#8201;")|raw }}</dd>
 
-                <dt class="font-normal">Packages installed<br><small>(since {{ downloadsStartDate }})</small></dt>
+                <dt class="font-normal">{{ 'statistics.installed'|trans }}<br><small>({{ 'statistics.since'|trans }} {{ downloadsStartDate }})</small></dt>
                 <dd class="font-normal">{% if downloads == 'N/A' %}{{ downloads }}{% else %}{{ downloads|number_format(0, '.', "&#8201;")|raw }}{% endif %}</dd>
             </dl>
         </div>

--- a/src/Packagist/WebBundle/Resources/views/layout.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/layout.html.twig
@@ -34,21 +34,21 @@
                 <div class="navbar" role="navigation">
                     <div class="navbar-header">
                         <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-                            <span class="sr-only">Toggle navigation</span>
+                            <span class="sr-only">{{ 'menu.togglenav'|trans }}</span>
                             <span class="icon-bar"></span>
                             <span class="icon-bar"></span>
                             <span class="icon-bar"></span>
                         </button>
-                        <h1 class="navbar-brand"><a href="{{ path('home') }}">Packagist</a> <em class="hidden-sm hidden-xs">The PHP Package Repository</em></h1>
+                        <h1 class="navbar-brand"><a href="{{ path('home') }}">{{ 'brandname'|trans }}</a> <em class="hidden-sm hidden-xs">{{ 'navclaim'|trans }}</em></h1>
                     </div>
 
                     <div class="collapse navbar-collapse">
                         <ul class="nav navbar-nav">
                             <li>
-                                <a href="{{ path('browse') }}">Browse</a>
+                                <a href="{{ path('browse') }}">{{ 'menu.browse'|trans }}</a>
                             </li>
                             <li>
-                                <a href="{{ path('submit') }}">Submit</a>
+                                <a href="{{ path('submit') }}">{{ 'menu.submit'|trans }}</a>
                             </li>
                         {%- if app.user %}
                             <li class="nav-user">
@@ -62,11 +62,11 @@
                             </li>
                         {%- else %}
                             <li>
-                                <a href="{{ path('fos_user_registration_register') }}">Create account</a>
+                                <a href="{{ path('fos_user_registration_register') }}">{{ 'menu.create_account'|trans }}</a>
                             </li>
                             <li class="nav-user">
                                 <section class="nav-user-signin">
-                                    <a href="{{ path('hwi_oauth_connect') }}">Sign in</a>
+                                    <a href="{{ path('hwi_oauth_connect') }}">{{ 'menu.sign_in'|trans }}</a>
 
                                     <section class="signin-box">
                                         <form action="{{ path('login_check') }}" method="POST">
@@ -97,7 +97,7 @@
                                         </form>
 
                                         <div class="signin-box-register">
-                                            <a href="{{ path('fos_user_registration_register') }}">No account yet? Create one now!</a>
+                                            <a href="{{ path('fos_user_registration_register') }}">{{ 'signinbox.register'|trans }}</a>
                                         </div>
                                     </section>
                                 </section>


### PR DESCRIPTION
This commit moves labels and texts from the HTML templates into `translations/messages.en.yml` in order to allow localization and/or renaming (e.g. "package" => "plugin" as used for plugins.roundcube.net)

Templates with lots of content and instructions are subject to be moved into `translations/<template>.en.html` for easy translation.

Although not yet fully complete I hope you can accept this as a start for full localization of the Packagist site.