### PR TITLE
API: add documentation for the security advisory endpoint

### DIFF
--- a/src/Packagist/WebBundle/Resources/translations/messages.en.yml
+++ b/src/Packagist/WebBundle/Resources/translations/messages.en.yml
@@ -151,6 +151,7 @@ api_doc:
     search_by_type: Search packages by type
     get_by_name: Get a package by name
     get_package_data: Getting package data
+    list_security_advisory: List security advisories
 
 mirrors:
     title: Mirrors of the Packagist.org Metadata

--- a/src/Packagist/WebBundle/Resources/views/api_doc/index.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/api_doc/index.html.twig
@@ -20,6 +20,7 @@
   </li>
   <li><a href="#get-package-data">{{ 'api_doc.get_package_data'|trans }}</a></li>
   <li><a href="#get-statistics">{{ 'api_doc.get_statistics'|trans }}</a></li>
+  <li><a href="#list-security-advisories">{{ 'api_doc.list_security_advisory'|trans }}</a></li>
 </ul>
 
 
@@ -223,6 +224,38 @@ GET https://{{ packagist_host }}/statistics.json
 }
 </code></pre>
 <p>Working example: <code><a href="https://{{ packagist_host }}/statistics.json">https://{{ packagist_host }}/statistics.json</a></code></p>
+
+</section>
+
+<section class="col-d-12">
+  <h3 id="list-security-advisories">{{ 'api_doc.list_security_advisory'|trans }}</h3>
+
+  <h4 id="list-security-advisories-by-package">{{ 'api_doc.list_security_advisory'|trans }}</h4>
+
+    <p>This endpoint provides a list of security advisories. Either a list of packages as query or request parameter or a timestamp as updatedSince query parameter need to be passed.</p>
+
+    <pre>
+GET https://{{ packagist_host }}/api/security-advisories/?updatedSince=[timestamp]&packages[]=[vendor/package]
+<code>
+{
+  "advisories": {
+    "[vendor]/[package]": [
+      {
+        "packageName": "[vendor]/[package]",
+        "remoteId": "[unique id per source]",
+        "title": "[title]",
+        "link": "[url to issue disclosure]",
+        "cve": "[cve if available]",
+        "affectedVersions": [affected version in form of a composer constraint]",
+        "source": "[source where the issue was found]",
+        "reportedAt": "[date the issue was reported]",
+        "composerRepository": "[composer repository the package can be found in]"
+      }
+    ]
+  }
+}
+</code></pre>
+    <p>Working example: <code><a href="https://{{ packagist_host }}/api/security-advisories/?packages[]=monolog/monolog">https://{{ packagist_host }}/api/security-advisories/?packages[]=monolog/monolog</a></code></p>
 
 </section>
 


### PR DESCRIPTION
<img width="1198" alt="Screenshot 2020-07-16 at 10 43 12" src="https://user-images.githubusercontent.com/442056/87656263-2aa5aa80-c751-11ea-82d2-cb914adccb63.png">
