### PR TITLE
Fix monthly stats averages

### DIFF
--- a/src/Packagist/WebBundle/Controller/PackageController.php
+++ b/src/Packagist/WebBundle/Controller/PackageController.php
@@ -984,7 +984,7 @@ class PackageController extends Controller
             foreach ($values as $valueKey) {
                 $value += $dlData[$valueKey] ?? 0;
             }
-            $datePoints[$label] = $value;
+            $datePoints[$label] = ceil($value / count($datePoints[$label]));
         }
 
         $datePoints = array(
@@ -993,17 +993,6 @@ class PackageController extends Controller
         );
 
         $datePoints['average'] = $average;
-
-        if ($average !== 'daily') {
-            $dividers = [
-                'monthly' => 30.41,
-                'weekly' => 7,
-            ];
-            $divider = $dividers[$average];
-            $datePoints['values'] = array_map(function ($val) use ($divider) {
-                return ceil($val / $divider);
-            }, $datePoints['values']);
-        }
 
         if (empty($datePoints['labels']) && empty($datePoints['values'])) {
             $datePoints['labels'][] = date('Y-m-d');
@@ -1101,13 +1090,15 @@ class PackageController extends Controller
         $dateKey = 'Ymd';
         $dateFormat = $average === 'monthly' ? 'Y-m' : 'Y-m-d';
         $dateJump = '+1day';
-        if ($average === 'monthly') {
-            $from = new DateTimeImmutable('first day of ' . $from->format('Y-m'));
-            $to = new DateTimeImmutable('last day of ' . $to->format('Y-m'));
-        }
 
         $nextDataPointLabel = $from->format($dateFormat);
-        $nextDataPoint = $from->modify($interval);
+
+        if ($average === 'monthly') {
+            $nextDataPoint = new DateTimeImmutable('first day of ' . $from->format('Y-m'));
+            $nextDataPoint = $nextDataPoint->modify($interval);
+        } else {
+            $nextDataPoint = $from->modify($interval);
+        }
 
         $datePoints = [];
         while ($from <= $to) {

--- a/src/Packagist/WebBundle/Controller/PackageController.php
+++ b/src/Packagist/WebBundle/Controller/PackageController.php
@@ -984,7 +984,7 @@ class PackageController extends Controller
             foreach ($values as $valueKey) {
                 $value += $dlData[$valueKey] ?? 0;
             }
-            $datePoints[$label] = ceil($value / count($datePoints[$label]));
+            $datePoints[$label] = ceil($value / count($values));
         }
 
         $datePoints = array(


### PR DESCRIPTION
This PR fixes the calculations of daily downloads when averaging monthly.

Before| Now
------------ | -------------
The total monthly downloads were divided by `30.41` | The total monthly downloads are divided by the actual number of days in the month, `28` to `31`
The whole month of the `from` date was taken into account | The `from` date is actually respected
**Example**: `from=2018-01-29` yielded an interval `2018-01-01` → `2018-01-31` for the first month | `from=2018-01-29` yields `2018-01-29` → `2018-01-31`
The whole month of the `to` date was taken into account | The `to` date is actually respected
**Example**: `to=2019-03-12` yielded an interval `2019-03-01` → `2019-03-31` for the last month | `to=2019-03-12` yields `2019-03-01` → `2019-03-12`
The total number of downloads for the start and end month was divided by `30.41` | The total number of downloads **for the given interval** is divided by **the actual number of days in the interval**, `1` to `31`

### Why this change?

It will better reflect the actual daily downloads of the package, and will avoid sharp drops in the chart at the beginning of each month:

![Monthly stat drop](https://i.imgur.com/kjCaQ9h.png)