### PR TITLE
Adding default MAILER_DSN

### DIFF
--- a/.env
+++ b/.env
@@ -23,7 +23,7 @@ APP_MAILER_FROM_NAME=
 #TRUSTED_PROXIES=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 #TRUSTED_HOSTS='^(localhost|example\.com)$'
 
-# MAILER_DSN=null://null
+MAILER_DSN=null://null
 
 # Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
 # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml


### PR DESCRIPTION
I just cloned the projected. I followed the steps in the readme and got an error that `MAILER_DSN` was missing. 

This adds a nice default value for MAILER_DSN. 