### PR TITLE
Fix condition to display actions

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/Package/viewPackage.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/viewPackage.html.twig
@@ -22,7 +22,7 @@
     {{ package.description }}
 {%- endblock %}
 
-{% set hasActions = is_granted('ROLE_EDIT_PACKAGES') or is_granted('ROLE_EDIT_PACKAGES') or package.maintainers.contains(app.user) %}
+{% set hasActions = is_granted('ROLE_EDIT_PACKAGES') or is_granted('ROLE_UPDATE_PACKAGES') or package.maintainers.contains(app.user) %}
 
 {% block content %}
     <div class="row">


### PR DESCRIPTION
The `Update` button depends on the `ROLE_UPDATE_PACKAGES`. but currently, having `ROLE_UPDATE_PACKAGES` without `ROLE_EDIT_PACKAGES` would still not display the button, as `has_actions` was checking `ROLE_EDIT_PACKAGES` twice (probably a bad copy-paste)