### PR TITLE
Replace deprecated Twig uses

### DIFF
--- a/src/Packagist/WebBundle/Model/PackageManager.php
+++ b/src/Packagist/WebBundle/Model/PackageManager.php
@@ -18,6 +18,7 @@ use Psr\Log\LoggerInterface;
 use Algolia\AlgoliaSearch\SearchClient;
 use Predis\Client;
 use Packagist\WebBundle\Service\GitHubUserMigrationWorker;
+use Twig\Environment;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -36,7 +37,7 @@ class PackageManager
     protected $githubWorker;
     protected $metadataDir;
 
-    public function __construct(RegistryInterface $doctrine, \Swift_Mailer $mailer, \Swift_Mailer $instantMailer, \Twig_Environment $twig, LoggerInterface $logger, array $options, ProviderManager $providerManager, SearchClient $algoliaClient, string $algoliaIndexName, GitHubUserMigrationWorker $githubWorker, string $metadataDir, Client $redis)
+    public function __construct(RegistryInterface $doctrine, \Swift_Mailer $mailer, \Swift_Mailer $instantMailer, Environment $twig, LoggerInterface $logger, array $options, ProviderManager $providerManager, SearchClient $algoliaClient, string $algoliaIndexName, GitHubUserMigrationWorker $githubWorker, string $metadataDir, Client $redis)
     {
         $this->doctrine = $doctrine;
         $this->mailer = $mailer;

--- a/src/Packagist/WebBundle/Resources/views/forms.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/forms.html.twig
@@ -1,45 +1,38 @@
 {% extends 'form_div_layout.html.twig' %}
 
-{% block textarea_widget %}
-{% set attr = attr|merge({'class': attr.class|default('') ~ ' form-control'}) %}
-{{ parent() }}
-{% endblock textarea_widget %}
+{% block textarea_widget -%}
+    {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) %}
+    {{- parent() -}}
+{%- endblock textarea_widget %}
 
-{% block form_widget_simple %}
-{% apply spaceless %}
-    {% set attr = attr|merge({'class': attr.class|default('') ~ ' form-control'}) %}
-    {% set type = type|default('text') %}
-
-    {{ parent() }}
-{% endapply %}
-{% endblock form_widget_simple %}
-
-{% block form_row %}
-{% apply spaceless %}
-    <div class="form-group{% if errors|length > 0 %} has-error{% endif %}">
-        {{ form_label(form) }}
-
-        {{ form_widget(form) }}
-
-        {% for error in errors %}
-            <span class="help-block form-error">
-                {{
-                    error.messagePluralization is null
-                    ? error.messageTemplate|trans(error.messageParameters, 'validators')
-                    : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'validators')
-                }}
-            </span>
-        {% endfor %}
-    </div>
-{% endapply %}
-{% endblock form_row %}
-
-{% block form_errors %}
-{% apply spaceless %}
-    {% if errors|length > 0 %}
-        {% for error in errors %}
-            <div class="alert alert-danger">{{ error.message }}</div>
-        {% endfor %}
+{% block form_widget_simple -%}
+    {% if type is not defined or type not in ['file', 'hidden'] %}
+        {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) -%}
     {% endif %}
