### PR TITLE
Template tweaks

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/user/favorites.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/user/favorites.html.twig
@@ -2,9 +2,9 @@
 
 {% import "PackagistWebBundle::macros.html.twig" as macros %}
 
+{% block content %}
 {% set isActualUser = app.user and app.user.username is same as(user.username) %}
 
-{% block content %}
 <h2 class="title">
     {{ user.username }}
     <small>

--- a/src/Packagist/WebBundle/Resources/views/user/favorites.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/user/favorites.html.twig
@@ -7,14 +7,14 @@
 
 <h2 class="title">
     {{ user.username }}
-    <small>
-        {%- if not isActualUser %}
+    {%- if not isActualUser %}
+        <small>
             member since: {{ user.createdAt|date('M d, Y') }}
             {%- if is_granted('ROLE_ADMIN') %}
                 <a href="mailto:{{ user.email }}">{{ user.email }}</a>
             {%- endif %}
-        {%- endif %}
-    </small>
+        </small>
+    {%- endif %}
 </h2>
 
 <section class="row">

--- a/src/Packagist/WebBundle/Resources/views/user/packages.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/user/packages.html.twig
@@ -7,14 +7,14 @@
 {% set isActualUser = app.user and app.user.username is same as(user.username) %}
 <h2 class="title">
     {{ user.username }}
-    <small>
-        {%- if not isActualUser %}
+    {%- if not isActualUser %}
+        <small>
             member since: {{ user.createdAt|date('M d, Y') }}
             {%- if is_granted('ROLE_ADMIN') %}
                 <a href="mailto:{{ user.email }}">{{ user.email }}</a>
             {%- endif %}
-        {%- endif %}
-    </small>
+        </small>
+    {%- endif %}
 </h2>
 
 <section class="row">

--- a/src/Packagist/WebBundle/Resources/views/user/packages.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/user/packages.html.twig
@@ -2,9 +2,9 @@
 
 {% import "PackagistWebBundle::macros.html.twig" as macros %}
 
-{% set isActualUser = app.user and app.user.username is same as(user.username) %}
 
 {% block content %}
+{% set isActualUser = app.user and app.user.username is same as(user.username) %}
 <h2 class="title">
     {{ user.username }}
     <small>

--- a/src/Packagist/WebBundle/Resources/views/user/profile.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/user/profile.html.twig
@@ -2,8 +2,6 @@
 
 {% import "PackagistWebBundle::macros.html.twig" as macros %}
 
-{% set isActualUser = app.user and app.user.username is same as(user.username) %}
-
 {% block head_additions %}
     {% if user.hasRole('ROLE_SPAMMER') %}
         <meta name="robots" content="noindex, nofollow">
@@ -11,6 +9,7 @@
 {% endblock %}
 
 {% block content %}
+{% set isActualUser = app.user and app.user.username is same as(user.username) %}
 <h2 class="title">
     {{ user.username }}
     <small>


### PR DESCRIPTION
This PR makes two minor changes to the `user` templates:

 - Only set `isActualUser` in the block where it's needed - see https://github.com/composer/packagist/pull/1031#discussion_r332588385
 - Only render the <small> tag when we have content for it - see https://github.com/composer/packagist/pull/1031#discussion_r332588127