### PR TITLE
[WIP] Emoji in package name

### DIFF
--- a/src/Packagist/WebBundle/Tests/Entity/PackageTest.php
+++ b/src/Packagist/WebBundle/Tests/Entity/PackageTest.php
@@ -7,6 +7,7 @@ use Packagist\WebBundle\Entity\Package;
 use Prophecy\Argument;
 use ReflectionObject;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 class PackageTest extends \PHPUnit_Framework_TestCase
 {
@@ -29,25 +30,46 @@ class PackageTest extends \PHPUnit_Framework_TestCase
         ];
 
         foreach ($packages as $packageName) {
-            $package = new Package();
-            $package->setName($packageName);
-
-            $vcsDriver = $this->prophesize(VcsDriverInterface::class);
-            $vcsDriver->getComposerInformation('master')->shouldBeCalled()->willReturn([
-                'name' => $packageName,
-            ]);
-            $vcsDriver->getRootIdentifier()->shouldBeCalled()->willReturn('master');
-
-
-            $r = new ReflectionObject($package);
-            $p = $r->getProperty('vcsDriver');
-            $p->setAccessible(true);
-            $p->setValue($package, $vcsDriver->reveal());
-
             yield $packageName => [
-                $package,
+                $this->createPackage($packageName),
             ];
         }
+    }
+
+    public function provideInvalidPackages()
+    {
+        $invalidPackageNameMessage = 'The package name %s is invalid, it should have a vendor name, a forward slash, and a package name. The vendor and package name can be words separated by -, . or _. The complete name should match "[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9]([_.-]?[a-z0-9]+)*".';
+        $packages = [
+            'CVE-2006-6459' => sprintf($invalidPackageNameMessage, 'CVE-2006-6459'),
+            '☼/🔥' => sprintf($invalidPackageNameMessage, '☼/🔥'),
+            './.' => sprintf($invalidPackageNameMessage, './.'),
+        ];
+
+        foreach ($packages as $packageName => $expectedException) {
+            yield $packageName => [
+                $this->createPackage($packageName),
+                $expectedException
+            ];
+        }
+    }
+
+    protected function createPackage(string $packageName): Package
+    {
+        $package = new Package();
+        $package->setName($packageName);
+
+        $vcsDriver = $this->prophesize(VcsDriverInterface::class);
+        $vcsDriver->getComposerInformation('master')->shouldBeCalled()->willReturn([
+            'name' => $packageName,
+        ]);
+        $vcsDriver->getRootIdentifier()->shouldBeCalled()->willReturn('master');
+
+        $r = new ReflectionObject($package);
+        $p = $r->getProperty('vcsDriver');
+        $p->setAccessible(true);
+        $p->setValue($package, $vcsDriver->reveal());
+
+        return $package;
     }
 
     /**
@@ -58,5 +80,20 @@ class PackageTest extends \PHPUnit_Framework_TestCase
         $executionContext = $this->prophesize(ExecutionContextInterface::class);
         $package->isRepositoryValid($executionContext->reveal());
         $this->assertTrue(true, 'No exception occurred');
+    }
+
+    /**
+     * @dataProvider provideInvalidPackages
+     */
+    public function testIsRepositoryInvalid(Package $package, string $exceptionMessage)
+    {
+        $executionContextLevel3 = $this->prophesize(ConstraintViolationBuilderInterface::class);
+
+        $executionContextLevel2 = $this->prophesize(ConstraintViolationBuilderInterface::class);
+        $executionContextLevel2->atPath(Argument::any())->willReturn($executionContextLevel3->reveal());
+
+        $executionContext = $this->prophesize(ExecutionContextInterface::class);
+        $executionContext->buildViolation($exceptionMessage)->shouldBeCalled()->willReturn($executionContextLevel2->reveal());
+        $package->isRepositoryValid($executionContext->reveal());
     }
 }

--- a/src/Packagist/WebBundle/Tests/Entity/PackageTest.php
+++ b/src/Packagist/WebBundle/Tests/Entity/PackageTest.php
@@ -17,7 +17,7 @@ class PackageTest extends \PHPUnit_Framework_TestCase
             'api-clients/skeleton',
             'react/http-client',
             'wyrihaximus/☼',
