### PR TITLE
Remove packagist.vrkansagara.in mirror site

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/mirrors/index.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/mirrors/index.html.twig
@@ -20,7 +20,6 @@
   <li>Asia, China <a href="https://packagist.mirrors.sjtug.sjtu.edu.cn">packagist.mirrors.sjtug.sjtu.edu.cn</a></li>
   <li>Asia, China <a href="https://mirrors.cloud.tencent.com/help/composer.html">mirrors.cloud.tencent.com/help/composer.html</a></li>
   <li>Asia, India <a href="https://packagist.in">packagist.in</a></li>
-  <li>Asia, India <a href="https://packagist.vrkansagara.in">packagist.vrkansagara.in</a></li>
   <li>Asia, Indonesia <a href="https://packagist.phpindonesia.id">packagist.phpindonesia.id</a></li>
   <li>Asia, Japan <a href="https://packagist.jp">packagist.jp</a></li>
   <li>Asia, South Korea <a href="https://packagist.kr">packagist.kr</a></li>


### PR DESCRIPTION
# Changed log
- Remove `packagist.vrkansagara.in` mirror site because it's broken.
And it's not available.

## Reproducing this issue about using this mirror site

- Set using this mirror site with following command:

```Bash
composer config -g repos.packagist composer https://packagist.vrkansagara.in
```

After setting up this mirror site, using following command to install a package:

```Bash
composer require nesbot/carbon
```

### Expected

It should be worked to install this specific package successfully.

### Actual

Throw following exceptions:

```Bash
 [RuntimeException]
  No composer.json present in the current directory, this may be the cause of the following excepti
  on.
 [Composer\Downloader\TransportException]
  The "https://packagist.vrkansagara.in/packages.json" file could not be downloaded: Peer certifica
  te CN=`arthurandersonaccountants.co.uk' did not match expected CN=`packagist.vrkansagara.in'
  Failed to enable crypto
  failed to open stream: operation failed

```