### PR TITLE
Fix conditions for displaying maintainer forms

### DIFF
--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -1393,7 +1393,7 @@ class PackageController extends Controller
 
     private function createAddMaintainerForm(Package $package)
     {
-        if (!($user = $this->getUser()) || !$this->isGranted('ROLE_EDIT_PACKAGES') || !$package->getMaintainers()->contains($user)) {
+        if (!($user = $this->getUser()) || (!$this->isGranted('ROLE_EDIT_PACKAGES') && !$package->getMaintainers()->contains($user))) {
             return null;
         }
 
@@ -1403,7 +1403,7 @@ class PackageController extends Controller
 
     private function createRemoveMaintainerForm(Package $package)
     {
-        if (!($user = $this->getUser()) || 1 == $package->getMaintainers()->count() || !$this->isGranted('ROLE_EDIT_PACKAGES') || !$package->getMaintainers()->contains($user)) {
+        if (!($user = $this->getUser()) || 1 == $package->getMaintainers()->count() || (!$this->isGranted('ROLE_EDIT_PACKAGES') && !$package->getMaintainers()->contains($user))) {
             return null;
         }
 


### PR DESCRIPTION
The negation of a OR is not the OR of the negations. This was broken when switching that condition to include it in the early return (in https://github.com/composer/packagist/commit/c3f88efc5a96003eb38e368da96ce05cace013ec).

Closes #1181