### PR TITLE
Full package list as a big JSON file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,6 +80,7 @@
         "symfony/validator": "4.4.*",
         "symfony/web-link": "4.4.*",
         "symfony/yaml": "4.4.*",
+        "thecodingmachine/safe": "^1.3",
         "twig/extra-bundle": "^2.12|^3.0",
         "twig/string-extra": "^3.2",
         "twig/twig": "^2.12|^3.0"

--- a/src/Command/DumpFullPackagesCommand.php
+++ b/src/Command/DumpFullPackagesCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Package\PackageDumper;
+use App\Service\Locker;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DumpFullPackagesCommand extends Command
+{
+    private PackageDumper $packageDumper;
+    private Locker $locker;
+    private string $cacheDir;
+
+    public function __construct(PackageDumper $packageDumper, Locker $locker, string $cacheDir)
+    {
+        $this->packageDumper = $packageDumper;
+        $this->locker = $locker;
+        $this->cacheDir = $cacheDir;
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('packagist:dump-full')
+            ->setDescription('Dumps the packages with full information into a packages-full.json')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $verbose = (bool) $input->getOption('verbose');
+
+        $deployLock = $this->cacheDir.'/deploy.globallock';
+        if (file_exists($deployLock)) {
+            if ($verbose) {
+                $output->writeln('Aborting, '.$deployLock.' file present');
+            }
+            return 0;
+        }
+
+        $lockName = $this->getName();
+
+        if (! $this->locker->lockCommand($lockName)) {
+            if ($verbose) {
+                $output->writeln('Aborting, another task is running already');
+            }
+            return 0;
+        }
+
+        try {
+            $this->packageDumper->dump();
+        } finally {
+            $this->locker->unlockCommand($lockName);
+        }
+
+        return 0;
+    }
+}

--- a/src/Command/DumpPackagesCommand.php
+++ b/src/Command/DumpPackagesCommand.php
@@ -12,7 +12,6 @@
 
 namespace App\Command;
 
-use App\Package\PackageDumper;
 use Doctrine\Persistence\ManagerRegistry;
 use App\Entity\Package;
 use App\Package\SymlinkDumper;
