### PR TITLE
Add HiDPI version of maintainer gravatars

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/Package/viewPackage.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/viewPackage.html.twig
@@ -116,7 +116,7 @@
                         <div class="details col-xs-12 col-sm-6 col-md-12">
                             <p class="maintainers">
                                 {% for maintainer in package.maintainers -%}
-                                    <a href="{{ path('user_profile', {'name': maintainer.username}) }}"><img width="48" height="48" title="{{ maintainer.username }}" src="//www.gravatar.com/avatar/{{ maintainer.email|gravatar_hash }}?s=48&amp;d=identicon"></a>
+                                    <a href="{{ path('user_profile', {'name': maintainer.username}) }}"><img width="48" height="48" title="{{ maintainer.username }}" src="//www.gravatar.com/avatar/{{ maintainer.email|gravatar_hash }}?s=48&amp;d=identicon" srcset="//www.gravatar.com/avatar/{{ maintainer.email|gravatar_hash }}?s=96&amp;d=identicon 2x"></a>
                                 {% endfor %}
                                 {% if addMaintainerForm is defined or removeMaintainerForm is defined %}
                                     {% if removeMaintainerForm is defined %}<a title="Remove Maintainer" id="remove-maintainer" href="{{ path('remove_maintainer', {'name': package.name}) }}"><i class="glyphicon glyphicon-remove"></i></a>{% endif %}


### PR DESCRIPTION
Currently avatars of maintainers are only available in 48x48 pixels which makes them blurry on HiDPI screens. We can fix that by adding the `srcset` attribute.

Before/After:
<img width="181" alt="before-after" src="https://user-images.githubusercontent.com/617637/30422269-bde11246-993f-11e7-8e25-53ff0816c9d0.png">