### PR TITLE
FOS: still require a route called fos_user_security_login

### DIFF
--- a/src/Packagist/WebBundle/Controller/SecurityController.php
+++ b/src/Packagist/WebBundle/Controller/SecurityController.php
@@ -10,6 +10,7 @@ class SecurityController extends Controller
 {
     /**
      * @Route("/login/", name="login")
+     * @Route("/login/", name="fos_user_security_login")
      */
     public function loginAction(AuthenticationUtils $authenticationUtils): Response
     {


### PR DESCRIPTION
Regression which was introduced by #1082

This causes a 500 error when accessing pw reset URLs with invalid tokens e.g. https://packagist.org/resetting/reset/invalid-token