### PR TITLE
Login: add brute force protection

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -26,6 +26,7 @@ class AppKernel extends Kernel
             new Nelmio\CorsBundle\NelmioCorsBundle(),
             new Scheb\TwoFactorBundle\SchebTwoFactorBundle(),
             new Endroid\QrCodeBundle\EndroidQrCodeBundle(),
+            new Beelab\Recaptcha2Bundle\BeelabRecaptcha2Bundle(),
             new Packagist\WebBundle\PackagistWebBundle(),
         );
 

--- a/app/Resources/HWIOAuthBundle/views/Connect/login.html.twig
+++ b/app/Resources/HWIOAuthBundle/views/Connect/login.html.twig
@@ -18,15 +18,19 @@
             <div class="col-md-6">
                 {% if error is defined and error is not empty %}
                     <div class="alert alert-warning">
+                    {% if error.messageKey is defined %}
+                        {{ error.messageKey|trans(error.messageData) }}
+                    {% else %}
                         {{ error }}
+                    {% endif %}
                     </div>
                 {% endif %}
 
-                <form action="{{ path('login_check') }}" method="POST">
+                <form action="{{ path('login') }}" method="POST" id="page_login">
                     <div class="form-group clearfix">
                         <label for="username">{{ 'security.login.username'|trans({}, 'FOSUserBundle') }}</label>
                         <div class="input-group clearfix">
-                            <input class="form-control" type="text" id="username" name="_username">
+                            <input class="form-control" type="text" id="username" name="_username" value="{{ lastUsername|default('') }}">
                             <span class="input-group-addon"><span class="icon-user"></span></span>
                         </div>
                     </div>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -34,6 +34,7 @@ twig:
     globals:
         google_analytics: '%google_analytics%'
         packagist_host: '%packagist_host%'
+        recaptcha_site_key: '%recaptcha_site_key%'
         algolia:
           app_id: '%algolia.app_id%'
           search_key: '%algolia.search_key%'
@@ -184,3 +185,8 @@ sensio_framework_extra:
 
 endroid_qr_code:
     background_color: { r: 250, g: 250, b: 250 }
+
+beelab_recaptcha2:
+    enabled: '%recaptcha_enabled%'
+    site_key: '%recaptcha_site_key%'
+    secret: '%recaptcha_secret%'

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -88,6 +88,8 @@ nelmio_security:
                 - 'unsafe-eval'
                 - 'https://cdn.jsdelivr.net/'
                 - 'https://www.google-analytics.com/'
+                - 'https://www.google.com/recaptcha/api.js'
+                - 'https://www.gstatic.com/recaptcha/'
             connect-src:
                 - 'self'
                 - '*.algolia.net'
@@ -105,4 +107,6 @@ nelmio_security:
             font-src:
                 - 'self'
                 - 'https://fonts.gstatic.com/'
+            frame-src:
+                - 'https://www.google.com/recaptcha/'
             block-all-mixed-content: true # defaults to false, blocks HTTP content over HTTPS transport

--- a/app/config/defaults.yml
+++ b/app/config/defaults.yml
@@ -12,3 +12,8 @@ parameters:
     fingers_crossed_handlers: []
     aws_metadata: {}
     forced_ssl_hosts: []
+
+    # Recaptcha
+    recaptcha_enabled: false
+    recaptcha_site_key: 'site-key'
+    recaptcha_secret: 'secret'

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -42,9 +42,6 @@ github_check:
 logout:
     path: /logout
 
-login_check:
-    path: /login_check
-
 2fa_login:
     path: /2fa
     defaults:

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -12,12 +12,10 @@ security:
     firewalls:
         main:
             pattern:      .*
-            form_login:
-                provider:       packagist
-                login_path:     /login
-                use_forward:    false
-                check_path:     /login_check
-                failure_path:   null
+            guard:
+                provider: packagist
+                authenticators:
+                    - Packagist\WebBundle\Security\BruteForceLoginFormAuthenticator
             remember_me:
                 secret: '%remember_me.secret%'
                 user_providers: packagist

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
         "php-http/guzzle6-adapter": "^1.1",
         "zendframework/zenddiagnostics": "^1.4",
         "graze/dog-statsd": "^0.4.2",
