### PR TITLE
SecurityAdvisory: fix reported date when only year is available

### DIFF
--- a/src/Packagist/WebBundle/SecurityAdvisory/RemoteSecurityAdvisory.php
+++ b/src/Packagist/WebBundle/SecurityAdvisory/RemoteSecurityAdvisory.php
@@ -78,8 +78,11 @@ class RemoteSecurityAdvisory
     public static function createFromFriendsOfPhp(string $fileNameWithPath, array $info): RemoteSecurityAdvisory
     {
         $date = null;
+        $fallbackYearDate = null;
         if (preg_match('#(\d{4}-\d{2}-\d{2})#', basename($fileNameWithPath), $matches)) {
             $date = new \DateTime($matches[1] . ' 00:00:00');
+        } elseif (preg_match('#CVE-(2\d{3})-\d#', basename($fileNameWithPath), $matches)) {
+            $fallbackYearDate = new \DateTime($matches[1] . '-01-01 00:00:00');
         }
 
         $affectedVersions = [];
@@ -97,6 +100,8 @@ class RemoteSecurityAdvisory
         if (!$date) {
             if ($lowestBranchDate) {
                 $date = $lowestBranchDate;
+            } elseif ($fallbackYearDate) {
+                $date = $fallbackYearDate;
             } else {
                 $date = (new \DateTime())->setTime(0, 0, 0);
             }

--- a/src/Packagist/WebBundle/Tests/SecurityAdvisory/RemoteSecurityAdvisoryTest.php
+++ b/src/Packagist/WebBundle/Tests/SecurityAdvisory/RemoteSecurityAdvisoryTest.php
@@ -32,4 +32,43 @@ class RemoteSecurityAdvisoryTest extends TestCase
         $this->assertSame('2017-05-15 00:00:00', $advisory->getDate()->format('Y-m-d H:i:s'));
         $this->assertSame(SecurityAdvisory::PACKAGIST_ORG, $advisory->getComposerRepository());
     }
+
+    public function testCreateFromFriendsOfPhpOnlyYearAvailable(): void
+    {
+        $advisory = RemoteSecurityAdvisory::createFromFriendsOfPhp('erusev/parsedown/CVE-2019-10905.yaml', [
+            'title' => 'Class-Name Injection',
+            'link' => 'https://github.com/erusev/parsedown/issues/699',
+            'cve' => 'CVE-2019-10905',
+            'branches' => [
+                '1.0.x' => [
+                    'time' => null,
+                    'versions' => ['<1.7.2'],
+                ],
+
+            ],
+            'reference' => 'composer://erusev/parsedown'
+        ]);
+
+        $this->assertSame('2019-01-01 00:00:00', $advisory->getDate()->format('Y-m-d H:i:s'));
+    }
+
+    public function testCreateFromFriendsOfPhpOnlyYearButBranchDatesAvailable(): void
+    {
+        $advisory = RemoteSecurityAdvisory::createFromFriendsOfPhp('magento/magento1ee/CVE-2019-8114.yaml', [
+            'title' => 'PRODSECBUG-2462: Remote code execution via file upload in admin import feature',
+            'link' => 'https://magento.com/security/patches/magento-2.3.3-and-2.2.10-security-update',
+            'cve' => 'CVE-2019-8114',
+            'branches' => [
+                '1' => [
+                    'time' => 1570492800,
+                    'versions' => ['>=1', '<1.14.4.3'],
+                ],
+
+            ],
+            'reference' => 'composer://magento/magento1ee',
+            'composer-repository' => false,
+        ]);
+
+        $this->assertSame('2019-10-08 00:00:00', $advisory->getDate()->format('Y-m-d H:i:s'));
+    }
 }


### PR DESCRIPTION
Currently if a security advisory only has a year set and no branch has a fix date then this falls back to the current date which means every time we reimport them from the git repository the reportedAt date gets updated.

Settings this to Year-01-01 for now to avoid updating that date all the time.