### PR TITLE
Set version feed Date header to latest release date

### DIFF
--- a/src/Packagist/WebBundle/Controller/FeedController.php
+++ b/src/Packagist/WebBundle/Controller/FeedController.php
@@ -147,7 +147,14 @@ class FeedController extends Controller
             $packages
         );
 
-        return $this->buildResponse($req, $feed);
+        $response = $this->buildResponse($req, $feed);
+
+        $first = reset($packages);
+        if (false !== $first) {
+            $response->setDate($first->getReleasedAt());
+        }
+
+        return $response;
     }
 
     /**


### PR DESCRIPTION
This will make it possible for third party clients to determine the latest release date from a simple HEAD request, rather than downloading the whole body and checking the `<pubDate>` / `<updated>` value.