### PR TITLE
4.4 Upgrade Tweaks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
         "symfony/framework-bundle": "4.4.*",
         "symfony/http-client": "4.4.*",
         "symfony/intl": "4.4.*",
+        "symfony/lock": "4.4.*",
         "symfony/mailer": "4.4.*",
         "symfony/monolog-bundle": "^3.1",
         "symfony/process": "4.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8d9bce0d00bde608e1eb1ad92c065686",
+    "content-hash": "4917e2d39204cf9206e85ebaac3e051c",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -7758,6 +7758,83 @@
                 }
             ],
             "time": "2020-10-24T11:50:19+00:00"
+        },
+        {
+            "name": "symfony/lock",
+            "version": "v4.4.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/lock.git",
+                "reference": "25c6703afa7b1554750c864abbb33cf867ef5919"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/lock/zipball/25c6703afa7b1554750c864abbb33cf867ef5919",
+                "reference": "25c6703afa7b1554750c864abbb33cf867ef5919",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "psr/log": "~1.0"
+            },
+            "conflict": {
+                "doctrine/dbal": "<2.5"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^2.5|^3.0",
+                "predis/predis": "~1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Lock\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jérémy Derussé",
+                    "email": "jeremy@derusse.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Lock Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cas",
+                "flock",
+                "locking",
+                "mutex",
+                "redlock",
+                "semaphore"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/lock/tree/v4.4.17"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-28T20:42:29+00:00"
         },
         {
             "name": "symfony/mailer",

--- a/config/routes/hwioauth_fosub.yaml
+++ b/config/routes/hwioauth_fosub.yaml
@@ -20,16 +20,16 @@ fos_user_change_password:
 
 
 hwi_oauth_connect:
-    resource: '@HWIOAuthBundle/Resources/config/routing/connect.xml'
+    resource: '@HWIOAuthBundle/Resources/config/routing/connect_41.xml'
     prefix:   /connect
 
 # overrides the fosub /login page
 hwi_oauth_login:
-    resource: '@HWIOAuthBundle/Resources/config/routing/login.xml'
+    resource: '@HWIOAuthBundle/Resources/config/routing/login_41.xml'
     prefix:   /login
 
 hwi_oauth_redirect:
-    resource: '@HWIOAuthBundle/Resources/config/routing/redirect.xml'
+    resource: '@HWIOAuthBundle/Resources/config/routing/redirect_41.xml'
     prefix:   /login
 
 github_check:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -36,6 +36,7 @@ services:
             $metadataDir: '%packagist_metadata_dir%'
             $trustedIpHeader: '%trusted_ip_header%'
             $algoliaIndexName: '%env(ALGOLIA_INDEX_NAME)%'
+            $githubWebhookSecret: '%env(APP_GITHUB_WEBHOOK_SECRET)%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,7 @@
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
-        <server name="SYMFONY_PHPUNIT_VERSION" value="7.5" />
+        <server name="SYMFONY_PHPUNIT_VERSION" value="8.5" />
     </php>
 
     <testsuites>

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -13,7 +13,7 @@
 namespace App\Controller;
 
 use Doctrine\Persistence\ManagerRegistry;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller as BaseController;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController as BaseController;
 use Pagerfanta\Doctrine\ORM\QueryAdapter;
 use Pagerfanta\Pagerfanta;
 use App\Entity\Package;

--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -990,7 +990,7 @@ class PackageController extends Controller
             $em->persist($package);
             $em->flush();
 
-            $this->get("session")->getFlashBag()->set("success", "Changes saved.");
+            $this->addFlash("success", "Changes saved.");
 
             return $this->redirect(
                 $this->generateUrl("view_package", array("name" => $package->getName()))

--- a/src/Model/DownloadManager.php
+++ b/src/Model/DownloadManager.php
@@ -12,7 +12,7 @@
 
 namespace App\Model;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\DBAL\Connection;
 use App\Entity\Package;
 use App\Entity\Version;

--- a/src/Twig/PackagistExtension.php
+++ b/src/Twig/PackagistExtension.php
@@ -5,7 +5,6 @@ namespace App\Twig;
 use App\Model\ProviderManager;
 use App\Security\RecaptchaHelper;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Composer\Repository\PlatformRepository;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
@@ -18,17 +17,14 @@ class PackagistExtension extends AbstractExtension
      * @var ProviderManager
      */
     private $providerManager;
-    /** @var CsrfTokenManagerInterface */
-    private $csrfTokenManager;
     /** @var RecaptchaHelper */
     private $recaptchaHelper;
     /** @var RequestStack */
     private $requestStack;
 
-    public function __construct(ProviderManager $providerManager, CsrfTokenManagerInterface $csrfTokenManager, RecaptchaHelper $recaptchaHelper, RequestStack $requestStack)
+    public function __construct(ProviderManager $providerManager, RecaptchaHelper $recaptchaHelper, RequestStack $requestStack)
     {
         $this->providerManager = $providerManager;
-        $this->csrfTokenManager = $csrfTokenManager;
         $this->recaptchaHelper = $recaptchaHelper;
         $this->requestStack = $requestStack;
     }
@@ -55,7 +51,6 @@ class PackagistExtension extends AbstractExtension
     public function getFunctions()
     {
         return array(
-            new TwigFunction('csrf_token', [$this, 'getCsrfToken']),
             new TwigFunction('requires_recaptcha', [$this, 'requiresRecaptcha']),
         );
     }
@@ -124,11 +119,6 @@ class PackagistExtension extends AbstractExtension
         });
 
         return $links;
