### PR TITLE
add package name to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,5 @@
 {
+    "name": "composer/packagist",
     "description": "Package Repository Website",
     "keywords": ["package", "composer"],
     "homepage": "http://packagist.org/",


### PR DESCRIPTION
I'm working on a little sideproject that adds features to Packagist but those features don't belong in this repository. In this case I actually want to be able to install this repository as a composer dependency and then use [bundle inheritance](http://symfony.com/doc/current/bundles/inheritance.html) to make my changes.

Problem is, I can't install it because it doesn't have a name, so here's the proposed 1-line change. A tag will be nice too but I suppose I could manage without it :)