### PR TITLE
do not use outdated PHP version for example

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/Web/index.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/index.html.twig
@@ -43,7 +43,7 @@
     "name": "your-vendor-name/package-name",
     "description": "A short description of what your package does",
     "require": {
-        "php": "^5.3.3 || ^7.0",
+        "php": "^5.6.37 || ^7.0",
         "another-vendor/package": "1.*"
     }
 }</code></pre>


### PR DESCRIPTION
This should be changed in january to sth. like this:

```diff
- "php": "^5.6.37 || ^7.0",
+ "php": "^7.0.31 || ^7.1",
```