### PR TITLE
Upgrade Pagerfanta

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -20,7 +20,7 @@ class AppKernel extends Kernel
             new Http\HttplugBundle\HttplugBundle(),
             new HWI\Bundle\OAuthBundle\HWIOAuthBundle(),
             new Snc\RedisBundle\SncRedisBundle(),
-            new WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle(),
+            new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),
             new Nelmio\SecurityBundle\NelmioSecurityBundle(),
             new Knp\Bundle\MenuBundle\KnpMenuBundle(),
             new Nelmio\CorsBundle\NelmioCorsBundle(),

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,6 @@
         "nelmio/security-bundle": "^2.4",
         "predis/predis": "^1.0",
         "snc/redis-bundle": "^2.0",
-        "white-october/pagerfanta-bundle": "^1.0",
         "zendframework/zend-feed": "^2.0",
         "zendframework/zend-servicemanager": "^2.0",
         "zendframework/zend-uri": "^2.0",
@@ -61,7 +60,8 @@
         "zendframework/zenddiagnostics": "^1.4",
         "graze/dog-statsd": "^0.4.2",
         "incenteev/composer-parameter-handler": "^2.1",
-        "beelab/recaptcha2-bundle": "^2.3"
+        "beelab/recaptcha2-bundle": "^2.3",
+        "babdev/pagerfanta-bundle": "^2.7"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^4.2",

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "zendframework/zend-feed": "^2.0",
         "zendframework/zend-servicemanager": "^2.0",
         "zendframework/zend-uri": "^2.0",
-        "pagerfanta/pagerfanta": "^2.0",
+        "pagerfanta/pagerfanta": "^2.4",
         "knplabs/knp-menu-bundle": "^2.1",
         "ezyang/htmlpurifier": "^4.6",
         "nelmio/cors-bundle": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0bd7688572ba51407de6fdd8a10bad18",
+    "content-hash": "e1c75a42b74ad7964ee01d0f310e5c49",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -79,6 +79,89 @@
                 "source": "https://github.com/algolia/algoliasearch-client-php/tree/master"
             },
             "time": "2020-06-25T08:47:13+00:00"
