### PR TITLE
Fix readme h2 link color

### DIFF
--- a/web/css/main.css
+++ b/web/css/main.css
@@ -1498,7 +1498,7 @@ input:focus:invalid:focus, textarea:focus:invalid:focus, select:focus:invalid:fo
     vertical-align: middle;
 }
 
-.wrapper .content h2 a {
+.wrapper .content h2.title a {
     color: #2d2d32;
     font-weight: 600;
     text-decoration: none;


### PR DESCRIPTION
`.wrapper .content h2 a` selector matches the readme header link field causing it to be dark grey instead of orange like any other links. Instead, it the rule should be amended to match only the package title in page header.

```markdown
## Now available as [GitHub Action](https://packagist.org/)!
```

**Before:**
![image](https://user-images.githubusercontent.com/1985514/121862187-269d5680-cd2d-11eb-8af8-d2a8a3ffe793.png)

**After:**
![image](https://user-images.githubusercontent.com/1985514/121862251-37e66300-cd2d-11eb-968c-c8734ab6b457.png)

BTW I think it would be worth to introduce SCSS as there are many nested styles and rules that are repeated. Let me know if I can help with that.