### PR TITLE
Fix: daily stats calculation

### DIFF
--- a/src/Packagist/WebBundle/Controller/PackageController.php
+++ b/src/Packagist/WebBundle/Controller/PackageController.php
@@ -973,7 +973,7 @@ class PackageController extends Controller
         $datePoints = $this->createDatePoints($from, $to, $average, $package, $version);
 
         $redis = $this->get('snc_redis.default');
-        if ($average === 'Daily') {
+        if ($average === 'daily') {
             $datePoints = array_map(function ($vals) {
                 return $vals[0];
             }, $datePoints);


### PR DESCRIPTION
`$average` value is always lower case.

The calculation still was correct but it never executed the optimized code branch where all days get fetch with one redis call.