@@ -29,20 +28,17 @@ class DumpPackagesCommand extends Command
 {
     use \App\Util\DoctrineTrait;
 
-    private SymlinkDumper $symlinkDumper;
-    private PackageDumper $packageDumper;
+    private SymlinkDumper $dumper;
     private Locker $locker;
     private ManagerRegistry $doctrine;
     private string $cacheDir;
 
-    public function __construct(SymlinkDumper $symlinkDumper, PackageDumper $packageDumper, Locker $locker, ManagerRegistry $doctrine, string $cacheDir)
+    public function __construct(SymlinkDumper $dumper, Locker $locker, ManagerRegistry $doctrine, string $cacheDir)
     {
-        $this->symlinkDumper = $symlinkDumper;
-        $this->packageDumper = $packageDumper;
+        $this->dumper = $dumper;
         $this->locker = $locker;
         $this->doctrine = $doctrine;
         $this->cacheDir = $cacheDir;
-
         parent::__construct();
     }
 
@@ -86,21 +82,11 @@ class DumpPackagesCommand extends Command
 
         if ($gc) {
             try {
-                $this->symlinkDumper->gc();
+                $this->dumper->gc();
             } finally {
                 $this->locker->unlockCommand($lockName);
             }
             return 0;
-        }
-
-        if ($verbose) {
-            $output->writeln('Dumping full package list...');
-        }
-
-        $this->packageDumper->dump();
-
-        if ($verbose) {
-            $output->writeln('Dumping packages...');
         }
 
         if ($force) {
@@ -124,7 +110,7 @@ class DumpPackagesCommand extends Command
         gc_enable();
 
         try {
-            $result = $this->symlinkDumper->dump($ids, $force, $verbose);
+            $result = $this->dumper->dump($ids, $force, $verbose);
         } finally {
             $this->locker->unlockCommand($lockName);
         }

--- a/src/Command/DumpPackagesCommand.php
+++ b/src/Command/DumpPackagesCommand.php
@@ -39,9 +39,9 @@ class DumpPackagesCommand extends Command
     {
         $this->symlinkDumper = $symlinkDumper;
         $this->packageDumper = $packageDumper;
-        $this->locker        = $locker;
-        $this->doctrine      = $doctrine;
-        $this->cacheDir      = $cacheDir;
+        $this->locker = $locker;
+        $this->doctrine = $doctrine;
+        $this->cacheDir = $cacheDir;
 
         parent::__construct();
     }

--- a/src/Package/PackageDumper.php
+++ b/src/Package/PackageDumper.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Package;
+
+use App\Entity\Package;
+use App\Entity\PackageRepository;
+use App\Entity\User;
+use App\Model\DownloadManager;
+use App\Model\FavoriteManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Generator;
+use function Safe\fclose;
+use function Safe\fopen;
+use function Safe\fwrite;
+use function Safe\realpath;
+use function Safe\rename;
+use function Safe\tempnam;
+
+/**
+ * Dumps all packages, together with basic information, as a big JSON file, to the web root.
+ */
+class PackageDumper
+{
+    private EntityManagerInterface $em;
+
+    private DownloadManager $downloadManager;
+
+    private FavoriteManager $favoriteManager;
+
+    private string $webDir;
+
+    public function __construct(
+        EntityManagerInterface $em,
+        DownloadManager $downloadManager,
+        FavoriteManager $favoriteManager,
+        string $webDir
+    ) {
+        $this->em              = $em;
+        $this->downloadManager = $downloadManager;
+        $this->favoriteManager = $favoriteManager;
+        $this->webDir          = realpath($webDir);
+    }
+
+    public function dump(): void
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'packages-full.json.');
+
+        $fp = fopen($tmpFile, 'wb');
+        fwrite($fp, '[');
+
+        $comma = '';
+
+        foreach ($this->generatePackageData() as $packageData) {
+            fwrite($fp, $comma . json_encode($packageData, JSON_PRETTY_PRINT));
+            $comma = ',';
+        }
+
+        fwrite($fp, ']');
+        fclose($fp);
+
+        rename($tmpFile, $this->webDir . '/packages-full.json');
+    }
+
+    private function generatePackageData(): Generator
+    {
+        $lastId = 0;
+
+        /** @var PackageRepository $packageRepository */
+        $packageRepository = $this->em->getRepository(Package::class);
+
+        while (true) {
+            $this->em->clear();
+            $packages = $this->getPackageBatch($lastId);
+
+            if (! $packages) {
+                break;
+            }
+
+            foreach ($packages as $package) {
+                $maintainers = array_map(
+                    fn(User $user) => $user->toArray(),
+                    $package->getMaintainers()->toArray()
+                );
+
+                $data = [
+                    'name'               => $package->getName(),
+                    'description'        => $package->getDescription(),
+                    'time'               => $package->getCreatedAt()->format('c'),
+                    'maintainers'        => $maintainers,
+                    'type'               => $package->getType(),
+                    'repository'         => $package->getRepository(),
+                    'github_stars'       => $package->getGitHubStars(),
+                    'github_watchers'    => $package->getGitHubWatches(),
+                    'github_forks'       => $package->getGitHubForks(),
+                    'github_open_issues' => $package->getGitHubOpenIssues(),
+                    'language'           => $package->getLanguage(),
+                ];
+
+                $data['abandoned']  = $package->isAbandoned() ? ($package->getReplacementPackage() ?? true) : false;
+                $data['dependents'] = $packageRepository->getDependantCount($package->getName());
+                $data['suggesters'] = $packageRepository->getSuggestCount($package->getName());
+                $data['downloads']  = $this->downloadManager->getDownloads($package);
+                $data['favers']     = $this->favoriteManager->getFaverCount($package);
+
+                yield $data;
+
+                $lastId = $package->getId();
+            }
+        }
+    }
+
+    /**
+     * Returns a batch of max. 1000 packages.
+     *
+     * @return Package[]
+     */
+    private function getPackageBatch(int $lastId): array
+    {
+        return $this->em->createQueryBuilder()
+            ->select('p')
+            ->from(Package::class, 'p')
+            ->where('p.id > :lastId')
+            ->setParameter('lastId', $lastId)
+            ->orderBy('p.id', 'ASC')
+            ->setMaxResults(1000)
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/src/Package/PackageDumper.php
+++ b/src/Package/PackageDumper.php
@@ -37,10 +37,10 @@ class PackageDumper
         FavoriteManager $favoriteManager,
         string $webDir
     ) {
-        $this->em              = $em;
+        $this->em = $em;
         $this->downloadManager = $downloadManager;
         $this->favoriteManager = $favoriteManager;
-        $this->webDir          = realpath($webDir);
+        $this->webDir = realpath($webDir);
     }
 
     public function dump(): void
@@ -98,11 +98,11 @@ class PackageDumper
                     'language'           => $package->getLanguage(),
                 ];
 
