### PR TITLE
Recaptcha: assert _username is always a string to increase/reset counters

### DIFF
--- a/src/Packagist/WebBundle/Security/RecaptchaHelper.php
+++ b/src/Packagist/WebBundle/Security/RecaptchaHelper.php
@@ -49,7 +49,7 @@ class RecaptchaHelper
             $this->redis->getProfile()->defineCommand('incrFailedLoginCounter', FailedLoginCounter::class);
 
             $ipKey = self::LOGIN_BASE_KEY_IP . $request->getClientIp();
-            $userKey = self::LOGIN_BASE_KEY_USER . strtolower($request->get('_username'));
+            $userKey = self::LOGIN_BASE_KEY_USER . strtolower((string) $request->get('_username'));
             $this->redis->incrFailedLoginCounter($ipKey, $userKey);
         }
     }
@@ -57,7 +57,7 @@ class RecaptchaHelper
     public function clearCounter(Request $request): void
     {
         if ($this->recaptchaEnabled) {
-            $userKey = self::LOGIN_BASE_KEY_USER . strtolower($request->get('_username'));
+            $userKey = self::LOGIN_BASE_KEY_USER . strtolower((string) $request->get('_username'));
             $this->redis->del([$userKey]);
         }
     }


### PR DESCRIPTION
Fixes test failures introduced by https://github.com/composer/packagist/commit/e559612bba619903c649533649cbb85e141b7c7e