### PR TITLE
Add active filter widget

### DIFF
--- a/src/Packagist/WebBundle/Resources/public/js/search.js
+++ b/src/Packagist/WebBundle/Resources/public/js/search.js
@@ -92,6 +92,28 @@ search.addWidget(
 );
 
 search.addWidget(
+    instantsearch.widgets.currentRefinedValues({
+        container: '.search-facets-active-filters',
+        clearAll: 'before',
+        clearsQuery: true,
+        cssClasses: {
+            clearAll: 'pull-right'
+        },
+        templates: {
+            header: 'Active filters',
+            item: function (filter) {
+                if ('tags' == filter.attributeName) {
+                    return 'tag: ' + filter.name
+                } else {
+                    return filter.attributeName + ': ' + filter.name
+                }
+            }
+        },
+        onlyListedAttributes: true,
+    })
+);
+
+search.addWidget(
   instantsearch.widgets.menu({
     container: '.search-facets-type',
     attributeName: 'type',

--- a/src/Packagist/WebBundle/Resources/views/layout.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/layout.html.twig
@@ -143,6 +143,7 @@
                             <div class="search-list col-md-9"></div>
 
                             <div class="search-facets col-md-3">
+                                <div class="search-facets-active-filters"></div>
                                 <div class="search-facets-type"></div>
                                 <div class="search-facets-tags"></div>
                             </div>


### PR DESCRIPTION
If you have a filter activated and you search for something else, you may not realize a filter is active.
I added the active filter widget at the top of the sidebar.

![packagist-active-filters](https://user-images.githubusercontent.com/1525636/30382074-78188ea2-989e-11e7-8ee8-ee78f2ee6583.gif)