-            'elephpants/?-?',
+            'elephpants/🌈-🐘',
             'japan/象の虹',
             'vietnam/voi-cầu-vồng',
             'china-traditional/大象彩虹',

--- a/src/Packagist/WebBundle/Tests/Entity/PackageTest.php
+++ b/src/Packagist/WebBundle/Tests/Entity/PackageTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Packagist\WebBundle\Tests\Entity;
+
+use Composer\Repository\Vcs\VcsDriverInterface;
+use Packagist\WebBundle\Entity\Package;
+use Prophecy\Argument;
+use ReflectionObject;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+class PackageTest extends \PHPUnit_Framework_TestCase
+{
+    public function provideValidPackages()
+    {
+        $packages = [
+            'composer/composer',
+            'api-clients/skeleton',
+            'react/http-client',
+            'wyrihaximus/☼',
+            'elephpants/?-?',
+            'japan/象の虹',
+            'vietnam/voi-cầu-vồng',
+            'china-traditional/大象彩虹',
+            'china-traditional/слон-радуги',
+            'the-netherlands/0226',
+            '31/20',
+            'the.dot/the.dot',
+            'rdohms/c.hash',
+        ];
+
+        foreach ($packages as $packageName) {
+            $package = new Package();
+            $package->setName($packageName);
+
+            $vcsDriver = $this->prophesize(VcsDriverInterface::class);
+            $vcsDriver->getComposerInformation('master')->shouldBeCalled()->willReturn([
+                'name' => $packageName,
+            ]);
+            $vcsDriver->getRootIdentifier()->shouldBeCalled()->willReturn('master');
+
+
+            $r = new ReflectionObject($package);
+            $p = $r->getProperty('vcsDriver');
+            $p->setAccessible(true);
+            $p->setValue($package, $vcsDriver->reveal());
+
+            yield $packageName => [
+                $package,
+            ];
+        }
+    }
+
+    /**
+     * @dataProvider provideValidPackages
+     */
+    public function testIsRepositoryValid(Package $package)
+    {
+        $executionContext = $this->prophesize(ExecutionContextInterface::class);
+        $package->isRepositoryValid($executionContext->reveal());
+        $this->assertTrue(true, 'No exception occurred');
+    }
+}

