### PR TITLE
Fix funding links overflowing the sidebar

### DIFF
--- a/src/Packagist/WebBundle/Resources/public/css/main.css
+++ b/src/Packagist/WebBundle/Resources/public/css/main.css
@@ -1007,7 +1007,8 @@ input:focus:invalid:focus, textarea:focus:invalid:focus, select:focus:invalid:fo
   font-size: 35px;
   margin-top: 5px;
 }
-.package .details .canonical {
+.package .details .canonical,
+.package .funding p {
   text-overflow: ellipsis;
   overflow: hidden;
   width: 100%;


### PR DESCRIPTION
Currently, long funding links can overflow the sidebar:

![image](https://user-images.githubusercontent.com/202034/78836834-e15ef580-79c0-11ea-91e6-1a2298069484.png)

Applying the same styling as the `.details` section fixes this:

![image](https://user-images.githubusercontent.com/202034/78836897-ff2c5a80-79c0-11ea-8cc9-0c2f46d88958.png)
