### PR TITLE
Change github menu item name in packagist "GitHub Service Hook HowTo"

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/About/about.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/About/about.html.twig
@@ -107,7 +107,7 @@ v2.0.4-p1</code></pre>
             <ul>
                 <li>Go to your GitHub repository</li>
                 <li>Click the "Settings" button</li>
-                <li>Click "Webhooks &amp; Services"</li>
+                <li>Click "Integrations &amp; services"</li>
                 <li>Add a "Packagist" service, and configure it with your API token, plus your Packagist username</li>
                 <li>Check the "Active" box and submit the form</li>
             </ul>


### PR DESCRIPTION
The menu item "Webhooks & Services" does not longer exist. It is now named "Integrations & services".

![github-settings-menu](https://cloud.githubusercontent.com/assets/1578709/18988961/86db55ac-8709-11e6-932e-2d3742b47b2a.png)
