### PR TITLE
Improve Updater to not remove useful README titles

### DIFF
--- a/src/Packagist/WebBundle/Package/Updater.php
+++ b/src/Packagist/WebBundle/Package/Updater.php
@@ -629,12 +629,10 @@ class Updater
             }
         }
 
-        // remove first title as it's usually the project name which we don't need
-        if ($dom->getElementsByTagName('h1')->length) {
+        // remove first page element if it's a h1, because it's usually the project
+        // name or the `README` string which we don't need
+        if ('h1' === $dom->childNodes->item(0)->nodeName) {
             $first = $dom->getElementsByTagName('h1')->item(0);
-            $first->parentNode->removeChild($first);
-        } elseif ($dom->getElementsByTagName('h2')->length) {
-            $first = $dom->getElementsByTagName('h2')->item(0);
             $first->parentNode->removeChild($first);
         }
 

--- a/src/Packagist/WebBundle/Package/Updater.php
+++ b/src/Packagist/WebBundle/Package/Updater.php
@@ -629,10 +629,13 @@ class Updater
             }
         }
 
-        // remove first page element if it's a h1, because it's usually the project
-        // name or the `README` string which we don't need
+        // remove first page element if it's a <h1> or <h2>, because it's usually
+        // the project name or the `README` string which we don't need
         if ('h1' === $dom->childNodes->item(0)->nodeName) {
             $first = $dom->getElementsByTagName('h1')->item(0);
+            $first->parentNode->removeChild($first);
+        } elseif ('h2' === $dom->childNodes->item(0)->nodeName) {
+            $first = $dom->getElementsByTagName('h2')->item(0);
             $first->parentNode->removeChild($first);
         }
 

--- a/src/Packagist/WebBundle/Package/Updater.php
+++ b/src/Packagist/WebBundle/Package/Updater.php
@@ -631,7 +631,7 @@ class Updater
 
         // remove first page element if it's a <h1> or <h2>, because it's usually
         // the project name or the `README` string which we don't need
-        $first = $dom->childNodes->item(0);
+        $first = $dom->getElementsByTagName('body')->item(0)->childNodes->item(0);
 
         if ($first && ('h1' === $first->nodeName || 'h2' === $first->nodeName)) {
             $first->parentNode->removeChild($first);

--- a/src/Packagist/WebBundle/Package/Updater.php
+++ b/src/Packagist/WebBundle/Package/Updater.php
@@ -631,11 +631,9 @@ class Updater
 
         // remove first page element if it's a <h1> or <h2>, because it's usually
         // the project name or the `README` string which we don't need
-        if ('h1' === $dom->childNodes->item(0)->nodeName) {
-            $first = $dom->getElementsByTagName('h1')->item(0);
-            $first->parentNode->removeChild($first);
-        } elseif ('h2' === $dom->childNodes->item(0)->nodeName) {
-            $first = $dom->getElementsByTagName('h2')->item(0);
+        $first = $dom->childNodes->item(0);
+
+        if ($first && ('h1' === $first->nodeName || 'h2' === $first->nodeName)) {
             $first->parentNode->removeChild($first);
         }
 

--- a/src/Packagist/WebBundle/Tests/Package/UpdaterTest.php
+++ b/src/Packagist/WebBundle/Tests/Package/UpdaterTest.php
@@ -104,6 +104,34 @@ EOR;
         self::assertSame($readmeHtml, $this->package->getReadme());
     }
 
+    /**
+     * When <h1> or <h2> titles are not the first element of the README contents,
+     * they should not be removed.
+     */
+    public function testNoUsefulTitlesAreRemovedForReadme()
+    {
+        $readme = <<<EOR
+Lorem ipsum dolor sit amet.
+
+# some title
+
+EOR;
+        $readmeHtml = <<<EOR
+<p>Lorem ipsum dolor sit amet.</p>
+<h1>some title</h1>
+EOR;
+
+        $this->driverMock->expects($this->any())->method('getRootIdentifier')->willReturn('master');
+        $this->driverMock->expects($this->any())->method('getComposerInformation')
+                         ->willReturn(['readme' => 'README.md']);
+        $this->driverMock->expects($this->once())->method('getFileContent')->with('README.md', 'master')
+                         ->willReturn($readme);
+
+        $this->updater->update($this->ioMock, $this->config, $this->package, $this->repositoryMock);
+
+        self::assertSame($readmeHtml, $this->package->getReadme());
+    }
+
     public function testSurrondsTextReadme()
     {
         $this->driverMock->expects($this->any())->method('getRootIdentifier')->willReturn('master');


### PR DESCRIPTION
This tries to fix #764 by only removing the first `<h1>` element if it's the first actual element of the README file.