-                $data['abandoned']  = $package->isAbandoned() ? ($package->getReplacementPackage() ?? true) : false;
+                $data['abandoned'] = $package->isAbandoned() ? ($package->getReplacementPackage() ?? true) : false;
                 $data['dependents'] = $packageRepository->getDependantCount($package->getName());
                 $data['suggesters'] = $packageRepository->getSuggestCount($package->getName());
-                $data['downloads']  = $this->downloadManager->getDownloads($package);
-                $data['favers']     = $this->favoriteManager->getFaverCount($package);
+                $data['downloads'] = $this->downloadManager->getDownloads($package);
+                $data['favers'] = $this->favoriteManager->getFaverCount($package);
 
                 yield $data;
 


### PR DESCRIPTION
### What's this?

This is an implementation of my suggestion in an earlier email:

> I'm wondering if you'd be willing to provide an export of *all* packages on Packagist, together with basic information (description, downloads, etc., basically everything but versions), as a static file updated every 24h for example?
> 
> Background: I have in mind to create a website that lists the top PHP packages, fastest growing packages, etc.
> 
> The only way I found using the current API, is to get the list of packages every day:
> https://packagist.org/packages/list.json
> 
> Then get info about each package individually:
> https://packagist.org/packages/monolog/monolog.json
> 
> This translates into roughly 300,000 requests per day, and it's an awful lot of stress on your server, especially considering I'm probably not the only one to do this.
> 
> Any chance you'd consider that? I could probably help with a PR, although it'd probably take me some time to dig into the source code.

### What does it do?

The `packagist:dump-full` command generates a new JSON file in the web root: `packages-full.json`. It is designed to be run once a day.

The output is a big JSON array, where each element is a JSON object similar to the output of `/packages/{name}.json`, with the following differences:

- pretty-printed
- no `versions` key
- the `abandoned` key is always set

Once deployed on packagist.org, I expect the output file to be ~220 MB. The `PackageDumper` is designed to use little memory, so it should not be a problem to create the file. Client applications willing to read it though, will probably need a JSON streaming library such as [salsify/json-streaming-parser](https://github.com/salsify/jsonstreamingparser).

### Sample output

```
[{
    "name": "guzzlehttp\/psr7",
    "description": "PSR-7 message implementation that also provides common utility methods",
    "time": "2015-03-05T23:21:09+01:00",
    ...
},{
    ...
}]
```

### Other ideas I've considered:

- creating a zip file of all the `web/(p|p2)/{vendor}/{package}.json` files; this would work, but it's bloated with versions, and somehow I like a single file for all packages
- creating a big xml file instead of a big json file; xml is easily streamable, but because there also is a json streamer library available for PHP, I don't think it brings much value to use a different output format when packagist uses json only for now

### Questions

- <s>the dump is currently performed as part of the `packagist:dump` command; is this command run every 24 hours? If not, this new dump would have to be extracted to its own command to be run exactly once a day</s> **Update**: now extracted to its own command.
- should we gzip the file and only offer a gz version on the web? Or both a `.json` and a `.json.gz`?

Looking forward to your comments!