-{% endapply %}
-{% endblock form_errors %}
+    {%- set type = type|default('text') -%}
+    {{- parent() -}}
+{%- endblock form_widget_simple %}
+
+{% block form_row -%}
+    <div class="form-group{% if (not compound or force_error|default(false)) and not valid %} has-error{% endif %}">
+        {{- form_label(form) }} {# -#}
+        {{ form_widget(form) }} {# -#}
+        {%- for error in errors -%}
+            <span class="help-block form-error">
+                {{-
+                error.messagePluralization is null
+                ? error.messageTemplate|trans(error.messageParameters, 'validators')
+                : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'validators')
+                -}}
+            </span>
+        {%- endfor -%}
+    </div>
+{%- endblock form_row %}
+
+{% block form_errors -%}
+    {% if errors|length > 0 -%}
+        {%- for error in errors -%}
+            <div class="alert alert-danger">{{ error.message }}</div>
+        {%- endfor -%}
+    {%- endif %}
+{%- endblock form_errors %}

--- a/src/Packagist/WebBundle/Resources/views/forms.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/forms.html.twig
@@ -6,16 +6,16 @@
 {% endblock textarea_widget %}
 
 {% block form_widget_simple %}
-{% filter spaceless %}
+{% apply spaceless %}
     {% set attr = attr|merge({'class': attr.class|default('') ~ ' form-control'}) %}
     {% set type = type|default('text') %}
 
     {{ parent() }}
-{% endfilter %}
+{% endapply %}
 {% endblock form_widget_simple %}
 
 {% block form_row %}
-{% filter spaceless %}
+{% apply spaceless %}
     <div class="form-group{% if errors|length > 0 %} has-error{% endif %}">
         {{ form_label(form) }}
 
@@ -31,15 +31,15 @@
             </span>
         {% endfor %}
     </div>
-{% endfilter %}
+{% endapply %}
 {% endblock form_row %}
 
 {% block form_errors %}
-{% filter spaceless %}
+{% apply spaceless %}
     {% if errors|length > 0 %}
         {% for error in errors %}
             <div class="alert alert-danger">{{ error.message }}</div>
         {% endfor %}
     {% endif %}
-{% endfilter %}
+{% endapply %}
 {% endblock form_errors %}

--- a/src/Packagist/WebBundle/Twig/PackagistExtension.php
+++ b/src/Packagist/WebBundle/Twig/PackagistExtension.php
@@ -7,8 +7,12 @@ use Packagist\WebBundle\Security\RecaptchaHelper;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Composer\Repository\PlatformRepository;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+use Twig\TwigTest;
 
-class PackagistExtension extends \Twig\Extension\AbstractExtension
+class PackagistExtension extends AbstractExtension
 {
     /**
      * @var ProviderManager
@@ -32,27 +36,27 @@ class PackagistExtension extends \Twig\Extension\AbstractExtension
     public function getTests()
     {
         return array(
-            new \Twig_SimpleTest('existing_package', [$this, 'packageExistsTest']),
-            new \Twig_SimpleTest('existing_provider', [$this, 'providerExistsTest']),
-            new \Twig_SimpleTest('numeric', [$this, 'numericTest']),
+            new TwigTest('existing_package', [$this, 'packageExistsTest']),
+            new TwigTest('existing_provider', [$this, 'providerExistsTest']),
+            new TwigTest('numeric', [$this, 'numericTest']),
         );
     }
 
     public function getFilters()
     {
         return array(
-            new \Twig_SimpleFilter('prettify_source_reference', [$this, 'prettifySourceReference']),
-            new \Twig_SimpleFilter('gravatar_hash', [$this, 'generateGravatarHash']),
-            new \Twig_SimpleFilter('vendor', [$this, 'getVendor']),
-            new \Twig_SimpleFilter('sort_links', [$this, 'sortLinks']),
+            new TwigFilter('prettify_source_reference', [$this, 'prettifySourceReference']),
+            new TwigFilter('gravatar_hash', [$this, 'generateGravatarHash']),
+            new TwigFilter('vendor', [$this, 'getVendor']),
+            new TwigFilter('sort_links', [$this, 'sortLinks']),
         );
     }
 
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('csrf_token', [$this, 'getCsrfToken']),
-            new \Twig_SimpleFunction('requires_recaptcha', [$this, 'requiresRecaptcha']),
+            new TwigFunction('csrf_token', [$this, 'getCsrfToken']),
+            new TwigFunction('requires_recaptcha', [$this, 'requiresRecaptcha']),
         );
     }
 


### PR DESCRIPTION
Some of the Twig integration was still using older class names, and the templates were using the deprecated filter tag.  These have been updated.