### PR TITLE
Security Advisories

### DIFF
--- a/src/Packagist/WebBundle/Controller/ApiController.php
+++ b/src/Packagist/WebBundle/Controller/ApiController.php
@@ -258,7 +258,7 @@ class ApiController extends Controller
     public function securityAdvisoryAction(Request $request): JsonResponse
     {
         $packageNames = array_filter((array) $request->get('packages'));
-        if (!$packageNames) {
+        if ((!$request->query->has('updatedSince') && !$request->get('packages')) || (!$packageNames && $request->get('packages'))) {
             return new JsonResponse(['status' => 'error', 'message' => 'Missing array of package names as the "packages" parameter'], 400);
         }
 

--- a/src/Packagist/WebBundle/Controller/ApiController.php
+++ b/src/Packagist/WebBundle/Controller/ApiController.php
@@ -267,9 +267,9 @@ class ApiController extends Controller
         /** @var array[] $advisories */
         $advisories = $this->getDoctrine()->getRepository(SecurityAdvisory::class)->searchSecurityAdvisories($packageNames, $updatedSince);
 
-        $response = [];
+        $response = ['advisories' => []];
         foreach ($advisories as $advisory) {
-            $response[$advisory['packageName']][] = $advisory;
+            $response['advisories'][$advisory['packageName']][] = $advisory;
         }
 
         return new JsonResponse($response, 200);

--- a/src/Packagist/WebBundle/Controller/ApiController.php
+++ b/src/Packagist/WebBundle/Controller/ApiController.php
@@ -257,9 +257,11 @@ class ApiController extends Controller
      */
     public function securityAdvisoryAction(Request $request): JsonResponse
     {
-        $packageNames = array_values(array_filter(array_map(function (string $packageName) {
-            return trim($packageName);
-        }, explode(',', $request->get('packages')))));
+        $packageNames = array_filter((array) $request->get('packages'));
+        if (!$packageNames) {
+            return new JsonResponse(['status' => 'error', 'message' => 'Missing array of package names as the "packages" parameter'], 400);
+        }
+
         $updatedSince = $request->query->getInt('updatedSince', 0);
 
         /** @var array[] $advisories */

--- a/src/Packagist/WebBundle/Controller/ApiController.php
+++ b/src/Packagist/WebBundle/Controller/ApiController.php
@@ -255,12 +255,12 @@ class ApiController extends Controller
      *     methods={"GET", "POST"}
      * )
      */
-    public function securityAdvisoryAction(Request $request)
+    public function securityAdvisoryAction(Request $request): JsonResponse
     {
         $packageNames = array_values(array_filter(array_map(function (string $packageName) {
             return trim($packageName);
         }, explode(',', $request->get('packages')))));
-        $updatedSince = $request->query->get('updatedSince', 0);
+        $updatedSince = $request->query->getInt('updatedSince', 0);
 
         /** @var array[] $advisories */
         $advisories = $this->getDoctrine()->getRepository(SecurityAdvisory::class)->searchSecurityAdvisories($packageNames, $updatedSince);

--- a/src/Packagist/WebBundle/Controller/PackageController.php
+++ b/src/Packagist/WebBundle/Controller/PackageController.php
@@ -1152,8 +1152,8 @@ class PackageController extends Controller
         $securityAdvisories = $repo->getPackageSecurityAdvisories($name);
         $advisoryCount = count($securityAdvisories);
 
-        $paginator = new Pagerfanta(new FixedAdapter($advisoryCount, $securityAdvisories));
-        $data['securityAdvisories'] = $paginator;
+        $data = [];
+        $data['securityAdvisories'] = $securityAdvisories;
         $data['count'] = $advisoryCount;
         $data['name'] = $name;
 
@@ -1164,11 +1164,11 @@ class PackageController extends Controller
                 'id' => $versionId,
             ]);
             if ($version) {
+                $versionParser = new VersionParser();
                 foreach ($securityAdvisories as $advisory) {
-                    $versionParser = new VersionParser();
                     $affectedVersionConstraint = $versionParser->parseConstraints($advisory['affectedVersions']);
-                    if (!isset($data['hasVersionSecurityAdvisories'][$version->getId()]) && $affectedVersionConstraint->matches(new Constraint('=', $version->getNormalizedVersion()))) {
-                        $data['matchingAdvisories'] = $advisory['id'];
+                    if ($affectedVersionConstraint->matches(new Constraint('=', $version->getNormalizedVersion()))) {
+                        $data['matchingAdvisories'][] = $advisory['id'];
                     }
                 }
             }

--- a/src/Packagist/WebBundle/Controller/PackageController.php
+++ b/src/Packagist/WebBundle/Controller/PackageController.php
@@ -1129,8 +1129,8 @@ class PackageController extends Controller
 
     /**
      * @Route(
-     *      "/packages/{name}/security_advisories",
-     *      name="view_package_security_advisories",
+     *      "/packages/{name}/advisories",
+     *      name="view_package_advisories",
      *      requirements={"name"="([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?|ext-[A-Za-z0-9_.-]+?)"}
      * )
      */

--- a/src/Packagist/WebBundle/Controller/PackageController.php
+++ b/src/Packagist/WebBundle/Controller/PackageController.php
@@ -1150,11 +1150,8 @@ class PackageController extends Controller
         /** @var SecurityAdvisoryRepository $repo */
         $repo = $this->getDoctrine()->getRepository(SecurityAdvisory::class);
         $securityAdvisories = $repo->getPackageSecurityAdvisories($name);
-        $advisoryCount = count($securityAdvisories);
 
         $data = [];
-        $data['securityAdvisories'] = $securityAdvisories;
-        $data['count'] = $advisoryCount;
         $data['name'] = $name;
 
         $data['matchingAdvisories'] = [];
@@ -1164,15 +1161,22 @@ class PackageController extends Controller
                 'id' => $versionId,
             ]);
             if ($version) {
+                $versionSecurityAdvisories = [];
                 $versionParser = new VersionParser();
                 foreach ($securityAdvisories as $advisory) {
                     $affectedVersionConstraint = $versionParser->parseConstraints($advisory['affectedVersions']);
                     if ($affectedVersionConstraint->matches(new Constraint('=', $version->getNormalizedVersion()))) {
-                        $data['matchingAdvisories'][] = $advisory['id'];
+                        $versionSecurityAdvisories[] = $advisory;
                     }
                 }
+
+                $data['version'] = $version->getVersion();
+                $securityAdvisories = $versionSecurityAdvisories;
             }
         }
