### PR TITLE
A simple change - pre border using #f28d1a

### DIFF
--- a/src/Packagist/WebBundle/Resources/public/css/main.css
+++ b/src/Packagist/WebBundle/Resources/public/css/main.css
@@ -37,7 +37,7 @@ pre, code {
     font-size: 12px;
 }
 pre {
-  border-left: 2px solid #2d2d32;
+  border-left: 2px solid #f28d1a;
 }
 code.hljs { display: inline; }
 


### PR DESCRIPTION
Using the color #f28d1a plus look better , easier to read the code (that is in black) .