### PR TITLE
Fix: Use https instead of http

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,12 @@
         {
             "name": "Nils Adermann",
             "email": "naderman@naderman.de",
-            "homepage": "http://www.naderman.de"
+            "homepage": "https://www.naderman.de"
         },
         {
             "name": "Jordi Boggiano",
             "email": "j.boggiano@seld.be",
-            "homepage": "http://seld.be"
+            "homepage": "https://seld.be"
         }
     ],
     "support": {


### PR DESCRIPTION
This PR

* [x] uses `https` instead of `http` in URLs pointing to author homepages