### PR TITLE
Add missing services for UserManipulator

### DIFF
--- a/src/Packagist/WebBundle/Resources/config/services.yml
+++ b/src/Packagist/WebBundle/Resources/config/services.yml
@@ -53,7 +53,11 @@ services:
 
     fos_user.util.user_manipulator:
         class: Packagist\WebBundle\Util\UserManipulator
-        arguments: ['@fos_user.user_manager', '@fos_user.util.token_generator']
+        arguments:
+            - '@fos_user.user_manager'
+            - '@fos_user.util.token_generator'
+            - '@event_dispatcher'
+            - '@service_container'
 
     packagist.oauth.registration_form_handler:
         class: Packagist\WebBundle\Form\Handler\OAuthRegistrationFormHandler

--- a/src/Packagist/WebBundle/Util/UserManipulator.php
+++ b/src/Packagist/WebBundle/Util/UserManipulator.php
@@ -15,6 +15,8 @@ namespace Packagist\WebBundle\Util;
 use FOS\UserBundle\Model\UserManagerInterface;
 use FOS\UserBundle\Util\TokenGeneratorInterface;
 use FOS\UserBundle\Util\UserManipulator as BaseManipulator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class UserManipulator extends BaseManipulator
 {
@@ -24,12 +26,17 @@ class UserManipulator extends BaseManipulator
     /**
      * {@inheritdoc}
      */
-    public function __construct(UserManagerInterface $userManager, TokenGeneratorInterface $tokenGenerator)
+    public function __construct(
+        UserManagerInterface $userManager,
+        TokenGeneratorInterface $tokenGenerator,
+        EventDispatcherInterface $dispatcher,
+        ContainerInterface $container
+    )
     {
         $this->userManager = $userManager;
         $this->tokenGenerator = $tokenGenerator;
 
-        parent::__construct($userManager);
+        parent::__construct($userManager, $dispatcher, $container);
     }
 
     /**


### PR DESCRIPTION
I started working on https://github.com/composer/packagist/issues/65 but I found out, that the `UserManipulator` is broken since [upgrade to dev version of FOSUserBundle](https://github.com/composer/packagist/commit/b6588d10de4bba3f10263c0e38cba9efded09d18#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780R41) (it is not possible to call `php app\console fos:user:create`).

This PR adds the missing dependencies.