### PR TITLE
Improve Algolia relevancy

### DIFF
--- a/src/Packagist/WebBundle/Resources/config/algolia_settings.yml
+++ b/src/Packagist/WebBundle/Resources/config/algolia_settings.yml
@@ -1,22 +1,22 @@
 searchableAttributes:
-    - "name"
-    - "package_name"
-    - "package_organisation"
-    - "description"
-    - "tags"
+  - "unordered(package_name)"
+  - "unordered(tags)"
+  - "unordered(package_organisation)"
+  - "unordered(description)"
 
 ranking:
     - "typo"
     - "geo"
     - "words"
     - "filters"
+    - "desc(popularity)"
     - "attribute"
     - "proximity"
     - "exact"
     - "custom"
 
 customRanking:
-    - "desc(popularity)"
+    - "asc(abandoned)"
 
 attributesToHighlight:
     - "name"


### PR DESCRIPTION
I tweaked the ranking formula to improve relevancy. You can try it on the `packagist_prod_replica` index. (no reindexing required).

`popularity` is between 0 and 10 so it create [a lot of ties](https://www.algolia.com/doc/guides/ranking/ranking-formula/), that's why we can put it so high in the ranking formula.

We search first in the package name and then it tags. It helps finding templating engine when you search _"templating"_ for instance.

Then if every criteria are the same, we promote a package that is not deprecated compare to a deprecated one. We could even add the trendiness after that for instance.

Let me know what you think :)

---

Live testable version available here: https://piano-tuner-rhinoceros-60112.netlify.com