### PR TITLE
[CS] Remove unused imports

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -1,7 +1,6 @@
 <?php
 
 use Symfony\Component\Config\Loader\LoaderInterface;
-use Symfony\Component\Debug\ErrorHandler;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel

--- a/src/Packagist/WebBundle/Command/CompileStatsCommand.php
+++ b/src/Packagist/WebBundle/Command/CompileStatsCommand.php
@@ -12,9 +12,7 @@
 
 namespace Packagist\WebBundle\Command;
 
-use Packagist\WebBundle\Package\Updater;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Packagist/WebBundle/Command/DumpPackagesCommand.php
+++ b/src/Packagist/WebBundle/Command/DumpPackagesCommand.php
@@ -13,7 +13,6 @@
 namespace Packagist\WebBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Packagist/WebBundle/Controller/WebController.php
+++ b/src/Packagist/WebBundle/Controller/WebController.php
@@ -14,8 +14,6 @@ namespace Packagist\WebBundle\Controller;
 
 use Packagist\WebBundle\Form\Model\SearchQuery;
 use Packagist\WebBundle\Form\Type\SearchQueryType;
-use Pagerfanta\Adapter\SolariumAdapter;
-use Pagerfanta\Pagerfanta;
 use Predis\Connection\ConnectionException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;

--- a/src/Packagist/WebBundle/Package/Updater.php
+++ b/src/Packagist/WebBundle/Package/Updater.php
@@ -21,7 +21,6 @@ use Composer\Repository\Vcs\GitHubDriver;
 use Composer\Repository\InvalidRepositoryException;
 use Composer\Util\ErrorHandler;
 use Composer\Util\RemoteFilesystem;
-use Composer\Json\JsonFile;
 use Composer\Config;
 use Composer\IO\IOInterface;
 use Packagist\WebBundle\Entity\Author;

--- a/src/Packagist/WebBundle/PackagistWebBundle.php
+++ b/src/Packagist/WebBundle/PackagistWebBundle.php
@@ -13,7 +13,6 @@
 namespace Packagist\WebBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>

--- a/src/Packagist/WebBundle/Tests/Controller/WebControllerTest.php
+++ b/src/Packagist/WebBundle/Tests/Controller/WebControllerTest.php
@@ -4,8 +4,6 @@ namespace Packagist\WebBundle\Tests\Controller;
 
 use Exception;
 use Packagist\WebBundle\Entity\Package;
-use Packagist\WebBundle\Model\DownloadManager;
-use Packagist\WebBundle\Model\FavoriteManager;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 


### PR DESCRIPTION
I've cleaned up some unused imports. This can save us some lines :put_litter_in_its_place: 

[`PHP-CS-Fixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer) helped find them.