-        "incenteev/composer-parameter-handler": "^2.1"
+        "incenteev/composer-parameter-handler": "^2.1",
+        "beelab/recaptcha2-bundle": "^2.3"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^4.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3c7d82fe75c83017f0ff392df4238b80",
+    "content-hash": "8abbb1940bbe8a35befa5d9b18bbe629",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -186,6 +186,66 @@
                 "source": "https://github.com/beberlei/assert/tree/v3"
             },
             "time": "2019-12-19T17:51:41+00:00"
+        },
+        {
+            "name": "beelab/recaptcha2-bundle",
+            "version": "v2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Bee-Lab/BeelabRecaptcha2Bundle.git",
+                "reference": "0c019b46546bf7cea40c4ed91aa653e12a2b1236"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Bee-Lab/BeelabRecaptcha2Bundle/zipball/0c019b46546bf7cea40c4ed91aa653e12a2b1236",
+                "reference": "0c019b46546bf7cea40c4ed91aa653e12a2b1236",
+                "shasum": ""
+            },
+            "require": {
+                "google/recaptcha": "^1.2",
+                "php": "^7.2",
+                "symfony/config": "^3.4 || ^4.4 || ^5.0",
+                "symfony/dependency-injection": "^3.4 || ^4.4 || ^5.0",
+                "symfony/form": "^3.4 || ^4.4 || ^5.0",
+                "symfony/http-kernel": "^3.4 || ^4.4 || ^5.0",
+                "symfony/validator": "^3.4 || ^4.4 || ^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5",
+                "symfony/phpunit-bridge": "^4.4 || 5.0"
+            },
+            "suggest": {
+                "symfony/twig-bundle": "To render widget. Minimum supported Twig version is 1.34, minimum suggested is 2.4"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Beelab\\Recaptcha2Bundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Massimiliano Arione",
+                    "email": "massimiliano.arione@bee-lab.net"
+                }
+            ],
+            "description": "Provide Google Recaptch2 form type",
+            "homepage": "https://github.com/bee-lab/",
+            "keywords": [
+                "form",
+                "recaptcha",
+                "symfony"
+            ],
+            "time": "2020-04-10T12:50:54+00:00"
         },
         {
             "name": "cebe/markdown",
@@ -2214,6 +2274,53 @@
                 "User management"
             ],
             "time": "2018-03-08T08:59:27+00:00"
