### PR TITLE
Make delete confirmation alerts more descriptive

### DIFF
--- a/web/js/view.js
+++ b/web/js/view.js
@@ -162,7 +162,7 @@
     });
     $('.package .delete').on('submit', function (e) {
         e.preventDefault();
-        if (window.confirm('Are you sure?')) {
+        if (window.confirm('Are you sure you want to delete this package?')) {
             dispatchAjaxForm(this, function () {
                 humane.log('Package successfully deleted', {timeout: 0, clickToClose: true});
                 setTimeout(function () {
@@ -187,7 +187,7 @@
         e.preventDefault();
         e.stopImmediatePropagation();
         var form = this;
-        if (window.confirm('Are you sure?')) {
+        if (window.confirm('Are you sure you want to delete this package version?')) {
             dispatchAjaxForm(this, function () {
                 humane.log('Version successfully deleted', {timeout: 3000, clickToClose: true});
                 $(form).closest('.version').remove();


### PR DESCRIPTION
I noticed that both package delete and version delete buttons show a plain `Are you sure?` confirmation message. IMO it’s better when the alert contains what you are about to delete and that you’re even going to delete that.

Ideally, for the package versions, it would tell the user the name of the version they’re about to delete. That’s because the delete buttons are pretty close to each other, avoiding misclicks.

![image](https://user-images.githubusercontent.com/28510368/116087326-0a702800-a6a1-11eb-8050-0a87c8102760.png)