-    }
-
-    public function getCsrfToken($name)
-    {
-        return $this->csrfTokenManager->getToken($name)->getValue();
     }
 
     public function requiresRecaptcha(?string $username): bool

--- a/symfony.lock
+++ b/symfony.lock
@@ -1,0 +1,302 @@
+{
+    "doctrine/sql-formatter": {
+        "version": "1.1.1"
+    },
+    "nikic/php-parser": {
+        "version": "v4.10.2"
+    },
+    "symfony/asset": {
+        "version": "v4.4.16"
+    },
+    "symfony/browser-kit": {
+        "version": "v4.4.16"
+    },
+    "symfony/cache": {
+        "version": "v4.4.16"
+    },
+    "symfony/cache-contracts": {
+        "version": "v2.2.0"
+    },
+    "symfony/config": {
+        "version": "v4.4.16"
+    },
+    "symfony/console": {
+        "version": "4.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "4.4",
+            "ref": "ea8c0eda34fda57e7d5cd8cbd889e2a387e3472c"
+        },
+        "files": [
+            "bin/console",
+            "config/bootstrap.php"
+        ]
+    },
+    "symfony/css-selector": {
+        "version": "v4.4.16"
+    },
+    "symfony/debug": {
+        "version": "v4.4.16"
+    },
+    "symfony/debug-bundle": {
+        "version": "4.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "4.1",
+            "ref": "f8863cbad2f2e58c4b65fa1eac892ab189971bea"
+        },
+        "files": [
+            "config/packages/dev/debug.yaml"
+        ]
+    },
+    "symfony/dependency-injection": {
+        "version": "v4.4.16"
+    },
+    "symfony/doctrine-bridge": {
+        "version": "v4.4.16"
+    },
+    "symfony/dom-crawler": {
+        "version": "v4.4.16"
+    },
+    "symfony/dotenv": {
+        "version": "v4.4.16"
+    },
+    "symfony/error-handler": {
+        "version": "v4.4.16"
+    },
+    "symfony/event-dispatcher": {
+        "version": "v4.4.16"
+    },
+    "symfony/event-dispatcher-contracts": {
+        "version": "v1.1.9"
+    },
+    "symfony/expression-language": {
+        "version": "v4.4.16"
+    },
+    "symfony/filesystem": {
+        "version": "v4.4.16"
+    },
+    "symfony/finder": {
+        "version": "v4.4.16"
+    },
+    "symfony/flex": {
+        "version": "1.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "1.0",
+            "ref": "c0eeb50665f0f77226616b6038a9b06c03752d8e"
+        },
+        "files": [
+            ".env"
+        ]
+    },
+    "symfony/form": {
+        "version": "v4.4.16"
+    },
+    "symfony/framework-bundle": {
+        "version": "4.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "4.4",
+            "ref": "df1f2fe60b8fbb5cf7e26a7af19445c128a13b90"
+        },
+        "files": [
+            "config/bootstrap.php",
+            "config/packages/cache.yaml",
+            "config/packages/framework.yaml",
+            "config/packages/test/framework.yaml",
+            "config/preload.php",
+            "config/routes/dev/framework.yaml",
+            "config/services.yaml",
+            "web/index.php",
+            "src/Controller/.gitignore",
+            "src/Kernel.php"
+        ]
+    },
+    "symfony/http-client": {
+        "version": "v4.4.16"
+    },
+    "symfony/http-client-contracts": {
+        "version": "v2.3.1"
+    },
+    "symfony/http-foundation": {
+        "version": "v4.4.16"
+    },
+    "symfony/http-kernel": {
+        "version": "v4.4.16"
+    },
+    "symfony/inflector": {
+        "version": "v4.4.16"
+    },
+    "symfony/intl": {
+        "version": "v4.4.16"
+    },
+    "symfony/mailer": {
+        "version": "4.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "4.3",
+            "ref": "15658c2a0176cda2e7dba66276a2030b52bd81b2"
+        },
+        "files": [
+            "config/packages/mailer.yaml"
+        ]
+    },
+    "symfony/maker-bundle": {
+        "version": "1.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "1.0",
+            "ref": "fadbfe33303a76e25cb63401050439aa9b1a9c7f"
+        }
+    },
+    "symfony/mime": {
+        "version": "v4.4.16"
+    },
+    "symfony/monolog-bridge": {
+        "version": "v4.4.16"
+    },
+    "symfony/options-resolver": {
+        "version": "v4.4.16"
+    },
+    "symfony/process": {
+        "version": "v4.4.16"
+    },
+    "symfony/property-access": {
+        "version": "v4.4.16"
+    },
+    "symfony/property-info": {
+        "version": "v4.4.16"
+    },
+    "symfony/routing": {
+        "version": "4.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "4.2",
+            "ref": "683dcb08707ba8d41b7e34adb0344bfd68d248a7"
+        },
+        "files": [
+            "config/packages/prod/routing.yaml",
+            "config/packages/routing.yaml",
+            "config/routes.yaml"
+        ]
+    },
+    "symfony/security-bundle": {
+        "version": "4.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "4.4",
+            "ref": "7b4408dc203049666fe23fabed23cbadc6d8440f"
+        },
+        "files": [
+            "config/packages/security.yaml"
+        ]
+    },
+    "symfony/security-core": {
+        "version": "v4.4.16"
+    },
+    "symfony/security-csrf": {
+        "version": "v4.4.16"
+    },
+    "symfony/security-guard": {
+        "version": "v4.4.16"
+    },
+    "symfony/security-http": {
+        "version": "v4.4.16"
+    },
+    "symfony/serializer": {
+        "version": "v4.4.16"
+    },
+    "symfony/service-contracts": {
+        "version": "v2.2.0"
+    },
+    "symfony/stopwatch": {
+        "version": "v4.4.16"
+    },
+    "symfony/templating": {
+        "version": "v4.4.16"
+    },
+    "symfony/translation": {
+        "version": "3.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "3.3",
+            "ref": "2ad9d2545bce8ca1a863e50e92141f0b9d87ffcd"
+        },
+        "files": [
+            "config/packages/translation.yaml",
+            "translations/.gitignore"
+        ]
+    },
+    "symfony/translation-contracts": {
+        "version": "v2.3.0"
+    },
+    "symfony/twig-bridge": {
+        "version": "v4.4.16"
+    },
+    "symfony/twig-bundle": {
+        "version": "4.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "4.4",
+            "ref": "15a41bbd66a1323d09824a189b485c126bbefa51"
+        },
+        "files": [
+            "config/packages/test/twig.yaml",
+            "config/packages/twig.yaml",
+            "templates/base.html.twig"
+        ]
+    },
+    "symfony/validator": {
+        "version": "4.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "4.3",
+            "ref": "d902da3e4952f18d3bf05aab29512eb61cabd869"
+        },
+        "files": [
+            "config/packages/test/validator.yaml",
+            "config/packages/validator.yaml"
+        ]
+    },
+    "symfony/var-dumper": {
+        "version": "v4.4.16"
+    },
+    "symfony/var-exporter": {
+        "version": "v4.4.16"
+    },
+    "symfony/web-link": {
+        "version": "v4.4.16"
+    },
+    "symfony/web-profiler-bundle": {
+        "version": "3.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "3.3",
+            "ref": "6bdfa1a95f6b2e677ab985cd1af2eae35d62e0f6"
+        },
+        "files": [
+            "config/packages/dev/web_profiler.yaml",
+            "config/packages/test/web_profiler.yaml",
+            "config/routes/dev/web_profiler.yaml"
+        ]
+    },
+    "symfony/yaml": {
+        "version": "v4.4.16"
+    },
+    "twig/extra-bundle": {
+        "version": "v3.1.1"
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -135,6 +135,9 @@
     "symfony/intl": {
         "version": "v4.4.16"
     },
+    "symfony/lock": {
+        "version": "v4.4.17"
+    },
     "symfony/mailer": {
         "version": "4.3",
         "recipe": {


### PR DESCRIPTION
- Added `symfony/lock` component for the lockable trait to work on the worker command
- Checked in `symfony.lock` for Flex
- Set PHPUnit default version at 8.5 (matches current master)
- Replaced `$this->get()` use in controllers with DI (for both params and services)
- Removed local `csrf_token()` Twig function in favor of the one from the framework