### PR TITLE
Fix webhook source identification

### DIFF
--- a/src/Packagist/WebBundle/Controller/ApiController.php
+++ b/src/Packagist/WebBundle/Controller/ApiController.php
@@ -109,13 +109,13 @@ class ApiController extends Controller
             return new JsonResponse(array('status' => 'error', 'message' => 'Missing payload parameter'), 406);
         }
 
-        if (isset($payload['repository']['url'])) { // github/anything hook
+        if (isset($payload['project']['git_http_url'])) { // gitlab event payload
+            $urlRegex = '{^(?:ssh://git@|https?://|git://|git@)?(?P<host>[a-z0-9.-]+)(?::[0-9]+/|[:/])(?P<path>[\w.-]+(?:/[\w.-]+?)+)(?:\.git|/)?$}i';
+            $url = $payload['project']['git_http_url'];
+        } elseif (isset($payload['repository']['url'])) { // github/anything hook
             $urlRegex = '{^(?:ssh://git@|https?://|git://|git@)?(?P<host>[a-z0-9.-]+)(?::[0-9]+/|[:/])(?P<path>[\w.-]+(?:/[\w.-]+?)+)(?:\.git|/)?$}i';
             $url = $payload['repository']['url'];
             $url = str_replace('https://api.github.com/repos', 'https://github.com', $url);
-        } elseif (isset($payload['project']['git_http_url'])) { // gitlab event payload
-            $urlRegex = '{^(?:ssh://git@|https?://|git://|git@)?(?P<host>[a-z0-9.-]+)(?::[0-9]+/|[:/])(?P<path>[\w.-]+(?:/[\w.-]+?)+)(?:\.git|/)?$}i';
-            $url = $payload['project']['git_http_url'];
         } elseif (isset($payload['repository']['links']['html']['href'])) { // bitbucket push event payload
             $urlRegex = '{^(?:https?://|git://|git@)?(?:api\.)?(?P<host>bitbucket\.org)[/:](?P<path>[\w.-]+/[\w.-]+?)(\.git)?/?$}i';
             $url = $payload['repository']['links']['html']['href'];


### PR DESCRIPTION
GitHub and GitLab both send `$payload['repository']['url']`, but only GitLab's payload contains `$payload['project']`.

This ensures that the proper URLs are used from webhook payloads when GitLab is configured with nonstandard URLs (for example, when developing integrations in a local instance of gitlab-development-kit).