### PR TITLE
Allow all github user content domains for images in CSP

### DIFF
--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -86,7 +86,7 @@ nelmio_security:
             img-src:
                 - 'self'
                 - 'https://www.gravatar.com/'
-                - 'https://camo.githubusercontent.com/'
+                - 'https://*.githubusercontent.com/'
                 - 'https://ssl.google-analytics.com/'
                 - 'http://www.google-analytics.com/'
             style-src:


### PR DESCRIPTION
Github does not only use the camo subdomain. Images which are already pointing to a githubusercontent subdomain are not rewritten in readme files.

Closes #879