### PR TITLE
Fix tests

### DIFF
--- a/src/Packagist/WebBundle/Service/Scheduler.php
+++ b/src/Packagist/WebBundle/Service/Scheduler.php
@@ -5,7 +5,6 @@ namespace Packagist\WebBundle\Service;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Predis\Client as RedisClient;
 use Packagist\WebBundle\Entity\Package;
-use Packagist\WebBundle\Entity\Organization;
 use Packagist\WebBundle\Entity\Job;
 
 class Scheduler

--- a/src/Packagist/WebBundle/Tests/Controller/ApiControllerTest.php
+++ b/src/Packagist/WebBundle/Tests/Controller/ApiControllerTest.php
@@ -30,6 +30,10 @@ class ApiControllerTest extends WebTestCase
         $package = new Package;
         $package->setRepository($url);
 
+        $ref = new \ReflectionProperty(Package::class, 'id');
+        $ref->setAccessible(true);
+        $ref->setValue($package, 1);
+
         $user = new User;
         $user->addPackages($package);
 


### PR DESCRIPTION
The code expects the package to have an integer id. But as the EntityManager is mocked and does not load the package from the DB in the test, there was no id.