### PR TITLE
Display funding information for packages and expose funding info to Composer

### DIFF
--- a/src/Packagist/WebBundle/Entity/Version.php
+++ b/src/Packagist/WebBundle/Entity/Version.php
@@ -180,7 +180,7 @@ class Version
     private $support;
 
     /**
-     * @ORM\Column(type="text", nullable=true)
+     * @ORM\Column(type="json", nullable=true)
      */
     private $funding;
 
@@ -270,7 +270,7 @@ class Version
         if ($serializeForApi && $this->getSupport()) {
             $data['support'] = $this->getSupport();
         }
-        if ($serializeForApi && $this->getFunding()) {
+        if ($this->getFunding()) {
             $data['funding'] = $this->getFunding();
         }
         if ($this->getReleasedAt()) {
@@ -329,7 +329,6 @@ class Version
             $array['support'] = $this->getSupport();
             ksort($array['support']);
         }
-        // TODO do we need to do something for funding here? sort by type/url?
 
         return $array;
     }
@@ -632,7 +631,17 @@ class Version
      */
     public function setFunding($funding)
     {
-        $this->funding = $funding ? json_encode($funding) : null;
+        // sort records when storing so to help the V2 metadata compression algo
+        if ($funding) {
+            usort($funding, function ($a, $b) {
+                $keyA = ($a['type'] ?? '') . ($a['url'] ?? '');
+                $keyB = ($b['type'] ?? '') . ($b['url'] ?? '');
+                
+                return $keyA <=> $keyB;
+            });
+        }
+
+        $this->funding = $funding;
     }
 
     /**
@@ -642,7 +651,7 @@ class Version
      */
     public function getFunding()
     {
-        return $this->funding ? json_decode($this->funding, true) : null;
+        return $this->funding;
     }
 
     /**

--- a/src/Packagist/WebBundle/Entity/Version.php
+++ b/src/Packagist/WebBundle/Entity/Version.php
@@ -180,6 +180,11 @@ class Version
     private $support;
 
     /**
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $funding;
+
+    /**
      * @ORM\Column(name="authors", type="json", nullable=true)
      */
     private $authorJson;
@@ -265,6 +270,9 @@ class Version
         if ($serializeForApi && $this->getSupport()) {
             $data['support'] = $this->getSupport();
         }
+        if ($serializeForApi && $this->getFunding()) {
+            $data['funding'] = $this->getFunding();
+        }
         if ($this->getReleasedAt()) {
             $data['time'] = $this->getReleasedAt()->format('Y-m-d\TH:i:sP');
         }
@@ -321,6 +329,7 @@ class Version
             $array['support'] = $this->getSupport();
             ksort($array['support']);
         }
+        // TODO do we need to do something for funding here? sort by type/url?
 
         return $array;
     }
@@ -614,6 +623,26 @@ class Version
     public function getSupport()
     {
         return json_decode($this->support, true);
+    }
+
+    /**
+     * Set Funding
+     *
+     * @param array $funding
+     */
+    public function setFunding($funding)
+    {
+        $this->funding = $funding ? json_encode($funding) : null;
+    }
+
+    /**
+     * Get funding
+     *
+     * @return array|null
+     */
+    public function getFunding()
+    {
+        return json_decode($this->funding, true);
     }
 
     /**

--- a/src/Packagist/WebBundle/Entity/Version.php
+++ b/src/Packagist/WebBundle/Entity/Version.php
@@ -642,7 +642,7 @@ class Version
      */
     public function getFunding()
     {
-        return json_decode($this->funding, true);
+        return $this->funding ? json_decode($this->funding, true) : null;
     }
 
     /**

--- a/src/Packagist/WebBundle/Package/Updater.php
+++ b/src/Packagist/WebBundle/Package/Updater.php
@@ -339,6 +339,7 @@ class Updater
         $version->setBinaries($data->getBinaries());
         $version->setIncludePaths($data->getIncludePaths());
         $version->setSupport($data->getSupport());
+        $version->setFunding($data->getFunding());
 
         if ($data->getKeywords()) {
             $keywords = array();

--- a/src/Packagist/WebBundle/Resources/views/package/view_package.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/package/view_package.html.twig
@@ -175,6 +175,16 @@
                         </div>
 
                         <div class="facts col-xs-12 col-sm-6 col-md-12">
+                            {% if version and version.funding is defined and version.funding|length > 0 %}
+                                <p>
+                                    Fund package maintenance!
+                                    {% for fundingOption in version.funding %}
+                                        <br>&raquo; <a rel="nofollow noopener external noindex" href="{{ fundingOption.url }}">{{ fundingOption.type == 'custom' ? fundingOption.url : fundingOption.type }}</a>
+                                    {% endfor %}
+                            {% endif %}
+                        </div>
+
+                        <div class="facts col-xs-12 col-sm-6 col-md-12">
                             <p>
                                 <span>
                                     <a href="{{ path('view_package_stats', {name: package.name}) }}" rel="nofollow">Installs</a>:


### PR DESCRIPTION
Requires funding support (https://github.com/composer/composer/pull/8453) to be merged into Composer and the composer/composer dep to be updated before this can be merged.

Displaying of funding info in the UI is pretty basic for now. It simply lists all links in the details section. Maybe someone can come up with a nicer way to display this? Maybe a button in that section that is a bit more obvious and then a modal with all the options?

<img width="899" alt="Screenshot_20191129_001636" src="https://user-images.githubusercontent.com/154844/69835140-90cfd280-123f-11ea-8fd2-225bafa1b636.png">

*Requires the addition of a funding text column to the version table prior to deployment.*