### PR TITLE
Add a "tagPattern" to allow some tags and ignore others

### DIFF
--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -1038,6 +1038,7 @@ class PackageController extends Controller
 
         $form = $this->createFormBuilder($package, ["validation_groups" => ["Update"]])
             ->add('repository', TextType::class)
+            ->add('tagPattern', TextType::class, ['required'=>false, 'label'=>'packages.tag_pattern.label'])
             ->setMethod('POST')
             ->setAction($this->generateUrl('edit_package', ['name' => $package->getName()]))
             ->getForm();

--- a/src/Entity/Package.php
+++ b/src/Entity/Package.php
@@ -188,6 +188,11 @@ class Package
      */
     private $suspect;
 
+    /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private $tagPattern;
+
     private $entityRepository;
     private $router;
 
@@ -881,6 +886,25 @@ class Package
     public function getSuspect(): ?string
     {
         return $this->suspect;
+    }
+
+    /**
+     * If defined, tags/versions must match this pattern or they will be ignored.
+     */
+    public function getTagPattern(): ?string
+    {
+        return $this->tagPattern;
+    }
+
+    /**
+     * @param string $tagPattern
+     */
+    public function setTagPattern(string $tagPattern): void
+    {
+        if ($tagPattern === '') {
+            $tagPattern = null;
+        }
+        $this->tagPattern = $tagPattern;
     }
 
     /**

--- a/src/Entity/Package.php
+++ b/src/Entity/Package.php
@@ -189,6 +189,7 @@ class Package
     private $suspect;
 
     /**
+     * @var string|null
      * @ORM\Column(type="string", length=255, nullable=true)
      */
     private $tagPattern;

--- a/src/Package/Updater.php
+++ b/src/Package/Updater.php
@@ -349,7 +349,7 @@ class Updater
 
         // Filter package versions
         $pattern = $package->getTagPattern();
-        if ($pattern !== null && $pattern !== '' && $pattern !== '*' && !preg_match('#'.$pattern.'#', $normVersion)) {
+        if ($pattern !== null && $pattern !== '' && $pattern !== '*' && !preg_match('#'.$pattern.'#', $data->getPrettyVersion())) {
             throw new VersionIgnoredException();
         }
 

--- a/src/Package/VersionIgnoredException.php
+++ b/src/Package/VersionIgnoredException.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace App\Package;
+
+/**
+ * Thrown when an ignored version is parsed.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class VersionIgnoredException extends \RuntimeException
+{
+}

--- a/templates/package/edit.html.twig
+++ b/templates/package/edit.html.twig
@@ -9,7 +9,12 @@
 
 <section class="row">
     {{ form_start(form, { attr: { class: 'col-md-6' } }) }}
-        {{ form_widget(form) }}
+        {{ form_row(form.repository) }}
+        <div class="form-group">
+            {{ form_label(form.tagPattern) }}
+            {{ form_widget(form.tagPattern) }}
+            <p>{{ 'packages.tag_pattern.help'|trans }}</p>
+        </div>
 
         <input class="btn btn-block btn-primary btn-lg" id="submit" type="submit" value="{{ 'edit.submit'|trans }}" />
     {{ form_end(form) }}

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -67,6 +67,13 @@ packages:
     from: "Packages from %vendor%"
     security_advisory_title: Security Advisories
     security_advisories: Security Advisories
+    tag_pattern:
+        label: Version regex
+        help: |
+            You may add a regex to only allow some specific versions. The default
+            behavior is to allow everyting (same as "*"). If you only want to add
+            versions starting with 2, 3, 4 or "dev-", you can add the following
+            regex (no quotes): "^([234]|dev-).*"
 
 browse:
     packages: Packages


### PR DESCRIPTION
My issue is that I want to be able to avoid adding some tags to packagist. Ie, I dont want the next major release to be available but I still want to tag patch releases on existing versions. I can also imagine that people are using tags for pre-releases or part of a very custom build process. 

This PR introduce a `$tagPattern` property on the Package where the user will be able to specify a regex. If a **new** tag does not match the regex it will not be added. 

This PR is missing a GUI but I would be happy to see if this feature (or a version of it) would be accepted first. 

### TODO

- [x] Add a GUI for adding a value for `Package::$tagPattern`