+        },
+        {
+            "name": "babdev/pagerfanta-bundle",
+            "version": "v2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/BabDev/PagerfantaBundle.git",
+                "reference": "1f3078a9134d7073cdba73343ad3cf9401086a8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/BabDev/PagerfantaBundle/zipball/1f3078a9134d7073cdba73343ad3cf9401086a8a",
+                "reference": "1f3078a9134d7073cdba73343ad3cf9401086a8a",
+                "shasum": ""
+            },
+            "require": {
+                "pagerfanta/pagerfanta": "^2.4",
+                "php": "^7.2",
+                "symfony/config": "^3.4 || ^4.4 || ^5.1",
+                "symfony/dependency-injection": "^3.4 || ^4.4 || ^5.1",
+                "symfony/deprecation-contracts": "^2.1",
+                "symfony/http-foundation": "^3.4 || ^4.4 || ^5.1",
+                "symfony/http-kernel": "^3.4 || ^4.4 || ^5.1",
+                "symfony/property-access": "^3.4 || ^4.4 || ^5.1",
+                "symfony/routing": "^3.4 || ^4.4 || ^5.1"
+            },
+            "conflict": {
+                "twig/twig": "<1.35 || >=2.0,<2.5",
+                "white-october/pagerfanta-bundle": "*"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.8",
+                "friendsofphp/php-cs-fixer": "^2.16",
+                "jms/serializer": "^3.0",
+                "jms/serializer-bundle": "^3.0",
+                "matthiasnoback/symfony-dependency-injection-test": "^4.1",
+                "phpstan/extension-installer": "^1.0.3",
+                "phpstan/phpstan": "^0.12.37",
+                "phpstan/phpstan-phpunit": "^0.12.16",
+                "phpstan/phpstan-symfony": "^0.12.7",
+                "phpunit/phpunit": "^8.5 || ^9.0",
+                "symfony/serializer": "^3.4 || ^4.4 || ^5.1",
+                "symfony/translation": "^3.4 || ^4.4 || ^5.1",
+                "symfony/twig-bridge": "^3.4 || ^4.4 || ^5.1",
+                "symfony/twig-bundle": "^3.4 || ^4.4 || ^5.1",
+                "twig/twig": "^1.35 || ^2.5 || ^3.0"
+            },
+            "suggest": {
+                "jms/serializer-bundle": "To use the Pagerfanta class with the JMS Serializer",
+                "symfony/serializer": "To use the Pagerfanta class with the Symfony Serializer",
+                "symfony/translation": "To use the Pagerfanta views with translation support",
+                "twig/twig": "To integrate Pagerfanta with Twig through extensions"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "BabDev\\PagerfantaBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Bundle integrating Pagerfanta with Symfony",
+            "keywords": [
+                "pagerfanta",
+                "pagination",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/BabDev/PagerfantaBundle/issues",
+                "source": "https://github.com/BabDev/PagerfantaBundle/tree/v2.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/mbabker",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-14T22:45:11+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",
@@ -8002,72 +8085,6 @@
                 "source": "https://github.com/ua-parser/uap-php/tree/v3.9.13"
             },
             "time": "2020-08-05T22:13:41+00:00"
-        },
-        {
-            "name": "white-october/pagerfanta-bundle",
-            "version": "v1.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/whiteoctober/WhiteOctoberPagerfantaBundle.git",
-                "reference": "6df560869b5e09a3acf920890ab40598998b30ae"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/whiteoctober/WhiteOctoberPagerfantaBundle/zipball/6df560869b5e09a3acf920890ab40598998b30ae",
-                "reference": "6df560869b5e09a3acf920890ab40598998b30ae",
-                "shasum": ""
-            },
-            "require": {
-                "pagerfanta/pagerfanta": "^1.1.0|^2.0.0",
-                "php": ">=5.3.3",
-                "symfony/framework-bundle": "~2.3|~3.0|~4.0",
-                "symfony/property-access": "~2.3|~3.0|~4.0",
-                "symfony/translation": "~2.3|~3.0|~4.0",
-                "symfony/twig-bundle": "~2.3|~3.0|~4.0"
-            },
-            "conflict": {
-                "twig/twig": "<1.34|>=2.0,<2.4"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~3.7|~4.0|^5.0",
-                "symfony/symfony": "~2.3|~3.0|~4.0"
-            },
-            "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "WhiteOctober\\PagerfantaBundle\\": ""
-                },
-                "exclude-from-classmap": [
-                    "Tests/",
-                    "TestsProject/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Pablo Díez",
-                    "email": "pablodip@gmail.com"
-                }
-            ],
-            "description": "Bundle to use Pagerfanta with Symfony2",
-            "keywords": [
-                "page",
-                "paging"
-            ],
-            "support": {
-                "issues": "https://github.com/whiteoctober/WhiteOctoberPagerfantaBundle/issues",
-                "source": "https://github.com/whiteoctober/WhiteOctoberPagerfantaBundle/tree/v1.3.2"
-            },
-            "abandoned": "babdev/pagerfanta-bundle",
-            "time": "2019-12-02T14:19:37+00:00"
         },
         {
             "name": "zendframework/zend-escaper",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e1c75a42b74ad7964ee01d0f310e5c49",
+    "content-hash": "e664e1bc09b8aad0af6cfd6193621b95",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",

--- a/src/Packagist/WebBundle/Controller/Controller.php
+++ b/src/Packagist/WebBundle/Controller/Controller.php
@@ -13,7 +13,7 @@
 namespace Packagist\WebBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller as BaseController;
-use Pagerfanta\Adapter\DoctrineORMAdapter;
+use Pagerfanta\Doctrine\ORM\QueryAdapter;
 use Pagerfanta\Pagerfanta;
 use Packagist\WebBundle\Entity\Package;
 
@@ -74,9 +74,10 @@ class Controller extends BaseController
      */
     protected function setupPager($query, $page)
     {
-        $paginator = new Pagerfanta(new DoctrineORMAdapter($query, true));
+        $paginator = new Pagerfanta(new QueryAdapter($query, true));
+        $paginator->setNormalizeOutOfRangePages(true);
         $paginator->setMaxPerPage(15);
-        $paginator->setCurrentPage($page, false, true);
+        $paginator->setCurrentPage($page);
 
         return $paginator;
     }

--- a/src/Packagist/WebBundle/Controller/ExploreController.php
+++ b/src/Packagist/WebBundle/Controller/ExploreController.php
@@ -105,8 +105,9 @@ class ExploreController extends Controller
             });
 
             $packages = new Pagerfanta(new FixedAdapter($redis->zcard('downloads:trending'), $popular));
