### PR TITLE
Package: fix update job failure email

### DIFF
--- a/src/Model/PackageManager.php
+++ b/src/Model/PackageManager.php
@@ -136,7 +136,7 @@ class PackageManager
             $recipients = array();
             foreach ($package->getMaintainers() as $maintainer) {
                 if ($maintainer->isNotifiableForFailures()) {
-                    $recipients[$maintainer->getEmail()] = $maintainer->getUsername();
+                    $recipients[$maintainer->getEmail()] = new Address($maintainer->getEmail(), $maintainer->getUsername());
                 }
             }
 
@@ -151,7 +151,7 @@ class PackageManager
                 $message = (new Email())
                     ->subject($package->getName().' failed to update, invalid composer.json data')
                     ->from(new Address($this->options['from'], $this->options['fromName']))
-                    ->to($recipients)
+                    ->to(...array_values($recipients))
                     ->text($body)
                 ;
 


### PR DESCRIPTION
Package update jobs with a broken branch or failure currently return instead of the actual error and also do not email the maintainers because of `{"status":"errored","message":"An unexpected failure occurred","exception":[],"exceptionMsg":"An address can be an instance of Address or a string (\\\"array\\\") given).\",\"exceptionClass\":\"Symfony\\\\Component\\\\Mime\\\\Exception\\\\InvalidArgumentException\"}"`