### PR TITLE
Update the CSP configuration

### DIFF
--- a/config/packages/nelmio_security.yaml
+++ b/config/packages/nelmio_security.yaml
@@ -26,13 +26,13 @@ nelmio_security:
                 - 'https://www.gstatic.com/recaptcha/'
             connect-src:
                 - 'self'
-                - '*.algolia.net'
-                - '*.algolianet.com'
+                - 'https://*.algolia.net'
+                - 'https://*.algolianet.com'
+                - 'https://www.google-analytics.com/'
             img-src:
                 - 'self'
                 - 'https:'
                 - 'data:'
-                - 'http://www.google-analytics.com/'
             style-src:
                 - 'self'
                 - 'unsafe-inline'


### PR DESCRIPTION
- allow AJAX request to www.google-analytics.com as they are needed by GA
- restrict Algolia rules to HTTPS, following their own recommendation anyway
- remove the non-HTTPS img-src for google analytics. This is blocked by blocking mixed content anyway.