--- a/src/Packagist/WebBundle/Tests/Entity/PackageTest.php
+++ b/src/Packagist/WebBundle/Tests/Entity/PackageTest.php
@@ -40,7 +40,7 @@ class PackageTest extends \PHPUnit_Framework_TestCase
     {
         $invalidPackageNameMessage = 'The package name %s is invalid, it should have a vendor name, a forward slash, and a package name. The vendor and package name can be words separated by -, . or _. The complete name should match "[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9]([_.-]?[a-z0-9]+)*".';
         $packages = [
-            'CVE-2006-6459' => sprintf($invalidPackageNameMessage, 'CVE-2006-6459'), // Register globals is bad, WyriHaximus learned it the hardway
+            'CVE-2006-6459' => sprintf($invalidPackageNameMessage, 'CVE-2006-6459'), // Register globals is bad, WyriHaximus learned it the hard way
             '☼/🔥' => sprintf($invalidPackageNameMessage, '☼/🔥'), // Sun burn
             './.' => sprintf($invalidPackageNameMessage, './.'), // Just dots
         ];

--- a/src/Packagist/WebBundle/Tests/Entity/PackageTest.php
+++ b/src/Packagist/WebBundle/Tests/Entity/PackageTest.php
@@ -14,19 +14,19 @@ class PackageTest extends \PHPUnit_Framework_TestCase
     public function provideValidPackages()
     {
         $packages = [
-            'composer/composer',
-            'api-clients/skeleton',
-            'react/http-client',
-            'wyrihaximus/☼',
-            'elephpants/🌈-🐘',
-            'japan/象の虹',
-            'vietnam/voi-cầu-vồng',
-            'china-traditional/大象彩虹',
-            'china-traditional/слон-радуги',
-            'the-netherlands/0226',
-            '31/20',
-            'the.dot/the.dot',
-            'rdohms/c.hash',
+            'composer/composer', // Actual package
+            'api-clients/skeleton', // Actual package
+            'react/http-client', // Actual package
+            'wyrihaximus/☼', // The package I'm doing this PR for
+            'elephpants/🌈-🐘', // https://twitter.com/RainbowLePHPant
+            'japan/象の虹', // Rainbow Elephant in Japanese
+            'vietnam/voi-cầu-vồng', // Rainbow Elephant in Vietnamese
+            'china-traditional/大象彩虹', // Rainbow Elephant in Traditional Chinese
+            'russia/слон-радуги', // Rainbow Elephant in Russian
+            'the-netherlands/0226', // WyriHaximus' area code
+            '31/20', // Amsterdam area code
+            'the.dot/the.dot', // Just the dot
+            'rdohms/c.hash', // https://youtu.be/wYccKQBy26Q?t=3m24s
         ];
 
         foreach ($packages as $packageName) {
@@ -40,9 +40,9 @@ class PackageTest extends \PHPUnit_Framework_TestCase
     {
         $invalidPackageNameMessage = 'The package name %s is invalid, it should have a vendor name, a forward slash, and a package name. The vendor and package name can be words separated by -, . or _. The complete name should match "[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9]([_.-]?[a-z0-9]+)*".';
         $packages = [
-            'CVE-2006-6459' => sprintf($invalidPackageNameMessage, 'CVE-2006-6459'),
-            '☼/🔥' => sprintf($invalidPackageNameMessage, '☼/🔥'),
-            './.' => sprintf($invalidPackageNameMessage, './.'),
+            'CVE-2006-6459' => sprintf($invalidPackageNameMessage, 'CVE-2006-6459'), // Register globals is bad, WyriHaximus learned it the hardway
+            '☼/🔥' => sprintf($invalidPackageNameMessage, '☼/🔥'), // Sun burn
+            './.' => sprintf($invalidPackageNameMessage, './.'), // Just dots
         ];
 
         foreach ($packages as $packageName => $expectedException) {

--- a/src/Packagist/WebBundle/Tests/Entity/PackageTest.php
+++ b/src/Packagist/WebBundle/Tests/Entity/PackageTest.php
@@ -77,9 +77,14 @@ class PackageTest extends \PHPUnit_Framework_TestCase
      */
     public function testIsRepositoryValid(Package $package)
     {
+        $executionContextLevel3 = $this->prophesize(ConstraintViolationBuilderInterface::class);
+
+        $executionContextLevel2 = $this->prophesize(ConstraintViolationBuilderInterface::class);
+        $executionContextLevel2->atPath(Argument::any())->willReturn($executionContextLevel3->reveal());
+
         $executionContext = $this->prophesize(ExecutionContextInterface::class);
+        $executionContext->buildViolation(Argument::any())->shouldNotBeCalled()->willReturn($executionContextLevel2->reveal());
         $package->isRepositoryValid($executionContext->reveal());
-        $this->assertTrue(true, 'No exception occurred');
     }
 
     /**


### PR DESCRIPTION
Gather round, gather round and let me tell you a tale on Hallows eve. A tale about adding support for package names with emoji in them.

It all started when a lone developer wanted to add a package named `wyrihaximus/☼` but packagist wouldn't let him. The developer was disappointed but decided to dive into the horrors of `UTF-8` and found it how hard it would be to add this as a feature. He realised `composer` would also need a PR but decided to seek guidance of the packagist high council of wizards, witches, and other magical beings first, before embarking on his quest.

The council listened to his plan. He explained that while `UTF-8` is dangerous and has wacky controll characters that can do serious harm, only allowing certain ranges would slay that dragon. The question is what ranges to allow, only emoji, or also chinese, russian, and other languages. Where to draw the line. He hands over a an quick rough drawing of his plan and sits down waiting for a response from the council.

♪ Waiting medival flute music ♪
