### PR TITLE
Add api_url to popular endpoint in json response payload

### DIFF
--- a/src/Packagist/WebBundle/Controller/ExploreController.php
+++ b/src/Packagist/WebBundle/Controller/ExploreController.php
@@ -125,11 +125,13 @@ class ExploreController extends Controller
             /** @var Package $package */
             foreach ($packages as $package) {
                 $url = $this->generateUrl('view_package', array('name' => $package->getName()), UrlGeneratorInterface::ABSOLUTE_URL);
+                $apiUrl = $this->generateUrl('view_package', array('name' => $package->getName(), '_format' => 'json'), UrlGeneratorInterface::ABSOLUTE_URL);
 
                 $result['packages'][] = array(
                     'name' => $package->getName(),
                     'description' => $package->getDescription() ?: '',
                     'url' => $url,
+                    'api_url' => $apiUrl,
                     'downloads' => $data['meta']['downloads'][$package->getId()],
                     'favers' => $data['meta']['favers'][$package->getId()],
                 );


### PR DESCRIPTION
```
{
    "packages": [
        {
            "api_url": "http://127.0.0.1:8000/app_dev.php/packages/composer/composer.json",
            "description": "",
            "downloads": 0,
            "favers": 0,
            "name": "composer/composer",
            "url": "http://127.0.0.1:8000/app_dev.php/packages/composer/composer"
        }
    ],
    "total": 1
}

```

This helps clients to avoid generating the api url on their side.