### PR TITLE
do not use outdated PHP version. refs #968

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/Web/index.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Web/index.html.twig
@@ -43,7 +43,7 @@
     "name": "your-vendor-name/package-name",
     "description": "A short description of what your package does",
     "require": {
-        "php": "^5.6.37 || ^7.0",
+        "php": "^7.2",
         "another-vendor/package": "1.*"
     }
 }</code></pre>


### PR DESCRIPTION
Follow up #968 

As PHP `7.1` receives security fixes only, `7.2` should be recommended