+
+        $data['securityAdvisories'] = $securityAdvisories;
+        $data['count'] = count($securityAdvisories);
 
         return $this->render('PackagistWebBundle:package:security_advisories.html.twig', $data);
     }

--- a/src/Packagist/WebBundle/Entity/SecurityAdvisory.php
+++ b/src/Packagist/WebBundle/Entity/SecurityAdvisory.php
@@ -6,7 +6,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Packagist\WebBundle\SecurityAdvisory\RemoteSecurityAdvisory;
 
 /**
- * @ORM\Entity()
+ * @ORM\Entity(repositoryClass="Packagist\WebBundle\Entity\SecurityAdvisoryRepository")
  * @ORM\Table(
  *     name="security_advisory",
  *     uniqueConstraints={@ORM\UniqueConstraint(name="source_packagename_idx", columns={"source","packageName"})},

--- a/src/Packagist/WebBundle/Entity/SecurityAdvisory.php
+++ b/src/Packagist/WebBundle/Entity/SecurityAdvisory.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+
+namespace Packagist\WebBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Packagist\WebBundle\SecurityAdvisory\RemoteSecurityAdvisory;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(
+ *     name="security_advisory",
+ *     uniqueConstraints={@ORM\UniqueConstraint(name="source_packagename_idx", columns={"source","packageName"})},
+ *     indexes={
+ *         @ORM\Index(name="package_name_idx",columns={"packageName"})
+ *     }
+ * )
+ */
+class SecurityAdvisory
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    private $remoteId;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    private $packageName;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    private $title;
+
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
+    private $link;
+
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
+    private $cve;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    private $affectedVersions;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    private $source;
+
+    public function __construct(RemoteSecurityAdvisory $advisory, string $source)
+    {
+        $this->source = $source;
+        $this->updateAdvisory($advisory);
+    }
+
+    public function updateAdvisory(RemoteSecurityAdvisory $advisory): void
+    {
+        $this->remoteId = $advisory->getId();
+        $this->packageName = $advisory->getPackageName();
+        $this->title = $advisory->getTitle();
+        $this->link = $advisory->getLink();
+        $this->cve = $advisory->getCve();
+        $this->affectedVersions = $advisory->getAffectedVersions();
+    }
+
+    public function getRemoteId(): string
+    {
+        return $this->remoteId;
+    }
+}

--- a/src/Packagist/WebBundle/Entity/SecurityAdvisory.php
+++ b/src/Packagist/WebBundle/Entity/SecurityAdvisory.php
@@ -9,9 +9,10 @@ use Packagist\WebBundle\SecurityAdvisory\RemoteSecurityAdvisory;
  * @ORM\Entity(repositoryClass="Packagist\WebBundle\Entity\SecurityAdvisoryRepository")
  * @ORM\Table(
  *     name="security_advisory",
- *     uniqueConstraints={@ORM\UniqueConstraint(name="source_packagename_idx", columns={"source","packageName"})},
+ *     uniqueConstraints={@ORM\UniqueConstraint(name="source_remoteid_idx", columns={"source","remoteId"})},
  *     indexes={
- *         @ORM\Index(name="package_name_idx",columns={"packageName"})
+ *         @ORM\Index(name="package_name_idx",columns={"packageName"}),
+ *         @ORM\Index(name="updated_at_idx",columns={"updatedAt"})
  *     }
  * )
  */
@@ -59,6 +60,11 @@ class SecurityAdvisory
      */
     private $source;
 
+    /**
+     * @ORM\Column(type="datetime")
+     */
+    private $updatedAt;
+
     public function __construct(RemoteSecurityAdvisory $advisory, string $source)
     {
         $this->source = $source;
@@ -67,6 +73,17 @@ class SecurityAdvisory
 
     public function updateAdvisory(RemoteSecurityAdvisory $advisory): void
     {
+        if (
+            $this->remoteId !== $advisory->getId() ||
+            $this->packageName !== $advisory->getPackageName() ||
+            $this->title !== $advisory->getTitle() ||
+            $this->link !== $advisory->getLink() ||
+            $this->cve !== $advisory->getCve() ||
+            $this->affectedVersions !== $advisory->getAffectedVersions()
+        ) {
+            $this->updatedAt = new \DateTime();
+        }
+
         $this->remoteId = $advisory->getId();
         $this->packageName = $advisory->getPackageName();
         $this->title = $advisory->getTitle();
@@ -78,5 +95,35 @@ class SecurityAdvisory
     public function getRemoteId(): string
     {
         return $this->remoteId;
+    }
+
+    public function getPackageName(): string
+    {
+        return $this->packageName;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getLink(): ?string
+    {
+        return $this->link;
+    }
+
+    public function getCve(): ?string
+    {
+        return $this->cve;
+    }
+
+    public function getAffectedVersions(): string
+    {
+        return $this->affectedVersions;
+    }
+
+    public function getSource(): string
+    {
+        return $this->source;
     }
 }

--- a/src/Packagist/WebBundle/Entity/SecurityAdvisoryRepository.php
+++ b/src/Packagist/WebBundle/Entity/SecurityAdvisoryRepository.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Packagist\WebBundle\Entity;
+
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\Cache\QueryCacheProfile;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+
+class SecurityAdvisoryRepository extends ServiceEntityRepository
+{
+    public function __construct(RegistryInterface $registry)
+    {
+        parent::__construct($registry, SecurityAdvisory::class);
+    }
+
+    public function getPackageSecurityAdvisories($name)
+    {
+        $sql = 'SELECT s.*
+            FROM security_advisory s
+            WHERE s.packageName = :name
+            ORDER BY s.id DESC';
+
+        $stmt = $this->getEntityManager()->getConnection()
+            ->executeQuery(
+                $sql,
+                ['name' => $name],
+                []
+//                new QueryCacheProfile(7*86400, 'security_advisories_'.$name.'_'.$offset.'_'.$limit, $this->getEntityManager()->getConfiguration()->getResultCacheImpl())
+            );
+        $result = $stmt->fetchAll();
+        $stmt->closeCursor();
+
+        return $result;
+    }
+}

--- a/src/Packagist/WebBundle/Entity/SecurityAdvisoryRepository.php
+++ b/src/Packagist/WebBundle/Entity/SecurityAdvisoryRepository.php
@@ -20,16 +20,8 @@ class SecurityAdvisoryRepository extends ServiceEntityRepository
             WHERE s.packageName = :name
             ORDER BY s.id DESC';
 
-        $stmt = $this->getEntityManager()->getConnection()
-            ->executeQuery(
-                $sql,
-                ['name' => $name],
-                []
-            );
-        $result = $stmt->fetchAll();
-        $stmt->closeCursor();
-
-        return $result;
+        return $this->getEntityManager()->getConnection()
+            ->fetchAll($sql, ['name' => $name]);
     }
 
     public function searchSecurityAdvisories(array $packageNames, int $updatedSince): array
@@ -40,18 +32,14 @@ class SecurityAdvisoryRepository extends ServiceEntityRepository
             (count($packageNames) > 0 ? ' AND s.packageName IN (:packageNames)' : '')
             .' ORDER BY s.id DESC';
 
-        $stmt = $this->getEntityManager()->getConnection()
-            ->executeQuery(
+        return $this->getEntityManager()->getConnection()
+            ->fetchAll(
                 $sql,
                 [
                     'packageNames' => $packageNames,
-                    'updatedSince' => (new \DateTime('@' . $updatedSince))->format('Y-m-d H:i:s'),
+                    'updatedSince' => date('Y-m-d H:i:s', $updatedSince),
                 ],
                 ['packageNames' => Connection::PARAM_STR_ARRAY]
             );
-        $result = $stmt->fetchAll();
-        $stmt->closeCursor();
-
-        return $result;
     }
 }