+            $packages->setNormalizeOutOfRangePages(true);
             $packages->setMaxPerPage($perPage);
-            $packages->setCurrentPage($req->get('page', 1), false, true);
+            $packages->setCurrentPage($req->get('page', 1));
         } catch (ConnectionException $e) {
             $packages = new Pagerfanta(new FixedAdapter(0, array()));
         }

--- a/src/Packagist/WebBundle/Controller/PackageController.php
+++ b/src/Packagist/WebBundle/Controller/PackageController.php
@@ -399,8 +399,9 @@ class PackageController extends Controller
         $packages = $repo->getSuspectPackages(($page - 1) * 50, 50);
 
         $paginator = new Pagerfanta(new FixedAdapter($count, $packages));
+        $paginator->setNormalizeOutOfRangePages(true);
         $paginator->setMaxPerPage(50);
-        $paginator->setCurrentPage($page, false, true);
+        $paginator->setCurrentPage($page);
 
         $data['packages'] = $paginator;
         $data['count'] = $count;
@@ -1103,8 +1104,9 @@ class PackageController extends Controller
         $packages = $repo->getDependents($name, ($page - 1) * $perPage, $perPage, $orderBy);
 
         $paginator = new Pagerfanta(new FixedAdapter($depCount, $packages));
+        $paginator->setNormalizeOutOfRangePages(true);
         $paginator->setMaxPerPage($perPage);
-        $paginator->setCurrentPage($page, false, true);
+        $paginator->setCurrentPage($page);
 
         if ($req->getRequestFormat() === 'json') {
             $data = [
@@ -1158,8 +1160,9 @@ class PackageController extends Controller
         $packages = $repo->getSuggests($name, ($page - 1) * $perPage, $perPage);
 
         $paginator = new Pagerfanta(new FixedAdapter($suggestCount, $packages));
+        $paginator->setNormalizeOutOfRangePages(true);
         $paginator->setMaxPerPage($perPage);
-        $paginator->setCurrentPage($page, false, true);
+        $paginator->setCurrentPage($page);
 
         if ($req->getRequestFormat() === 'json') {
             $data = [

--- a/src/Packagist/WebBundle/Controller/UserController.php
+++ b/src/Packagist/WebBundle/Controller/UserController.php
@@ -23,7 +23,7 @@ use Packagist\WebBundle\Form\Model\EnableTwoFactorRequest;
 use Packagist\WebBundle\Form\Type\EnableTwoFactorAuthType;
 use Packagist\WebBundle\Model\RedisAdapter;
 use Packagist\WebBundle\Security\TwoFactorAuthManager;
-use Pagerfanta\Adapter\DoctrineORMAdapter;
+use Pagerfanta\Doctrine\ORM\QueryAdapter;
 use Pagerfanta\Pagerfanta;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -237,8 +237,9 @@ class UserController extends Controller
             new RedisAdapter($this->get('packagist.favorite_manager'), $user, 'getFavorites', 'getFavoriteCount')
         );
 
+        $paginator->setNormalizeOutOfRangePages(true);
         $paginator->setMaxPerPage(15);
-        $paginator->setCurrentPage(max(1, (int) $req->query->get('page', 1)), false, true);
+        $paginator->setCurrentPage(max(1, (int) $req->query->get('page', 1)));
 
         return array('packages' => $paginator, 'user' => $user);
     }
@@ -428,9 +429,10 @@ class UserController extends Controller
             ->getRepository(Package::class)
             ->getFilteredQueryBuilder(array('maintainer' => $user->getId()), true);
 
-        $paginator = new Pagerfanta(new DoctrineORMAdapter($packages, true));
+        $paginator = new Pagerfanta(new QueryAdapter($packages, true));
+        $paginator->setNormalizeOutOfRangePages(true);
         $paginator->setMaxPerPage(15);
-        $paginator->setCurrentPage(max(1, (int) $req->query->get('page', 1)), false, true);
+        $paginator->setCurrentPage(max(1, (int) $req->query->get('page', 1)));
 
         return $paginator;
     }


### PR DESCRIPTION
`WhiteOctoberPagerfantaBundle` is now abandoned and my `BabDevPagerfantaBundle` is the replacement for it.  The bundle is replaced with this pull request, and deprecated uses of the Pagerfanta API replaced as well.