### PR TITLE
Add tags link backward compat

### DIFF
--- a/src/Packagist/WebBundle/Controller/WebController.php
+++ b/src/Packagist/WebBundle/Controller/WebController.php
@@ -78,7 +78,10 @@ class WebController extends Controller
         $tagsFilter = $req->query->get('tags');
 
         if ($req->getRequestFormat() !== 'json') {
-            return $this->render('PackagistWebBundle:Web:search.html.twig', ['packages' => []]);
+            return $this->render('PackagistWebBundle:Web:search.html.twig', [
+                'packages' => [],
+                'tags' => $tagsFilter
+            ]);
         }
 
         if (!$req->query->has('search_query') && !$typeFilter && !$tagsFilter) {

--- a/src/Packagist/WebBundle/Resources/config/algolia_settings.yml
+++ b/src/Packagist/WebBundle/Resources/config/algolia_settings.yml
@@ -32,4 +32,4 @@ separatorsToIndex:
 
 attributesForFaceting:
     - "type"
-    - "tags"
+    - "searchable(tags)"

--- a/src/Packagist/WebBundle/Resources/public/js/search.js
+++ b/src/Packagist/WebBundle/Resources/public/js/search.js
@@ -3,6 +3,12 @@ document.getElementById('search_query_query').addEventListener('keydown', functi
         e.preventDefault();
     }
 });
+var searchParameters = algoliaConfig.tags ? {
+    facets: ['tags'],
+    facetsRefinements: {
+        tags: [algoliaConfig.tags]
+    }
+} : {};
 
 var search = instantsearch({
     appId: algoliaConfig.app_id,
@@ -13,13 +19,20 @@ var search = instantsearch({
     },
     searchFunction: function(helper) {
         var searchResults = $('#search-container');
-        if (helper.state.query === '' && helper.state.hierarchicalFacetsRefinements.type === undefined && helper.state.hierarchicalFacetsRefinements.tags === undefined) {
+
+        if (helper.state.query === ''
+            && helper.state.hierarchicalFacetsRefinements.type === undefined
+            && helper.state.hierarchicalFacetsRefinements.tags === undefined
+            && algoliaConfig.tags.length == 0
+        ) {
             searchResults.addClass('hidden');
         } else {
-            helper.search();
             searchResults.removeClass('hidden');
         }
-    }
+
+        helper.search();
+    },
+    searchParameters: searchParameters
 });
 
 search.addWidget(

--- a/src/Packagist/WebBundle/Resources/public/js/search.js
+++ b/src/Packagist/WebBundle/Resources/public/js/search.js
@@ -151,7 +151,8 @@ search.addWidget(
         showMore: true,
         templates: {
             header: 'Tags'
-        }
+        },
+        searchForFacetValues:true
     })
 );
 

--- a/src/Packagist/WebBundle/Resources/public/js/search.js
+++ b/src/Packagist/WebBundle/Resources/public/js/search.js
@@ -8,7 +8,9 @@ var search = instantsearch({
     appId: algoliaConfig.app_id,
     apiKey: algoliaConfig.search_key,
     indexName: algoliaConfig.index_name,
-    urlSync: true,
+    urlSync: {
+        trackedParameters: ['query', 'attribute:*', 'page']
+    },
     searchFunction: function(helper) {
         var searchResults = $('#search-container');
         if (helper.state.query === '' && helper.state.hierarchicalFacetsRefinements.type === undefined && helper.state.hierarchicalFacetsRefinements.tags === undefined) {

--- a/src/Packagist/WebBundle/Resources/public/js/search.js
+++ b/src/Packagist/WebBundle/Resources/public/js/search.js
@@ -28,10 +28,7 @@ search.addWidget(
         magnifier: false,
         reset: false,
         wrapInput: false,
-        autofocus: true,
-        //queryHook: function (query, search) {
-        //    search(query);
-        //}
+        autofocus: true
     })
 );
 
@@ -122,27 +119,33 @@ search.addWidget(
 );
 
 search.addWidget(
-  instantsearch.widgets.menu({
-    container: '.search-facets-type',
-    attributeName: 'type',
-    limit: 15,
-    showMore: true,
-    templates: {
-      header: 'Package type'
-    }
-  })
+    instantsearch.widgets.menu({
+        container: '.search-facets-type',
+        attributeName: 'type',
+        limit: 15,
+        showMore: true,
+        templates: {
+            header: 'Package type'
+        }
+    })
 );
 
 search.addWidget(
-  instantsearch.widgets.menu({
-    container: '.search-facets-tags',
-    attributeName: 'tags',
-    limit: 15,
-    showMore: true,
-    templates: {
-      header: 'Tags'
-    }
-  })
+    instantsearch.widgets.menu({
+        container: '.search-facets-tags',
+        attributeName: 'tags',
+        limit: 15,
+        showMore: true,
+        templates: {
+            header: 'Tags'
+        }
+    })
 );
 
 search.start();
+
+if(algoliaConfig.tags !== '') {
+    search.helper.once('change', function (e) {
+        window.history.replaceState(null, 'title', window.location.pathname);
+    });
+}

--- a/src/Packagist/WebBundle/Resources/public/js/search.js
+++ b/src/Packagist/WebBundle/Resources/public/js/search.js
@@ -4,8 +4,8 @@ document.getElementById('search_query_query').addEventListener('keydown', functi
     }
 });
 var searchParameters = algoliaConfig.tags ? {
-    facets: ['tags'],
-    facetsRefinements: {
+    disjunctiveFacets: ['tags'],
+    disjunctiveFacetsRefinements: {
         tags: [algoliaConfig.tags]
     }
 } : {};
@@ -22,7 +22,7 @@ var search = instantsearch({
 
         if (helper.state.query === ''
             && helper.state.hierarchicalFacetsRefinements.type === undefined
-            && helper.state.hierarchicalFacetsRefinements.tags === undefined
+            && helper.state.disjunctiveFacetsRefinements.tags === undefined
             && algoliaConfig.tags.length == 0
         ) {
             searchResults.addClass('hidden');
@@ -144,7 +144,7 @@ search.addWidget(
 );
 
 search.addWidget(
-    instantsearch.widgets.menu({
+    instantsearch.widgets.refinementList({
         container: '.search-facets-tags',
         attributeName: 'tags',
         limit: 15,

--- a/src/Packagist/WebBundle/Resources/views/layout.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/layout.html.twig
@@ -204,6 +204,7 @@
 
         <script>
             var algoliaConfig = {{ algolia|json_encode|raw }};
+            algoliaConfig['tags'] = '{{ tags|default(false) }}';
         </script>
 
         <script src="{{ asset('libs/jquery-2.1.4.min.js') }}"></script>


### PR DESCRIPTION
I added backward compatibility for link like https://packagist.org/search/tags=templating

In the meantime, I switch tags to checkbox link so they can be combined and I added search for tags.

![sep-27-2017 18-43-18](https://user-images.githubusercontent.com/1525636/30925922-caed8054-a3b3-11e7-8966-06997e3e1d99.gif)