--- a/src/Packagist/WebBundle/Entity/SecurityAdvisoryRepository.php
+++ b/src/Packagist/WebBundle/Entity/SecurityAdvisoryRepository.php
@@ -3,7 +3,7 @@
 namespace Packagist\WebBundle\Entity;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\DBAL\Cache\QueryCacheProfile;
+use Doctrine\DBAL\Connection;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 
 class SecurityAdvisoryRepository extends ServiceEntityRepository
@@ -13,7 +13,7 @@ class SecurityAdvisoryRepository extends ServiceEntityRepository
         parent::__construct($registry, SecurityAdvisory::class);
     }
 
-    public function getPackageSecurityAdvisories($name)
+    public function getPackageSecurityAdvisories(string $name): array
     {
         $sql = 'SELECT s.*
             FROM security_advisory s
@@ -25,7 +25,29 @@ class SecurityAdvisoryRepository extends ServiceEntityRepository
                 $sql,
                 ['name' => $name],
                 []
-//                new QueryCacheProfile(7*86400, 'security_advisories_'.$name.'_'.$offset.'_'.$limit, $this->getEntityManager()->getConfiguration()->getResultCacheImpl())
+            );
+        $result = $stmt->fetchAll();
+        $stmt->closeCursor();
+
+        return $result;
+    }
+
+    public function searchSecurityAdvisories(array $packageNames, int $updatedSince): array
+    {
+        $sql = 'SELECT s.packageName, s.remoteId, s.title, s.link, s.cve, s.affectedVersions, s.source
+            FROM security_advisory s
+            WHERE s.updatedAt >= :updatedSince ' .
+            (count($packageNames) > 0 ? ' AND s.packageName IN (:packageNames)' : '')
+            .' ORDER BY s.id DESC';
+
+        $stmt = $this->getEntityManager()->getConnection()
+            ->executeQuery(
+                $sql,
+                [
+                    'packageNames' => $packageNames,
+                    'updatedSince' => (new \DateTime('@' . $updatedSince))->format('Y-m-d H:i:s'),
+                ],
+                ['packageNames' => Connection::PARAM_STR_ARRAY]
             );
         $result = $stmt->fetchAll();
         $stmt->closeCursor();

--- a/src/Packagist/WebBundle/Resources/config/services.yml
+++ b/src/Packagist/WebBundle/Resources/config/services.yml
@@ -236,7 +236,7 @@ services:
             - "@locker"
             - "@logger"
             - "@doctrine"
-            - 'sensiolabs/security-advisories': "@Packagist\\WebBundle\\SecurityAdvisory\\FriendsOfPhpSecurityAdvisoriesSource"
+            - 'FriendsOfPHP/security-advisories': "@Packagist\\WebBundle\\SecurityAdvisory\\FriendsOfPhpSecurityAdvisoriesSource"
 
 parameters:
     security.exception_listener.class: Packagist\WebBundle\Security\ExceptionListener

--- a/src/Packagist/WebBundle/Resources/config/services.yml
+++ b/src/Packagist/WebBundle/Resources/config/services.yml
@@ -29,6 +29,9 @@ services:
     Packagist\WebBundle\Entity\:
         resource: '../../Entity/*Repository.php'
 
+    Packagist\WebBundle\SecurityAdvisory\:
+        resource: '../../SecurityAdvisory/*.php'
+
     packagist.twig.extension:
         public: true
         class: Packagist\WebBundle\Twig\PackagistExtension
@@ -182,6 +185,7 @@ services:
             - "@logger"
             - 'package:updates': '@updater_worker'
               'githubuser:migrate': '@github_user_migration_worker'
+              'security:advisory': '@security_advisory_worker'
 
     Packagist\WebBundle\Security\TwoFactorAuthManager:
         public: true
@@ -200,6 +204,10 @@ services:
             - "@snc_redis.cache_client"
         tags:
             - { name: kernel.event_subscriber }
+
+    Packagist\WebBundle\SecurityAdvisory\FriendsOfPhpSecurityAdvisoriesSource:
+        class: Packagist\WebBundle\SecurityAdvisory\FriendsOfPhpSecurityAdvisoriesSource
+        arguments: ["@doctrine"]
 
     scheduler:
         public: true
@@ -220,6 +228,15 @@ services:
         public: true
         class: Packagist\WebBundle\Service\GitHubUserMigrationWorker
         arguments: ["@logger", "@doctrine", "@guzzle_client", "%github.webhook_secret%"]
+
+    security_advisory_worker:
+        public: true
+        class: Packagist\WebBundle\Service\SecurityAdvisoryWorker
+        arguments:
+            - "@locker"
+            - "@logger"
+            - "@doctrine"
+            - 'sensiolabs/security-advisories': "@Packagist\\WebBundle\\SecurityAdvisory\\FriendsOfPhpSecurityAdvisoriesSource"
 
 parameters:
     security.exception_listener.class: Packagist\WebBundle\Security\ExceptionListener

--- a/src/Packagist/WebBundle/Resources/public/css/main.css
+++ b/src/Packagist/WebBundle/Resources/public/css/main.css
@@ -1100,9 +1100,17 @@ input:focus:invalid:focus, textarea:focus:invalid:focus, select:focus:invalid:fo
 .package .package-aside i:hover {
   color: #a5aab0;
 }
-.package .package-aside i.advisory-alert {
-    color: #ff4533;
+.package .package-aside a.advisory-alert {
     margin-left: -20px;
+}
+.package .package-aside a.advisory-alert:hover, .package .package-aside a.advisory-alert:active {
+    text-decoration: none;
+}
+.package .package-aside a.advisory-alert i {
+    color: #ff4533;
+}
+.package .package-aside a.advisory-alert:hover i {
+    color: #cd3729;
 }
 
 .package .details-toggler.open, .package .details-toggler.open a, .package .details-toggler.open i {

--- a/src/Packagist/WebBundle/Resources/public/css/main.css
+++ b/src/Packagist/WebBundle/Resources/public/css/main.css
@@ -1100,6 +1100,10 @@ input:focus:invalid:focus, textarea:focus:invalid:focus, select:focus:invalid:fo
 .package .package-aside i:hover {
   color: #a5aab0;
 }
+.package .package-aside i.advisory-alert {
+    color: #ff4533;
+    margin-left: -20px;
+}
 
 .package .details-toggler.open, .package .details-toggler.open a, .package .details-toggler.open i {
   background: #f28d1a;

--- a/src/Packagist/WebBundle/Resources/translations/messages.en.yml
+++ b/src/Packagist/WebBundle/Resources/translations/messages.en.yml
@@ -64,6 +64,8 @@ packages:
     suggesters: suggesters
     suggesters_title: Suggesters Packages
     from: "Packages from %vendor%"
+    security_advisory_title: Security Advisories
+    security_advisories: Security Advisories
 
 browse:
     packages: Packages

--- a/src/Packagist/WebBundle/Resources/views/package/security_advisories.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/package/security_advisories.html.twig
@@ -23,7 +23,7 @@
             {% if securityAdvisories|length %}
                 <ul class="packages list-unstyled">
                     {% for advisory in securityAdvisories %}
-                        <li class="row">
+                        <li class="row {% if advisory.id in matchingAdvisories %}selected{% endif %}">
                             <div class="col-xs-12 package-item">
                                 <div class="row">
                                     <div class="col-sm-8 col-lg-9">

--- a/src/Packagist/WebBundle/Resources/views/package/security_advisories.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/package/security_advisories.html.twig
@@ -11,7 +11,11 @@
         <div class="col-xs-12 package">
             <div class="package-header">
                 <h2 class="title">
-                    <a href="{{ path("view_package", {name: name}) }}">{{ name }}</a> {{ 'packages.security_advisories'|trans }}
+                    <a href="{{ path("view_package", {name: name}) }}">{{ name }}</a>
+                    {{ 'packages.security_advisories'|trans }}
+                    {% if version is defined %}
+                        for {{ version }}
+                    {% endif %}
                     <small>({{ count }})</small>
                 </h2>
             </div>
@@ -23,7 +27,7 @@
             {% if securityAdvisories|length %}
                 <ul class="packages list-unstyled">
                     {% for advisory in securityAdvisories %}
-                        <li class="row {% if advisory.id in matchingAdvisories %}selected{% endif %}">
+                        <li class="row">
                             <div class="col-xs-12 package-item">
                                 <div class="row">
                                     <div class="col-sm-8 col-lg-9">

--- a/src/Packagist/WebBundle/Resources/views/package/security_advisories.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/package/security_advisories.html.twig
@@ -1,0 +1,55 @@
+{% extends "PackagistWebBundle::layout.html.twig" %}
+
+{% set showSearchDesc = 'hide' %}
+
+{% block head_additions %}<meta name="robots" content="noindex, nofollow">{% endblock %}
+
+{% block title %}{{ 'packages.security_advisory_title'|trans }} - {{ name }} - {{ parent() }}{% endblock %}
+
+{% block content %}
+    <div class="row">
+        <div class="col-xs-12 package">
+            <div class="package-header">
+                <h2 class="title">
+                    <a href="{{ path("view_package", {name: name}) }}">{{ name }}</a> {{ 'packages.security_advisories'|trans }}
+                    <small>({{ count }})</small>
+                </h2>
+            </div>
+        </div>
+    </div>
+
+    <section class="row">
+        <section class="col-md-12">
+            {% if securityAdvisories|length %}
+                <ul class="packages list-unstyled">
+                    {% for advisory in securityAdvisories %}
+                        <li class="row">
+                            <div class="col-xs-12 package-item">
+                                <div class="row">
+                                    <div class="col-sm-8 col-lg-9">
+                                        <h4 class="font-bold">
+                                            <a href="{{ advisory.link }}">{{ advisory.title }}</a>
+                                        </h4>
+                                        {% if advisory.cve %}
+                                            <p>
+                                                <a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name={{ advisory.cve }}">{{ advisory.cve }}</a>
+                                            </p>
+                                        {% endif %}
+                                        <p>Affected version: {{ advisory.affectedVersions }}</p>
+                                    </div>
+                                    <div class="col-sm-4 col-lg-3">
+                                        <p>Reported by:<br/>{{ advisory.source }}</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% else %}
+                <div class="alert alert-danger">
+                    <p>{{ 'listing.no_security_advisories'|trans }}</p>
+                </div>
+            {% endif %}
+        </section>
+    </section>
+{% endblock %}

--- a/src/Packagist/WebBundle/Resources/views/package/version_list.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/package/version_list.html.twig
@@ -29,6 +29,7 @@
         <div class="hidden versions-expander">
             <i class="glyphicon glyphicon-chevron-down"></i>
         </div>
+    </div>
 
     {% if showUpdated is defined and showUpdated and package.getUpdatedAt() %}
         <div class="last-update">

--- a/src/Packagist/WebBundle/Resources/views/package/version_list.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/package/version_list.html.twig
@@ -10,6 +10,10 @@
                     {% endif -%}
                 </a>
 
+                {% if hasVersionSecurityAdvisories[version.id]|default(false) %}
+                    <i class="glyphicon glyphicon-alert advisory-alert" title="Version has security advisories"></i>
+                {% endif %}
+
                 {% if deleteVersionCsrfToken is defined and deleteVersionCsrfToken is not empty %}
                 <form class="delete-version" action="{{ path("delete_version", {"versionId": version.id}) }}" method="DELETE">
                     <input type="hidden" name="_token" value="{{ deleteVersionCsrfToken }}" />

--- a/src/Packagist/WebBundle/Resources/views/package/version_list.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/package/version_list.html.twig
@@ -11,7 +11,9 @@
                 </a>
 
                 {% if hasVersionSecurityAdvisories[version.id]|default(false) %}
-                    <i class="glyphicon glyphicon-alert advisory-alert" title="Version has security advisories"></i>
+                    <a class="advisory-alert" href="{{ path('view_package_advisories', {name: package.name, version: version.id}) }}">
+                        <i class="glyphicon glyphicon-alert " title="Version has security advisories"></i>
+                    </a>
                 {% endif %}
 
                 {% if deleteVersionCsrfToken is defined and deleteVersionCsrfToken is not empty %}

--- a/src/Packagist/WebBundle/Resources/views/package/view_package.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/package/view_package.html.twig
@@ -200,7 +200,7 @@
                             {% if securityAdvisories is defined %}
                                 <p>
                                     <span>
-                                        <a href="{{ path('view_package_security_advisories', {name: package.name}) }}" rel="nofollow">Security Advisories</a>:
+                                        <a href="{{ path('view_package_advisories', {name: package.name}) }}" rel="nofollow">Security</a>:
                                     </span>
                                     {{ securityAdvisories|number_format(0, '.', '&#8201;')|raw }}
                                 </p>

--- a/src/Packagist/WebBundle/Resources/views/package/view_package.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/package/view_package.html.twig
@@ -197,6 +197,14 @@
                                     {{ suggesters|number_format(0, '.', '&#8201;')|raw }}
                                 </p>
                             {% endif %}
+                            {% if securityAdvisories is defined %}
+                                <p>
+                                    <span>
+                                        <a href="{{ path('view_package_security_advisories', {name: package.name}) }}" rel="nofollow">Security Advisories</a>:
+                                    </span>
+                                    {{ securityAdvisories|number_format(0, '.', '&#8201;')|raw }}
+                                </p>
+                            {% endif %}
                             {% if package.gitHubStars is not null %}
                                 <p>
                                     <span>
@@ -286,7 +294,7 @@
                         {% include 'PackagistWebBundle:package:version_details.html.twig' with {version: expandedVersion} %}
                     {% endif %}
                 </div>
-                {% include 'PackagistWebBundle:package:version_list.html.twig' with {versions: versions, expandedId: expandedVersion.id, deleteVersionCsrfToken: deleteVersionCsrfToken|default(null)} %}
+                {% include 'PackagistWebBundle:package:version_list.html.twig' with {versions: versions, expandedId: expandedVersion.id, deleteVersionCsrfToken: deleteVersionCsrfToken|default(null), hasVersionSecurityAdvisories: hasVersionSecurityAdvisories} %}
             {% elseif package.crawledAt is null %}
                 <p class="col-xs-12">This package has not been crawled yet, some information is missing.</p>
             {% else %}

--- a/src/Packagist/WebBundle/SecurityAdvisory/FriendsOfPhpSecurityAdvisoriesSource.php
+++ b/src/Packagist/WebBundle/SecurityAdvisory/FriendsOfPhpSecurityAdvisoriesSource.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace Packagist\WebBundle\SecurityAdvisory;
+
+use Composer\Downloader\TransportException;
+use Composer\Downloader\ZipDownloader;
+use Composer\Factory;
+use Composer\IO\ConsoleIO;
+use Composer\Package\CompletePackage;
+use Composer\Package\Loader\ArrayLoader;
+use Packagist\WebBundle\Entity\Package;
+use Psr\Log\LoggerInterface;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Yaml\Yaml;
+
+class FriendsOfPhpSecurityAdvisoriesSource implements SecurityAdvisorySourceInterface
+{
+    public const SOURCE_NAME = self::SECURITY_PACKAGE;
+    public const SECURITY_PACKAGE = 'sensiolabs/security-advisories';
+
+    /** @var RegistryInterface */
+    private $doctrine;
+    /** @var LoggerInterface */
+    private $logger;
+
+    public function __construct(RegistryInterface $doctrine)
+    {
+        $this->doctrine = $doctrine;
+    }
+
+    public function getAdvisories(ConsoleIO $io): ?array
+    {
+        /** @var Package $package */
+        $package = $this->doctrine->getRepository(Package::class)->findOneBy(['name' => self::SECURITY_PACKAGE]);
+        if (!$package || !($version = $package->getVersion('9999999-dev'))) {
+            return [];
+        }
+
+        $config = Factory::createConfig($io);
+
+        $loader = new ArrayLoader(null, true);
+        /** @var CompletePackage $composerPackage */
+        $composerPackage = $loader->load($version->toArray([]), CompletePackage::class);
+
+        $localDir = null;
+        $advisories = null;
+        try {
+            $rfs = Factory::createRemoteFilesystem($io, $config, []);
+            $downloader = new ZipDownloader($io, $config, null, null, null, $rfs);
+            $downloader->setOutputProgress(false);
+            $localDir = sys_get_temp_dir() . '/' . uniqid('friends-of-php-advisories', true);
+            $downloader->download($composerPackage, $localDir);
+
+            $finder = new Finder();
+            $finder->name('*.yaml');
+            $advisories = [];
+            /** @var \SplFileInfo $file */
+            foreach ($finder->in($localDir) as $file) {
+                $content = Yaml::parse(file_get_contents($file->getRealPath()));
+                $advisories[] = RemoteSecurityAdvisory::createFromFriendsOfPhp($file->getRelativePathname(), $content);
+            }
+        } catch (TransportException $e) {
+            $this->logger->error('Failed to download "sensiolabs/security-advisories" zip file', [
+                'exception' => $e,
+            ]);
+        } finally {
+            if ($localDir) {
+                $filesystem = new Filesystem();
+                $filesystem->remove($localDir);
+            }
+        }
+
+        return $advisories;
+    }
+}

--- a/src/Packagist/WebBundle/SecurityAdvisory/FriendsOfPhpSecurityAdvisoriesSource.php
+++ b/src/Packagist/WebBundle/SecurityAdvisory/FriendsOfPhpSecurityAdvisoriesSource.php
@@ -17,7 +17,7 @@ use Symfony\Component\Yaml\Yaml;
 
 class FriendsOfPhpSecurityAdvisoriesSource implements SecurityAdvisorySourceInterface
 {
-    public const SOURCE_NAME = self::SECURITY_PACKAGE;
+    public const SOURCE_NAME = 'FriendsOfPHP/security-advisories';
     public const SECURITY_PACKAGE = 'sensiolabs/security-advisories';
 
     /** @var RegistryInterface */
@@ -50,7 +50,7 @@ class FriendsOfPhpSecurityAdvisoriesSource implements SecurityAdvisorySourceInte
             $rfs = Factory::createRemoteFilesystem($io, $config, []);
             $downloader = new ZipDownloader($io, $config, null, null, null, $rfs);
             $downloader->setOutputProgress(false);
-            $localDir = sys_get_temp_dir() . '/' . uniqid('friends-of-php-advisories', true);
+            $localDir = sys_get_temp_dir() . '/' . uniqid(self::SOURCE_NAME, true);
             $downloader->download($composerPackage, $localDir);
 
             $finder = new Finder();
@@ -62,7 +62,7 @@ class FriendsOfPhpSecurityAdvisoriesSource implements SecurityAdvisorySourceInte
                 $advisories[] = RemoteSecurityAdvisory::createFromFriendsOfPhp($file->getRelativePathname(), $content);
             }
         } catch (TransportException $e) {
-            $this->logger->error('Failed to download "sensiolabs/security-advisories" zip file', [
+            $this->logger->error(sprintf('Failed to download "%s" zip file', self::SECURITY_PACKAGE), [
                 'exception' => $e,
             ]);
         } finally {

--- a/src/Packagist/WebBundle/SecurityAdvisory/RemoteSecurityAdvisory.php
+++ b/src/Packagist/WebBundle/SecurityAdvisory/RemoteSecurityAdvisory.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+namespace Packagist\WebBundle\SecurityAdvisory;
+
+class RemoteSecurityAdvisory
+{
+    /** @var string */
+    private $id;
+    /** @var string */
+    private $title;
+    /** @var string */
+    private $packageName;
+    /** @var string */
+    private $affectedVersions;
+    /** @var string */
+    private $link;
+    /** @var ?string */
+    private $cve;
+
+    public function __construct(string $id, string $title, string $packageName, string $affectedVersions, string $link, $cve)
+    {
+        $this->id = $id;
+        $this->title = $title;
+        $this->packageName = $packageName;
+        $this->affectedVersions = $affectedVersions;
+        $this->link = $link;
+        $this->cve = $cve;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getPackageName(): string
+    {
+        return $this->packageName;
+    }
+
+    public function getAffectedVersions(): string
+    {
+        return $this->affectedVersions;
+    }
+
+    public function getLink(): string
+    {
+        return $this->link;
+    }
+
+    public function getCve(): ?string
+    {
+        return $this->cve;
+    }
+
+    public static function createFromFriendsOfPhp(string $fileNameWithPath, array $info): RemoteSecurityAdvisory
+    {
+        $affectedVersion = implode('|', array_map(function (array $branchInfo) {
+            return implode(',', $branchInfo['versions']);
+        }, $info['branches']));
+
+        return new RemoteSecurityAdvisory(
+            $fileNameWithPath,
+            $info['title'],
+            str_replace('composer://', '', $info['reference']),
+            $affectedVersion,
+            $info['link'],
+            $info['cve'] ?? null
+        );
+    }
+}

--- a/src/Packagist/WebBundle/SecurityAdvisory/SecurityAdvisorySourceInterface.php
+++ b/src/Packagist/WebBundle/SecurityAdvisory/SecurityAdvisorySourceInterface.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Packagist\WebBundle\SecurityAdvisory;
+
+use Composer\IO\ConsoleIO;
+
+interface SecurityAdvisorySourceInterface
+{
+    /**
+     * @return null|RemoteSecurityAdvisory[]
+     */
+    public function getAdvisories(ConsoleIO $io): ?array;
+}

--- a/src/Packagist/WebBundle/Service/Locker.php
+++ b/src/Packagist/WebBundle/Service/Locker.php
@@ -27,6 +27,20 @@ class Locker
         $this->getConn()->fetchColumn('SELECT RELEASE_LOCK(:id)', ['id' => 'package_update_'.$packageId]);
     }
 
+    public function lockSecurityAdvisory(string $source, int $timeout = 0)
+    {
+        $this->getConn()->connect('master');
+
+        return (bool) $this->getConn()->fetchColumn('SELECT GET_LOCK(:id, :timeout)', ['id' => 'security_advisory_'.$source, 'timeout' => $timeout]);
+    }
+
+    public function unlockSecurityAdvisory(string $source)
+    {
+        $this->getConn()->connect('master');
+
+        $this->getConn()->fetchColumn('SELECT RELEASE_LOCK(:id)', ['id' => 'security_advisory_'.$source]);
+    }
+
     public function lockCommand(string $command, int $timeout = 0)
     {
         $this->getConn()->connect('master');

--- a/src/Packagist/WebBundle/Service/Scheduler.php
+++ b/src/Packagist/WebBundle/Service/Scheduler.php
@@ -61,6 +61,11 @@ class Scheduler
         return $this->createJob('githubuser:migrate', ['id' => $userId, 'old_scope' => $oldScope, 'new_scope' => $newScope], $userId);
     }
 
+    public function scheduleSecurityAdvisory(string $source, \DateTimeInterface $executeAfter = null): Job
+    {
+        return $this->createJob('security:advisory', ['source' => $source], null, $executeAfter);
+    }
+
     private function getPendingUpdateJob(int $packageId, $updateEqualRefs = false, $deleteBefore = false)
     {
         $result = $this->doctrine->getManager()->getConnection()->fetchAssoc(

--- a/src/Packagist/WebBundle/Service/SecurityAdvisoryWorker.php
+++ b/src/Packagist/WebBundle/Service/SecurityAdvisoryWorker.php
@@ -1,0 +1,85 @@
+<?php declare(strict_types=1);
+
+namespace Packagist\WebBundle\Service;
+
+use Composer\Console\HtmlOutputFormatter;
+use Composer\Factory;
+use Composer\IO\BufferIO;
+use Packagist\WebBundle\Entity\Job;
+use Packagist\WebBundle\Entity\SecurityAdvisory;
+use Packagist\WebBundle\SecurityAdvisory\SecurityAdvisorySourceInterface;
+use Psr\Log\LoggerInterface;
+use Seld\Signal\SignalHandler;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SecurityAdvisoryWorker
+{
+    /** @var Locker */
+    private $locker;
+    /** @var LoggerInterface */
+    private $logger;
+    /** @var RegistryInterface */
+    private $doctrine;
+    /** @var SecurityAdvisorySourceInterface[] */
+    private $sources;
+
+    public function __construct(Locker $locker, LoggerInterface $logger, RegistryInterface $doctrine, array $sources)
+    {
+        $this->locker = $locker;
+        $this->sources = $sources;
+        $this->logger = $logger;
+        $this->doctrine = $doctrine;
+    }
+
+    public function process(Job $job, SignalHandler $signal): array
+    {
+        $sourceName = $job->getPayload()['source'];
+        $lockAcquired = $this->locker->lockSecurityAdvisory($sourceName);
+        if (!$lockAcquired) {
+            return ['status' => Job::STATUS_RESCHEDULE, 'after' => new \DateTime('+5 minutes')];
+        }
+
+        $io = new BufferIO('', OutputInterface::VERBOSITY_VERY_VERBOSE, new HtmlOutputFormatter(Factory::createAdditionalStyles()));
+
+        /** @var SecurityAdvisorySourceInterface $source */
+        $source = $this->sources[$sourceName];
+        $remoteAdvisories = $source->getAdvisories($io);
+        if (null === $remoteAdvisories) {
+            $this->logger->info('Security advisory update failed, skipping', ['source' => $source]);
+
+            return ['status' => Job::STATUS_ERRORED, 'message' => 'Security advisory update failed, skipped'];
+        }
+
+        /** @var SecurityAdvisory[] $existingAdvisoryMap */
+        $existingAdvisoryMap = [];
+        /** @var SecurityAdvisory[] $existingAdvisories */
+        $existingAdvisories = $this->doctrine->getRepository(SecurityAdvisory::class)->findBy(['source' => $sourceName]);
+        foreach ($existingAdvisories as $advisory) {
+            $existingAdvisoryMap[$advisory->getRemoteId()] = $advisory;
+        }
+
+        foreach ($remoteAdvisories as $remoteAdvisory) {
+            if (isset($existingAdvisoryMap[$remoteAdvisory->getId()])) {
+                $existingAdvisoryMap[$remoteAdvisory->getId()]->updateAdvisory($remoteAdvisory);
+                unset($existingAdvisoryMap[$remoteAdvisory->getId()]);
+            } else {
+                $this->doctrine->getManager()->persist(new SecurityAdvisory($remoteAdvisory, $sourceName));
+            }
+        }
+
+        foreach ($existingAdvisoryMap as $advisory) {
+            $this->doctrine->getManager()->remove($advisory);
+        }
+
+        $this->doctrine->getManager()->flush();
+
+        $this->locker->unlockSecurityAdvisory($sourceName);
+
+        return [
+            'status' => Job::STATUS_COMPLETED,
+            'message' => 'Update of '.$sourceName.' security advisory complete',
+            'details' => '<pre>'.$io->getOutput().'</pre>',
+        ];
+    }
+}

--- a/src/Packagist/WebBundle/Service/UpdaterWorker.php
+++ b/src/Packagist/WebBundle/Service/UpdaterWorker.php
@@ -2,6 +2,7 @@
 
 namespace Packagist\WebBundle\Service;
 
+use Packagist\WebBundle\SecurityAdvisory\FriendsOfPhpSecurityAdvisoriesSource;
 use Packagist\WebBundle\Service\Scheduler;
 use Psr\Log\LoggerInterface;
 use Composer\Package\Loader\ArrayLoader;
@@ -243,6 +244,10 @@ class UpdaterWorker
             throw $e;
         } finally {
             $this->locker->unlockPackageUpdate($id);
+        }
+
+        if ($packageName === FriendsOfPhpSecurityAdvisoriesSource::SECURITY_PACKAGE) {
+            $this->scheduler->scheduleSecurityAdvisory(FriendsOfPhpSecurityAdvisoriesSource::SOURCE_NAME);
         }
 
         return [

--- a/src/Packagist/WebBundle/Tests/SecurityAdvisory/RemoteSecurityAdvisoryTest.php
+++ b/src/Packagist/WebBundle/Tests/SecurityAdvisory/RemoteSecurityAdvisoryTest.php
@@ -28,7 +28,5 @@ class RemoteSecurityAdvisoryTest extends TestCase
         $this->assertNull($advisory->getCve());
         $this->assertSame('<1.2', $advisory->getAffectedVersions());
         $this->assertSame('3f/pygmentize', $advisory->getPackageName());
-
-
     }
 }

--- a/src/Packagist/WebBundle/Tests/SecurityAdvisory/RemoteSecurityAdvisoryTest.php
+++ b/src/Packagist/WebBundle/Tests/SecurityAdvisory/RemoteSecurityAdvisoryTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Packagist\WebBundle\Tests\SecurityAdvisory;
+
+use Packagist\WebBundle\SecurityAdvisory\RemoteSecurityAdvisory;
+use PHPUnit\Framework\TestCase;
+
+class RemoteSecurityAdvisoryTest extends TestCase
+{
+    public function testCreateFromFriendsOfPhp(): void
+    {
+        $advisory = RemoteSecurityAdvisory::createFromFriendsOfPhp('3f/pygmentize/2017-05-15.yaml', [
+            'title' => 'Remote Code Execution',
+            'link' => 'https://github.com/dedalozzo/pygmentize/issues/1',
+            'cve' => null,
+            'branches' => [
+                '1.x' => [
+                    'time' => '2017-05-15 09:09:00',
+                    'versions' => ['<1.2'],
+                ],
+            ],
+            'reference' => 'composer://3f/pygmentize'
+        ]);
+
+        $this->assertSame('3f/pygmentize/2017-05-15.yaml', $advisory->getId());
+        $this->assertSame('Remote Code Execution', $advisory->getTitle());
+        $this->assertSame('https://github.com/dedalozzo/pygmentize/issues/1', $advisory->getLink());
+        $this->assertNull($advisory->getCve());
+        $this->assertSame('<1.2', $advisory->getAffectedVersions());
+        $this->assertSame('3f/pygmentize', $advisory->getPackageName());
+
+
+    }
+}

--- a/src/Packagist/WebBundle/Tests/SecurityAdvisoryWorkerTest.php
+++ b/src/Packagist/WebBundle/Tests/SecurityAdvisoryWorkerTest.php
@@ -1,0 +1,146 @@
+<?php declare(strict_types=1);
+
+namespace Packagist\WebBundle\Tests;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityRepository;
+use Packagist\WebBundle\Entity\Job;
+use Packagist\WebBundle\Entity\SecurityAdvisory;
+use Packagist\WebBundle\SecurityAdvisory\RemoteSecurityAdvisory;
+use Packagist\WebBundle\SecurityAdvisory\SecurityAdvisorySourceInterface;
+use Packagist\WebBundle\Service\Locker;
+use Packagist\WebBundle\Service\SecurityAdvisoryWorker;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Seld\Signal\SignalHandler;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+
+class SecurityAdvisoryWorkerTest extends TestCase
+{
+    /** @var SecurityAdvisoryWorker */
+    private $worker;
+    /** @var SecurityAdvisorySourceInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private $source;
+    /** @var EntityManager&\PHPUnit\Framework\MockObject\MockObject */
+    private $em;
+    /** @var \PHPUnit\Framework\MockObject\MockObject */
+    private $securityAdvisoryRepository;
+
+    protected function setUp(): void
+    {
+        $this->source = $this->getMockBuilder(SecurityAdvisorySourceInterface::class)->disableOriginalConstructor()->getMock();
+        $locker = $this->getMockBuilder(Locker::class)->disableOriginalConstructor()->getMock();
+        $doctrine = $this->getMockBuilder(RegistryInterface::class)->disableOriginalConstructor()->getMock();
+        $this->worker = new SecurityAdvisoryWorker($locker, new NullLogger(), $doctrine, ['test' => $this->source]);
+
+        $this->em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
+
+        $doctrine
+            ->method('getManager')
+            ->willReturn($this->em);
+
+        $locker
+            ->method('lockSecurityAdvisory')
+            ->willReturn(true);
+
+        $this->securityAdvisoryRepository = $this->getMockBuilder(EntityRepository::class)->disableOriginalConstructor()->getMock();
+
+        $doctrine
+            ->method('getRepository')
+            ->with($this->equalTo(SecurityAdvisory::class))
+            ->willReturn($this->securityAdvisoryRepository);
+    }
+
+    public function testProcess(): void
+    {
+        $advisory1Existing = $this->getMockBuilder(RemoteSecurityAdvisory::class)->disableOriginalConstructor()->getMock();
+        $advisory2New = $this->getMockBuilder(RemoteSecurityAdvisory::class)->disableOriginalConstructor()->getMock();
+        $advisories = [
+            $advisory1Existing,
+            $advisory2New,
+        ];
+
+        $advisory1Existing
+            ->method('getId')
+            ->willReturn('remote-id-1');
+
+        $existingAdvisory1 = $this->getMockBuilder(SecurityAdvisory::class)->disableOriginalConstructor()->getMock();
+        $existingAdvisory1
+            ->method('getRemoteId')
+            ->willReturn('remote-id-1');
+
+        $existingAdvisory1
+            ->expects($this->once())
+            ->method('updateAdvisory')
+            ->with($this->equalTo($advisory1Existing));
+
+        $existingAdvisory2ToBeDeleted = $this->getMockBuilder(SecurityAdvisory::class)->disableOriginalConstructor()->getMock();
+        $existingAdvisory2ToBeDeleted
+            ->method('getRemoteId')
+            ->willReturn('to-be-deleted');
+
+        $this->source
+            ->expects($this->once())
+            ->method('getAdvisories')
+            ->willReturn($advisories);
+
+        $this->em
+            ->expects($this->once())
+            ->method('persist');
+
+        $this->em
+            ->expects($this->once())
+            ->method('remove')
+            ->with($this->equalTo($existingAdvisory2ToBeDeleted));
+
+        $this->securityAdvisoryRepository
+            ->method('findBy')
+            ->with($this->equalTo(['source' => 'test']))
+            ->willReturn([$existingAdvisory1, $existingAdvisory2ToBeDeleted]);
+
+        $job = new Job();
+        $job->setPayload(['source' => 'test']);
+        $this->worker->process($job, SignalHandler::create());
+    }
+
+    public function testProcessNone(): void
+    {
+        $this->source
+            ->expects($this->once())
+            ->method('getAdvisories')
+            ->willReturn([]);
+
+        $this->em
+            ->expects($this->never())
+            ->method('persist');
+
+        $this->securityAdvisoryRepository
+            ->method('findBy')
+            ->with($this->equalTo(['source' => 'test']))
+            ->willReturn([]);
+
+        $job = new Job();
+        $job->setPayload(['source' => 'test']);
+        $this->worker->process($job, SignalHandler::create());
+    }
+
+    public function testProcessFailed(): void
+    {
+        $this->source
+            ->expects($this->once())
+            ->method('getAdvisories')
+            ->willReturn(null);
+
+        $this->em
+            ->expects($this->never())
+            ->method('flush');
+
+        $this->securityAdvisoryRepository
+            ->expects($this->never())
+            ->method('findBy');
+
+        $job = new Job();
+        $job->setPayload(['source' => 'test']);
+        $this->worker->process($job, SignalHandler::create());
+    }
+}


### PR DESCRIPTION
This pull request integrates security advisories into packagist.org. It is built in a way to additional sources can be integrated.

**Users are able to:**
* see how many advisories are available for every package
* see which versions of a package are affected by one or more advisory
* see detailed information about advisories for a package
* query the data via an API

**Adjustments to the package view page:**
* number of security advisories
* red icon in the version list to see which versions are affected
<img width="923" alt="Screenshot 2019-11-23 at 13 22 04" src="https://user-images.githubusercontent.com/442056/69478630-f877bf00-0df4-11ea-9079-0938cb4db7cf.png">


**New package security advisory page**
* list all advisories for a package
* via the query param `version` matching advisories will be highlighted
<img width="1204" alt="Screenshot 2019-11-23 at 13 24 56" src="https://user-images.githubusercontent.com/442056/69478627-f281de00-0df4-11ea-80d9-1e9e30edec2a.png">
