### PR TITLE
Update IndexPackagesCommand.php

### DIFF
--- a/src/Packagist/WebBundle/Command/IndexPackagesCommand.php
+++ b/src/Packagist/WebBundle/Command/IndexPackagesCommand.php
@@ -31,7 +31,7 @@ class IndexPackagesCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this
-            ->setName('packcagist:index')
+            ->setName('packagist:index')
             ->setDefinition(array(
                 new InputOption('force', null, InputOption::VALUE_NONE, 'Force a re-indexing of all packages'),
                 new InputOption('all', null, InputOption::VALUE_NONE, 'Index all packages without clearing the index first'),


### PR DESCRIPTION
Just spot one typo issue:
./app/console packagist:index --no-debug --env=prod

[Symfony\Component\Console\Exception\CommandNotFoundException]
Command "packagist:index" is not defined.
Did you mean one of these?
packcagist:index
packagist:dump
packagist:update
packagist:tokens:generate
packagist:stats:compile
packagist:clear:versions

