### PR TITLE
Add PHP test server router script support

### DIFF
--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -10,6 +10,15 @@ use Symfony\Component\Debug\Debug;
 // read http://symfony.com/doc/current/book/installation.html#configuration-and-setup for more information
 //umask(0000);
 
+// When used directly as a php router script,
+// allow all assets to be served normally.
+if (preg_match(
+      '/\.(?:css|eot|gif|ico|js|osd|png|svg|ttf|txt|woff|woff2)$/i',
+      parse_url($_SERVER['REQUEST_URI'])['path'] ?? '')
+) {
+    return false;
+}
+
 // This check prevents access to debug front controllers that are deployed by accident to production servers.
 // Feel free to remove this, extend it, or make something more sophisticated.
 if (isset($_SERVER['HTTP_CLIENT_IP'])


### PR DESCRIPTION
Detects asset requiest uri, when called, and return false. Allows `web/app_dev.php` to function as a PHP test server router script.

With this merged, you may run Packagist on PHP Test Server with this command:
```
php -S localhost:8000 -t ./web ./web/app_dev.php
```

An improvement for developers who wants to improve Packagist.

Reference:
http://php.net/manual/en/features.commandline.webserver.php (Please see **Example 3**)