### PR TITLE
[WIP] Funding information for packages

### DIFF
--- a/src/Packagist/WebBundle/Entity/Package.php
+++ b/src/Packagist/WebBundle/Entity/Package.php
@@ -78,6 +78,11 @@ class Package
     private $readme;
 
     /**
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $funding;
+
+    /**
      * @ORM\Column(type="integer", nullable=true, name="github_stars")
      */
     private $gitHubStars;
@@ -493,6 +498,22 @@ class Package
     public function getReadme()
     {
         return $this->readme;
+    }
+
+    /**
+     * @param array|null $funding
+     */
+    public function setFunding($funding)
+    {
+        $this->funding = $funding ? json_encode($funding) : null;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getFunding()
+    {
+        return json_decode($this->funding, true);
     }
 
     /**

--- a/src/Packagist/WebBundle/Resources/views/package/view_package.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/package/view_package.html.twig
@@ -172,6 +172,14 @@
                             {% if version and version.support.docs is defined %}
                                 <p><a rel="nofollow noopener external noindex" href="{{ version.support.docs }}">Documentation</a></p>
                             {% endif %}
+                            {% if package.funding != null and (not package.isSuspect() or hasActions) %}
+                                <p>
+                                    Fund this package on
+                                    {% for fundingOption in package.funding %}
+                                        <a rel="nofollow noopener external noindex" href="{{ fundingOption.url }}">{{ fundingOption.type }}</a>
+                                    {% endfor %}
+                                </p>
+                            {% endif %}
                         </div>
 
                         <div class="facts col-xs-12 col-sm-6 col-md-12">


### PR DESCRIPTION
This initial idea for supporting GitHub FUNDING.yml files treats them similar to the README: The data is retrieved on package update and stored once per package based on the default branch contents. Unfortunately GitHub does not make the FUNDING information available through its API currently, so we need to manually parse it.

We should add support for specifying funding information in composer.json. This requires a new composer release adding the additional section (should be an array of objects with a type/url each, potentially allowing it to be just one object if you don't need multiple entries). We could then fall back to the FUNDING file only in cases where this information is not available in composer.json. Ideally this would happen in Composer, so this would work even for users of direct github URLs rather than just Packagist. However reading the FUNDING file currently requires a YAML parser which we don't want to add to Composer.

If we switch to loading the funding info from composer.json, it's more likely it would be stored in the per-version JSON object "support". It's unclear to me exactly how we would then best reconcile per-version composer.json funding info with per-package FUNDING.yml data.

Further if we want to support this in composer.json the information needs to be made available as part of the regular dumped JSON package data, so the FUNDING file info would need to be added to this as well if there is no funding data in composer.json files. For now this PR has no API support at all, but at least adding it to the regular public non-Composer API responses would be straight forward.

*Note: PR is untested, just a proof of concept for now, UI needs an update before this is usable.*