### PR TITLE
Removed unused variable

### DIFF
--- a/src/Packagist/WebBundle/Command/CompileStatsCommand.php
+++ b/src/Packagist/WebBundle/Command/CompileStatsCommand.php
@@ -117,7 +117,7 @@ class CompileStatsCommand extends ContainerAwareCommand
             $ids[] = $row['id'];
         }
 
-         if ($verbose) {
+        if ($verbose) {
             $output->writeln('Writing new trendiness data into redis');
         }
 

--- a/src/Packagist/WebBundle/Command/CompileStatsCommand.php
+++ b/src/Packagist/WebBundle/Command/CompileStatsCommand.php
@@ -117,10 +117,7 @@ class CompileStatsCommand extends ContainerAwareCommand
             $ids[] = $row['id'];
         }
 
-        // add downloads from the last 7 days to the solr index
-        $solarium = $this->getContainer()->get('solarium.client');
-
-        if ($verbose) {
+         if ($verbose) {
             $output->writeln('Writing new trendiness data into redis');
         }
 


### PR DESCRIPTION
>>>
  [Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]
  You have requested a non-existent service "solarium.client".
>>>