### PR TITLE
Write the minified key at the beginning of the dumped file

### DIFF
--- a/src/Package/V2Dumper.php
+++ b/src/Package/V2Dumper.php
@@ -247,10 +247,10 @@ class V2Dumper
         $path = $dir . '/' . $filename;
 
         $metadata = [
+            'minified' => 'composer/2.0',
             'packages' => [
                 $packageName => MetadataMinifier::minify($versionArrays),
             ],
-            'minified' => 'composer/2.0',
         ];
 
         $json = json_encode($metadata, JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE);


### PR DESCRIPTION
This make it easier to see it when a human look at the JSON returned by packagist, as the list of versions is quite long.

I got this idea while answering #1194