### PR TITLE
Focus the search box on the main page only

### DIFF
--- a/src/Packagist/WebBundle/Resources/public/js/search.js
+++ b/src/Packagist/WebBundle/Resources/public/js/search.js
@@ -57,13 +57,17 @@ var search = instantsearch({
     searchParameters: searchParameters
 });
 
+var autofocus = false;
+if(location.pathname == "/") {
+    autofocus = true;
+}
 search.addWidget(
     instantsearch.widgets.searchBox({
         container: '#search_query_query',
         magnifier: false,
         reset: false,
         wrapInput: false,
-        autofocus: true
+        autofocus: autofocus
     })
 );
 


### PR DESCRIPTION
This is a suggested solution for #849 where the focus on the search bar on pages where you probably want to do something other than search makes the site confusing/hard particularly for those with accessibility issues.  If there are other pages where the search bar _should_ be focussed, perhaps we can extend this patch to include those but I hope this works as a starting point.