### PR TITLE
Automatically create users when logging in via github

### DIFF
--- a/src/Packagist/WebBundle/Security/AccountEmailExistsWithoutGitHubException.php
+++ b/src/Packagist/WebBundle/Security/AccountEmailExistsWithoutGitHubException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Packagist\WebBundle\Security;
+
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+
+class AccountEmailExistsWithoutGitHubException extends UsernameNotFoundException
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getMessageKey()
+    {
+        return 'An account with your GitHub email already exists on Packagist.org but is not linked to your GitHub account. Please login to it via email/password and then connect your GitHub account in your settings.';
+    }
+}

--- a/src/Packagist/WebBundle/Security/AccountUsernameExistsWithoutGitHubException.php
+++ b/src/Packagist/WebBundle/Security/AccountUsernameExistsWithoutGitHubException.php
@@ -11,6 +11,6 @@ class AccountUsernameExistsWithoutGitHubException extends UsernameNotFoundExcept
      */
     public function getMessageKey()
     {
-        return 'An account with your GitHub user already exists on Packagist.org but is not linked to your GitHub account. Please login to it via username/password and then connect your GitHub account in your settings.';
+        return 'An account with your GitHub username already exists on Packagist.org but is not linked to your GitHub account. Please login to it via username/password and then connect your GitHub account in your settings.';
     }
 }

--- a/src/Packagist/WebBundle/Security/AccountUsernameExistsWithoutGitHubException.php
+++ b/src/Packagist/WebBundle/Security/AccountUsernameExistsWithoutGitHubException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Packagist\WebBundle\Security;
+
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+
+class AccountUsernameExistsWithoutGitHubException extends UsernameNotFoundException
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getMessageKey()
+    {
+        return 'An account with your GitHub user already exists on Packagist.org but is not linked to your GitHub account. Please login to it via username/password and then connect your GitHub account in your settings.';
+    }
+}


### PR DESCRIPTION
And fails with a clear message if a user already exists but is not connected, fixes #1111