+        },
+        {
+            "name": "google/recaptcha",
+            "version": "1.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/google/recaptcha.git",
+                "reference": "614f25a9038be4f3f2da7cbfd778dc5b357d2419"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/google/recaptcha/zipball/614f25a9038be4f3f2da7cbfd778dc5b357d2419",
+                "reference": "614f25a9038be4f3f2da7cbfd778dc5b357d2419",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.2.20|^2.15",
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^4.8.36|^5.7.27|^6.59|^7.5.11"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "ReCaptcha\\": "src/ReCaptcha"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Client library for reCAPTCHA, a free service that protects websites from spam and abuse.",
+            "homepage": "https://www.google.com/recaptcha/",
+            "keywords": [
+                "Abuse",
+                "captcha",
+                "recaptcha",
+                "spam"
+            ],
+            "time": "2020-03-31T17:50:54+00:00"
         },
         {
             "name": "graze/dog-statsd",

--- a/src/Packagist/Redis/FailedLoginCounter.php
+++ b/src/Packagist/Redis/FailedLoginCounter.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Packagist\Redis;
+
+class FailedLoginCounter extends \Predis\Command\ScriptCommand
+{
+    private $args;
+
+    public function getKeysCount()
+    {
+        if (!$this->args) {
+            throw new \LogicException('getKeysCount called before filterArguments');
+        }
+
+        return count($this->args);
+    }
+
+    protected function filterArguments(array $arguments)
+    {
+        $this->args = $arguments;
+
+        return parent::filterArguments($arguments);
+    }
+
+    public function getScript()
+    {
+        return <<<LUA
+for i, key in ipairs(KEYS) do
+  redis.call("INCR", key)
+  redis.call("EXPIRE", key, 604800)
+end
+LUA;
+    }
+}
+

--- a/src/Packagist/WebBundle/Controller/SecurityController.php
+++ b/src/Packagist/WebBundle/Controller/SecurityController.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Packagist\WebBundle\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
+
+class SecurityController extends Controller
+{
+    /**
+     * @Route("/login/", name="login")
+     */
+    public function loginAction(AuthenticationUtils $authenticationUtils): Response
+    {
+        $error = $authenticationUtils->getLastAuthenticationError();
+        $lastUsername = $authenticationUtils->getLastUsername();
+
+        return $this->render('@HWIOAuth/Connect/login.html.twig', [
+            'lastUsername' => $lastUsername,
+            'error' => $error,
+        ]);
+    }
+}

--- a/src/Packagist/WebBundle/Resources/config/services.yml
+++ b/src/Packagist/WebBundle/Resources/config/services.yml
@@ -205,6 +205,17 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    Packagist\WebBundle\Security\BruteForceLoginFormAuthenticator:
+        class: Packagist\WebBundle\Security\BruteForceLoginFormAuthenticator
+        arguments:
+            $recaptchaVerifier: "@beelab_recaptcha2.verifier"
+
+    Packagist\WebBundle\Security\RecaptchaHelper:
+        class: Packagist\WebBundle\Security\RecaptchaHelper
+        arguments:
+            $redis: "@snc_redis.cache_client"
+            $recaptchaEnabled: "%recaptcha_enabled%"
+
     Packagist\WebBundle\SecurityAdvisory\FriendsOfPhpSecurityAdvisoriesSource:
         class: Packagist\WebBundle\SecurityAdvisory\FriendsOfPhpSecurityAdvisoriesSource
         arguments: ["@doctrine"]

--- a/src/Packagist/WebBundle/Resources/views/layout.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/layout.html.twig
@@ -25,6 +25,31 @@
 
         <link rel="search" type="application/opensearchdescription+xml" href="{{ asset('search.osd') }}" title="Packagist" />
 
+        {% if not app.user and requires_recaptcha(lastUsername|default) %}
+            <script src="https://www.google.com/recaptcha/api.js?render=explicit&onload=onloadRecaptchaCallback" async defer></script>
+
+            <script type="text/javascript">
+                var onloadRecaptchaCallback = function() {
+                    if (document.getElementById('_submit')) {
+                        grecaptcha.render('_submit', {
+                            'sitekey' : '{{ recaptcha_site_key }}',
+                            'callback' : onPageLoginSubmit
+                        });
+                    }
+                    grecaptcha.render('_submit_mini', {
+                        'sitekey' : '{{ recaptcha_site_key }}',
+                        'callback' : onNavLoginSubmit
+                    });
+                };
+                function onNavLoginSubmit(token) {
+                    document.getElementById('nav_login').submit();
+                }
+                function onPageLoginSubmit(token) {
+                    document.getElementById('page_login').submit();
+                }
+            </script>
+        {% endif %}
+
         {% block head_additions %}{% endblock %}
     </head>
 
@@ -75,7 +100,7 @@
                                     <a href="{{ path('hwi_oauth_connect') }}">{{ 'menu.sign_in'|trans }}</a>
 
                                     <section class="signin-box">
-                                        <form action="{{ path('login_check') }}" method="POST">
+                                        <form action="{{ path('login') }}" method="POST" id="nav_login">
                                             <div class="input-group">
                                                 <input class="form-control" type="text" id="_username" name="_username" placeholder="{{ 'security.login.username'|trans({}, 'FOSUserBundle') }}">
                                                 <span class="input-group-addon"><span class="icon-user"></span></span>

--- a/src/Packagist/WebBundle/Security/BruteForceLoginFormAuthenticator.php
+++ b/src/Packagist/WebBundle/Security/BruteForceLoginFormAuthenticator.php
@@ -1,0 +1,125 @@
+<?php declare(strict_types=1);
+
+namespace Packagist\WebBundle\Security;
+
+use Beelab\Recaptcha2Bundle\Recaptcha\RecaptchaException;
+use Beelab\Recaptcha2Bundle\Recaptcha\RecaptchaVerifier;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Guard\Authenticator\AbstractFormLoginAuthenticator;
+use Symfony\Component\Security\Http\Util\TargetPathTrait;
+
+class BruteForceLoginFormAuthenticator extends AbstractFormLoginAuthenticator
+{
+    use TargetPathTrait;
+
+    public const LOGIN_ROUTE = 'login';
+
+    /** @var UrlGeneratorInterface */
+    private $urlGenerator;
+    /** @var RecaptchaVerifier */
+    private $recaptchaVerifier;
+    /** @var UserPasswordEncoderInterface */
+    private $passwordEncoder;
+    /** @var RecaptchaHelper */
+    private $recaptchaHelper;
+
+    public function __construct(
+        UrlGeneratorInterface $urlGenerator,
+        RecaptchaVerifier $recaptchaVerifier,
+        UserPasswordEncoderInterface $passwordEncoder,
+        RecaptchaHelper $recaptchaHelper
+    ) {
+        $this->urlGenerator = $urlGenerator;
+        $this->recaptchaVerifier = $recaptchaVerifier;
+        $this->passwordEncoder = $passwordEncoder;
+        $this->recaptchaHelper = $recaptchaHelper;
+    }
+
+    public function supports(Request $request)
+    {
+        return self::LOGIN_ROUTE === $request->attributes->get('_route')
+            && $request->isMethod('POST');
+    }
+
+    public function getCredentials(Request $request)
+    {
+        $credentials = [
+            'username' => $request->request->get('_username'),
+            'password' => $request->request->get('_password'),
+            'ip' => $request->getClientIp(),
+            'recaptcha' => $request->request->get(RecaptchaVerifier::GOOGLE_DEFAULT_INPUT),
+        ];
+        $request->getSession()->set(
+            Security::LAST_USERNAME,
+            $credentials['username']
+        );
+
+        return $credentials;
+    }
+
+    public function getUser($credentials, UserProviderInterface $userProvider)
+    {
+        $this->validateRecaptcha($credentials);
+
+        try {
+            return $userProvider->loadUserByUsername($credentials['username']);
+        } catch (UsernameNotFoundException $e) {
+            // fail authentication with a custom error
+            throw new CustomUserMessageAuthenticationException('Invalid credentials.', [], 0, $e);
+        }
+    }
+
+    public function checkCredentials($credentials, UserInterface $user)
+    {
+        return $this->passwordEncoder->isPasswordValid($user, $credentials['password']);
+
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
+    {
+        $this->recaptchaHelper->clearCounter($request);
+
+        if ($targetPath = $this->getTargetPath($request->getSession(), $providerKey)) {
+            return new RedirectResponse($targetPath);
+        }
+
+        return new RedirectResponse($this->urlGenerator->generate('home'));
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
+    {
+        $this->recaptchaHelper->increaseCounter($request);
+
+        return parent::onAuthenticationFailure($request, $exception);
+    }
+
+    protected function getLoginUrl()
+    {
+        return $this->urlGenerator->generate(self::LOGIN_ROUTE);
+    }
+
+    private function validateRecaptcha(array $credentials): void
+    {
+        if ($this->recaptchaHelper->requiresRecaptcha($credentials['ip'], $credentials['username'])) {
+            if (!$credentials['recaptcha']) {
+                throw new CustomUserMessageAuthenticationException('We detected too many failed login attempts. Please log in again with ReCaptcha.');
+            }
+
+            try {
+                $this->recaptchaVerifier->verify($credentials['recaptcha']);
+            } catch (RecaptchaException $e) {
+                throw new CustomUserMessageAuthenticationException('Invalid ReCaptcha');
+            }
+        }
+    }
+}

--- a/src/Packagist/WebBundle/Security/RecaptchaHelper.php
+++ b/src/Packagist/WebBundle/Security/RecaptchaHelper.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace Packagist\WebBundle\Security;
+
+use Packagist\Redis\FailedLoginCounter;
+use Predis\Client;
+use Symfony\Component\HttpFoundation\Request;
+
+class RecaptchaHelper
+{
+    private const LOGIN_BASE_KEY_IP = 'bf:login:ip:';
+    private const LOGIN_BASE_KEY_USER = 'bf:login:user:';
+
+    /** @var Client */
+    private $redis;
+    /** @var bool */
+    private $recaptchaEnabled;
+
+    public function __construct(Client $redis, bool $recaptchaEnabled)
+    {
+        $this->redis = $redis;
+        $this->recaptchaEnabled = $recaptchaEnabled;
+    }
+
+    public function requiresRecaptcha(string $ip, string $username): bool
+    {
+        if (!$this->recaptchaEnabled) {
+            return false;
+        }
+
+        $keys = [self::LOGIN_BASE_KEY_IP . $ip];
+        if ($username) {
+            $keys[] = self::LOGIN_BASE_KEY_USER . $username;
+        }
+
+        $result = $this->redis->mget($keys);
+        foreach ($result as $count) {
+            if ($count >= 3) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function increaseCounter(Request $request): void
+    {
+        if ($this->recaptchaEnabled) {
+            $this->redis->getProfile()->defineCommand('incrFailedLoginCounter', FailedLoginCounter::class);
+
+            $ipKey = self::LOGIN_BASE_KEY_IP . $request->getClientIp();
+            $userKey = self::LOGIN_BASE_KEY_USER . $request->get('_username');
+            $this->redis->incrFailedLoginCounter($ipKey, $userKey);
+        }
+    }
+
+    public function clearCounter(Request $request): void
+    {
+        if ($this->recaptchaEnabled) {
+            $userKey = self::LOGIN_BASE_KEY_USER . $request->get('_username');
+            $this->redis->del([$userKey]);
+        }
+    }
+}

--- a/src/Packagist/WebBundle/Tests/Security/BruteForceLoginFormAuthenticatorTest.php
+++ b/src/Packagist/WebBundle/Tests/Security/BruteForceLoginFormAuthenticatorTest.php
@@ -1,0 +1,129 @@
+<?php declare(strict_types=1);
+
+namespace Packagist\WebBundle\Tests\Security;
+
+use Beelab\Recaptcha2Bundle\Recaptcha\RecaptchaVerifier;
+use Packagist\WebBundle\Security\BruteForceLoginFormAuthenticator;
+use Packagist\WebBundle\Security\RecaptchaHelper;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+class BruteForceLoginFormAuthenticatorTest extends TestCase
+{
+    /** @var BruteForceLoginFormAuthenticator */
+    private $authenticator;
+    /** @var UrlGeneratorInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private $urlGenerator;
+    /** @var RecaptchaVerifier&\PHPUnit\Framework\MockObject\MockObject */
+    private $recaptchaVerifier;
+    /** @var UserPasswordEncoderInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private $passwordEncoder;
+    /** @var RecaptchaHelper&\PHPUnit\Framework\MockObject\MockObject */
+    private $recaptchaHelper;
+
+    protected function setUp(): void
+    {
+        $this->urlGenerator = $this->getMockBuilder(UrlGeneratorInterface::class)->disableOriginalConstructor()->getMock();
+        $this->recaptchaVerifier = $this->getMockBuilder(RecaptchaVerifier::class)->disableOriginalConstructor()->getMock();
+        $this->passwordEncoder = $this->getMockBuilder(UserPasswordEncoderInterface::class)->disableOriginalConstructor()->getMock();
+        $this->recaptchaHelper = $this->getMockBuilder(RecaptchaHelper::class)->disableOriginalConstructor()->getMock();
+
+        $this->authenticator = new BruteForceLoginFormAuthenticator($this->urlGenerator, $this->recaptchaVerifier, $this->passwordEncoder, $this->recaptchaHelper);
+    }
+
+    /**
+     * @dataProvider supportsProvider
+     */
+    public function testSupports(string $method, string $route, bool $expected): void
+    {
+        $request = new Request();
+        $request->setMethod($method);
+        $request->attributes->set('_route', $route);
+
+        $this->assertSame($expected, $this->authenticator->supports($request));
+    }
+
+    public function supportsProvider(): array
+    {
+        return [
+            ['POST', BruteForceLoginFormAuthenticator::LOGIN_ROUTE, true],
+            ['GET', BruteForceLoginFormAuthenticator::LOGIN_ROUTE, false],
+            ['POST', 'route', false],
+        ];
+    }
+
+    public function testGetUser(): void
+    {
+        $user = $this->getMockBuilder(UserInterface::class)->disableOriginalConstructor()->getMock();
+        $userProvider = $this->getMockBuilder(UserProviderInterface::class)->disableOriginalConstructor()->getMock();
+        $userProvider
+            ->expects($this->once())
+            ->method('loadUserByUsername')
+            ->with($this->equalTo('username'))
+            ->willReturn($user);
+
+        $this->recaptchaHelper
+            ->expects($this->once())
+            ->method('requiresRecaptcha')
+            ->willReturn(true);
+
+        $this->recaptchaVerifier
+            ->expects($this->once())
+            ->method('verify')
+            ->with($this->equalTo('recaptcha'));
+
+        $credentials = [
+            'username' => 'username',
+            'password' => 'password',
+            'ip' => '127.0.0.1',
+            'recaptcha' => 'recaptcha',
+        ];
+
+        $this->assertSame($user, $this->authenticator->getUser($credentials, $userProvider));
+    }
+
+    public function testOnAuthenticationSuccess(): void
+    {
+        $request = new Request();
+        $request->setSession($this->getMockBuilder(SessionInterface::class)->disableOriginalConstructor()->getMock());
+        $token = $this->getMockBuilder(UsernamePasswordToken::class)->disableOriginalConstructor()->getMock();
+
+        $this->urlGenerator
+            ->expects($this->once())
+            ->method('generate')
+            ->with($this->equalTo('home'))
+            ->willReturn('/');
+
+        $this->recaptchaHelper
+            ->expects($this->once())
+            ->method('clearCounter');
+
+        $this->authenticator->onAuthenticationSuccess($request, $token, 'main');
+    }
+
+    public function testOnAuthenticationFailureIncreaseCounter(): void
+    {
+        $request = new Request();
+        $exception = new AuthenticationException();
+
+        $this->recaptchaHelper
+            ->expects($this->once())
+            ->method('increaseCounter');
+
+
+        $this->urlGenerator
+            ->expects($this->once())
+            ->method('generate')
+            ->with($this->equalTo(BruteForceLoginFormAuthenticator::LOGIN_ROUTE))
+            ->willReturn('/');
+
+        $this->authenticator->onAuthenticationFailure($request, $exception);
+    }
+}

--- a/src/Packagist/WebBundle/Tests/Security/RecaptchaHelperTest.php
+++ b/src/Packagist/WebBundle/Tests/Security/RecaptchaHelperTest.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace Packagist\WebBundle\Tests\Security;
+
+use Packagist\WebBundle\Security\RecaptchaHelper;
+use PHPUnit\Framework\TestCase;
+use Predis\Client;
+use Predis\Profile\RedisProfile;
+use Symfony\Component\HttpFoundation\Request;
+
+class RecaptchaHelperTest extends TestCase
+{
+    /** @var RecaptchaHelper */
+    private $helper;
+    /** @var Client&\PHPUnit\Framework\MockObject\MockObject */
+    private $redis;
+
+    protected function setUp(): void
+    {
+        $this->redis = $this->getMockBuilder(Client::class)->disableOriginalConstructor()->getMock();
+        $this->helper = new RecaptchaHelper($this->redis, true);
+    }
+
+    public function testRequiresRecaptcha(): void
+    {
+        $this->redis
+            ->expects($this->once())
+            ->method('__call')
+            ->with($this->equalTo('mget'))
+            ->willReturn([2, 3]);
+
+        $this->assertTrue($this->helper->requiresRecaptcha('127.0.0.1', 'username'));
+    }
+
+    public function testIncreaseCounter(): void
+    {
+        $this->redis
+            ->expects($this->once())
+            ->method('getProfile')
+            ->willReturn($this->getMockBuilder(RedisProfile::class)->disableOriginalConstructor()->getMock());
+
+        $this->redis
+            ->expects($this->once())
+            ->method('__call')
+            ->with($this->equalTo('incrFailedLoginCounter'));
+
+        $this->helper->increaseCounter(new Request());
+    }
+
+    public function testClearCounter(): void
+    {
+        $this->redis
+            ->expects($this->once())
+            ->method('__call')
+            ->with($this->equalTo('del'));
+
+        $this->helper->clearCounter(new Request());
+    }
+}


### PR DESCRIPTION
Protection is implemented via Google ReCaptcha.
After the third failed login attempt for a certain IP or username an v3 invisible recaptcha is displayed and required to login via username+password.
The counters are reset after 7 days of no failed login.

This uses Symfony guard authentication which replaces the previously used form_login.