### PR TITLE
Fix the rendering of the API token

### DIFF
--- a/app/Resources/FOSUserBundle/views/Profile/show.html.twig
+++ b/app/Resources/FOSUserBundle/views/Profile/show.html.twig
@@ -9,7 +9,7 @@
 
         <div class="input-group api-token-group clearfix">
             <input id="api-token" type="text" class="form-control" value="" data-api-token="{{ app.user.apiToken }}" readonly="readonly">
-            <span class="input-group">
+            <span class="input-group-btn">
                 <button class="btn btn-success btn-show-api-token" type="button">{{ 'profile.show_api_token'|trans }}</button>
             </span>
         </div>


### PR DESCRIPTION
Before:
![packagist_token_before](https://user-images.githubusercontent.com/439401/37103413-73fe616e-222a-11e8-9c9c-794caaddf165.png)

after:
![packagist_token_after](https://user-images.githubusercontent.com/439401/37103425-7a6edd1c-222a-11e8-8836-935755f53a42.png)

Note that the design was already fine after revealing the token. (but it stays fine).