### PR TITLE
Add headers to improve maintainers visibility

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/Package/viewPackage.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/viewPackage.html.twig
@@ -117,6 +117,7 @@
                 <div class="col-md-offset-1 col-md-3">
                     <div class="row package-aside">
                         <div class="details col-xs-12 col-sm-6 col-md-12">
+                            <h4>Maintainers</h4>
                             <p class="maintainers">
                                 {% for maintainer in package.maintainers -%}
                                     <a href="{{ path('user_profile', {'name': maintainer.username}) }}"><img width="48" height="48" title="{{ maintainer.username }}" src="https://www.gravatar.com/avatar/{{ maintainer.email|gravatar_hash }}?s=48&amp;d=identicon" srcset="https://www.gravatar.com/avatar/{{ maintainer.email|gravatar_hash }}?s=96&amp;d=identicon 2x"></a>
@@ -127,6 +128,7 @@
                                 {% endif %}
                             </p>
 
+                            <h4>Details</h4>
                             {% set repoUrl = package.browsableRepository %}
                             <p class="canonical">
                                 <a href="{{ repoUrl }}" title="Canonical Repository URL">{{ repoUrl|replace({'https://':'', 'http://':''}) }}</a>


### PR DESCRIPTION
A number of my colleagues were unable to find how to add a maintainer after scouring aggressively as the button isn't the most obvious in its purpose.

It's mostly because when a package has one maintainer (the owner), it looks like the avatar of the package owner, not a collection of maintainers.

This PR updates the view from this:

<img width="319" alt="screen shot 2018-10-16 at 11 18 41" src="https://user-images.githubusercontent.com/23653050/47010657-8cc61b80-d137-11e8-9220-c10cd9cb7e8a.png"> 

To this:

<img width="328" alt="screen shot 2018-10-16 at 11 18 31" src="https://user-images.githubusercontent.com/23653050/47010677-98194700-d137-11e8-880b-1413cb772585.png">

