### PR TITLE
allow divs in readmes

### DIFF
--- a/src/Packagist/WebBundle/Package/Updater.php
+++ b/src/Packagist/WebBundle/Package/Updater.php
@@ -578,7 +578,7 @@ class Updater
             'pre', 'code', 'samp', 'kbd',
             'q', 'blockquote', 'abbr', 'cite',
             'table', 'thead', 'tbody', 'th', 'tr', 'td',
-            'a', 'span',
+            'a', 'span', 'div',
             'img',
         );
 


### PR DESCRIPTION
Can we enable divs at packagist.org, like this?

Basically, I want to split a series of images with a block-level container, and GitHub will allow me to do that with rst's `container`/`compound` directive.