### PR TITLE
Added support for GitHub Security Advisories

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ These steps are provided for development purposes only.
    ```bash
    symfony serve
    ```
-6. Run a CRON job `bin/console packagist:run-workers` to make sure packages update.
+6. Start Redis:
+   ```bash
+   docker compose up -d
+   ```
+7. Run a CRON job `bin/console packagist:run-workers` to make sure packages update.
 
 You should now be able to access the site, create a user, etc.
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -127,3 +127,4 @@ services:
         bind:
             $sources:
                 'FriendsOfPHP/security-advisories': '@App\SecurityAdvisory\FriendsOfPhpSecurityAdvisoriesSource'
+                'GitHub': '@App\SecurityAdvisory\GitHubSecurityAdvisoriesSource'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+    redis:
+        image: redis:6.2-alpine
+        ports:
+            - 6379:6379

--- a/src/SecurityAdvisory/FriendsOfPhpSecurityAdvisoriesSource.php
+++ b/src/SecurityAdvisory/FriendsOfPhpSecurityAdvisoriesSource.php
@@ -31,10 +31,13 @@ class FriendsOfPhpSecurityAdvisoriesSource implements SecurityAdvisorySourceInte
         $this->logger = $logger;
     }
 
-    public function getAdvisories(ConsoleIO $io): ?array
+    public function getAdvisories(ConsoleIO $io, Package $package): ?array
     {
-        $package = $this->doctrine->getRepository(Package::class)->findOneBy(['name' => self::SECURITY_PACKAGE]);
-        if (!$package || !($version = $this->doctrine->getRepository(Version::class)->findOneBy(['package' => $package->getId(), 'isDefaultBranch' => true]))) {
+        if ($package->getName() !== self::SECURITY_PACKAGE) {
+            return null;
+        }
+
+        if (!($version = $this->doctrine->getRepository(Version::class)->findOneBy(['package' => $package->getId(), 'isDefaultBranch' => true]))) {
             return null;
         }
 

--- a/src/SecurityAdvisory/GitHubSecurityAdvisoriesSource.php
+++ b/src/SecurityAdvisory/GitHubSecurityAdvisoriesSource.php
@@ -1,0 +1,127 @@
+<?php
+
+
+namespace App\SecurityAdvisory;
+
+use App\Entity\Package;
+use Composer\IO\ConsoleIO;
+use GuzzleHttp\Client;
+
+/**
+ * @author Yanick Witschi <yanick.witschi@terminal42.ch>
+ */
+class GitHubSecurityAdvisoriesSource implements SecurityAdvisorySourceInterface
+{
+    public const SOURCE_NAME = 'GitHub';
+
+    private Client $guzzle;
+
+    public function __construct(Client $guzzle)
+    {
+        $this->guzzle = $guzzle;
+    }
+
+    public function getAdvisories(ConsoleIO $io, Package $package): ?array
+    {
+        $githubToken = null;
+        $maintainers = $package->getMaintainers();
+        foreach ($maintainers as $maintainer) {
+            if ($maintainer->getGithubToken()) {
+                $githubToken = $maintainer->getGithubToken();
+                break;
+            }
+        }
+
+        if (null === $githubToken) {
+            return [];
+        }
+
+        /** @var RemoteSecurityAdvisory[] $advisories */
+        $advisories = [];
+        $hasNextPage = true;
+        $after = '';
+
+        while ($hasNextPage) {
+            $opts = [
+                'headers' => ['Authorization' => 'Bearer ' . $githubToken],
+                'json' => ['query' => $this->getQuery($package->getName(), $after)],
+            ];
+
+            $response = $this->guzzle->request('POST', 'https://api.github.com/graphql', $opts);
+            $data = json_decode($response->getBody()->getContents(), true);
+            $data = $data['data'];
+
+            foreach ($data['securityVulnerabilities']['nodes'] as $node) {
+                $remoteId = null;
+                $cve = null;
+
+                foreach ($node['advisory']['identifiers'] as $identifier) {
+                    if ('GHSA' === $identifier['type']) {
+                        $remoteId = $identifier['value'];
+                        continue;
+                    }
+                    if ('CVE' === $identifier['type']) {
+                        $cve = $identifier['value'];
+                    }
+                }
+
+                if (null === $remoteId) {
+                    continue;
+                }
+
+                if (isset($advisories[$remoteId])) {
+                    $advisories[$remoteId] = $advisories[$remoteId]->withAddedAffectedVersion($node['vulnerableVersionRange']);
+                    continue;
+                }
+
+                $advisories[$remoteId] = new RemoteSecurityAdvisory(
+                    $remoteId,
+                    $node['advisory']['summary'],
+                    $package->getName(),
+                    $node['vulnerableVersionRange'],
+                    $node['advisory']['permalink'],
+                    $cve,
+                    \DateTime::createFromFormat(\DateTimeInterface::ISO8601,  $node['advisory']['publishedAt']),
+                    null
+                );
+            }
+
+            $hasNextPage = $data['securityVulnerabilities']['pageInfo']['hasNextPage'];
+            $after = $data['securityVulnerabilities']['pageInfo']['endCursor'];
+        }
+
+        return array_values($advisories);
+    }
+
+    private function getQuery(string $packageName, string $after = ''): string
+    {
+        if ('' !== $after) {
+            $after = sprintf(',after:"%s"', $after);
+        }
+
+        $query = <<<QUERY
+query {
+  securityVulnerabilities(ecosystem:COMPOSER,package:"%s",first:100%s) {
+    nodes {
+      advisory {
+        summary,
+        permalink,
+        publishedAt,
+        identifiers {
+          type,
+          value
+        }
+      },
+      vulnerableVersionRange
+    },
+    pageInfo {
+      hasNextPage,
+      endCursor
+    }
+  }
+}
+QUERY;
+
+        return preg_replace('/[ \t\n]+/', '', sprintf($query, $packageName, $after));
+    }
+}

--- a/src/SecurityAdvisory/RemoteSecurityAdvisory.php
+++ b/src/SecurityAdvisory/RemoteSecurityAdvisory.php
@@ -67,6 +67,20 @@ class RemoteSecurityAdvisory
         return $this->composerRepository;
     }
 
+    public function withAddedAffectedVersion(string $version): self
+    {
+        return new self(
+            $this->getId(),
+            $this->getTitle(),
+            $this->getPackageName(),
+            implode('|', [$this->getAffectedVersions(), $version]),
+            $this->getLink(),
+            $this->getCve(),
+            $this->getDate(),
+            $this->getComposerRepository()
+        );
+    }
+
     public static function createFromFriendsOfPhp(string $fileNameWithPath, array $info): RemoteSecurityAdvisory
     {
         $date = null;

--- a/src/SecurityAdvisory/SecurityAdvisorySourceInterface.php
+++ b/src/SecurityAdvisory/SecurityAdvisorySourceInterface.php
@@ -2,6 +2,7 @@
 
 namespace App\SecurityAdvisory;
 
+use App\Entity\Package;
 use Composer\IO\ConsoleIO;
 
 interface SecurityAdvisorySourceInterface
@@ -9,5 +10,5 @@ interface SecurityAdvisorySourceInterface
     /**
      * @return null|RemoteSecurityAdvisory[]
      */
-    public function getAdvisories(ConsoleIO $io): ?array;
+    public function getAdvisories(ConsoleIO $io, Package $package): ?array;
 }

--- a/src/Service/Scheduler.php
+++ b/src/Service/Scheduler.php
@@ -59,9 +59,9 @@ class Scheduler
         return $this->createJob('githubuser:migrate', ['id' => $userId, 'old_scope' => $oldScope, 'new_scope' => $newScope], $userId);
     }
 
-    public function scheduleSecurityAdvisory(string $source, ?\DateTimeInterface $executeAfter = null): Job
+    public function scheduleSecurityAdvisory(string $source, int $packageId, ?\DateTimeInterface $executeAfter = null): Job
     {
-        return $this->createJob('security:advisory', ['source' => $source], null, $executeAfter);
+        return $this->createJob('security:advisory', ['source' => $source], $packageId, $executeAfter);
     }
 
     private function getPendingUpdateJob(int $packageId, $updateEqualRefs = false, $deleteBefore = false): ?string

--- a/src/Service/SecurityAdvisoryWorker.php
+++ b/src/Service/SecurityAdvisoryWorker.php
@@ -2,6 +2,7 @@
 
 namespace App\Service;
 
+use App\Entity\Package;
 use Composer\Console\HtmlOutputFormatter;
 use Composer\Factory;
 use Composer\IO\BufferIO;
@@ -35,6 +36,14 @@ class SecurityAdvisoryWorker
     public function process(Job $job, SignalHandler $signal): array
     {
         $sourceName = $job->getPayload()['source'];
+        $package = $this->doctrine->getRepository(Package::class)->findOneBy(['id' => $job->getPackageId()]);
+
+        if (!$package instanceof Package) {
+            $this->logger->info('Security advisory update failed, skipping', ['packageId' => $job->getPackageId()]);
+
+            return ['status' => Job::STATUS_ERRORED, 'message' => 'Security advisory update failed, skipped'];
+        }
+
         $lockAcquired = $this->locker->lockSecurityAdvisory($sourceName);
         if (!$lockAcquired) {
             return ['status' => Job::STATUS_RESCHEDULE, 'after' => new \DateTime('+5 minutes')];
@@ -44,7 +53,7 @@ class SecurityAdvisoryWorker
 
         /** @var SecurityAdvisorySourceInterface $source */
         $source = $this->sources[$sourceName];
-        $remoteAdvisories = $source->getAdvisories($io);
+        $remoteAdvisories = $source->getAdvisories($io, $package);
         if (null === $remoteAdvisories) {
             $this->logger->info('Security advisory update failed, skipping', ['source' => $source]);
 

--- a/src/Service/UpdaterWorker.php
+++ b/src/Service/UpdaterWorker.php
@@ -3,6 +3,7 @@
 namespace App\Service;
 
 use App\SecurityAdvisory\FriendsOfPhpSecurityAdvisoriesSource;
+use App\SecurityAdvisory\GitHubSecurityAdvisoriesSource;
 use Psr\Log\LoggerInterface;
 use Composer\Package\Loader\ArrayLoader;
 use Composer\Package\Loader\ValidatingArrayLoader;
@@ -270,7 +271,9 @@ class UpdaterWorker
         }
 
         if ($packageName === FriendsOfPhpSecurityAdvisoriesSource::SECURITY_PACKAGE) {
-            $this->scheduler->scheduleSecurityAdvisory(FriendsOfPhpSecurityAdvisoriesSource::SOURCE_NAME);
+            $this->scheduler->scheduleSecurityAdvisory(FriendsOfPhpSecurityAdvisoriesSource::SOURCE_NAME, $id);
+        } elseif (preg_match('{[@/]github.com[:/]([^/]+/[^/]+?)(\.git)?$}i', $package->getRepository())) {
+            $this->scheduler->scheduleSecurityAdvisory(GitHubSecurityAdvisoriesSource::SOURCE_NAME, $id);
         }
 
         return [

--- a/tests/SecurityAdvisory/GitHubSecurityAdvisoriesSourceTest.php
+++ b/tests/SecurityAdvisory/GitHubSecurityAdvisoriesSourceTest.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace App\Tests\SecurityAdvisory;
+
+use App\Entity\Package;
+use App\Entity\User;
+use App\SecurityAdvisory\GitHubSecurityAdvisoriesSource;
+use Composer\IO\BufferIO;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Yanick Witschi <yanick.witschi@terminal42.ch>
+ */
+class GitHubSecurityAdvisoriesSourceTest extends TestCase
+{
+    public function testNoAdvisoriesIfNoMaintainerHasAnyGitHubToken(): void
+    {
+        $client = $this->createMock(Client::class);
+
+        $source = new GitHubSecurityAdvisoriesSource($client);
+        $advisories = $source->getAdvisories(new BufferIO(), $this->getPackage());
+
+        $this->assertSame([], $advisories);
+    }
+
+    public function testWithoutPagination(): void
+    {
+        $transactions = [];
+        $history = Middleware::history($transactions);
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json; charset=utf-8'], json_encode($this->getGraphQLResultFirstPage(false))),
+        ]);
+        $handlerStack = HandlerStack::create($mock);
+        $handlerStack->push($history);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $source = new GitHubSecurityAdvisoriesSource($client);
+        $advisories = $source->getAdvisories(new BufferIO(), $this->getPackage('github-token'));
+
+        $this->assertCount(1, $transactions);
+        $this->assertSame('POST', $transactions[0]['request']->getMethod());
+        $this->assertSame('https://api.github.com/graphql', (string) $transactions[0]['request']->getUri());
+        $this->assertSame('Bearer github-token', $transactions[0]['request']->getHeader('Authorization')[0]);
+        $this->assertSame('{"query":"query{securityVulnerabilities(ecosystem:COMPOSER,package:\"vendor\/package\",first:100){nodes{advisory{summary,permalink,publishedAt,identifiers{type,value}},vulnerableVersionRange},pageInfo{hasNextPage,endCursor}}}"}', $transactions[0]['request']->getBody()->getContents());
+
+        $this->assertCount(2, $advisories);
+
+        $this->assertSame('GHSA-h58v-c6rf-g9f7', $advisories[0]->getId());
+        $this->assertSame('Cross site scripting in the system log', $advisories[0]->getTitle());
+        $this->assertSame('vendor/package', $advisories[0]->getPackageName());
+        $this->assertSame('>= 4.10.0, < 4.11.5|>= 4.5.0, < 4.9.16', $advisories[0]->getAffectedVersions());
+        $this->assertSame('https://github.com/advisories/GHSA-h58v-c6rf-g9f7', $advisories[0]->getLink());
+        $this->assertSame('CVE-2021-35210', $advisories[0]->getCve());
+        $this->assertSame('2021-07-01T17:00:04+0000', $advisories[0]->getDate()->format(\DateTimeInterface::ISO8601));
+        $this->assertSame(null, $advisories[0]->getComposerRepository());
+
+        $this->assertSame('GHSA-f7wm-x4gw-6m23', $advisories[1]->getId());
+        $this->assertSame('Insert tag injection in forms', $advisories[1]->getTitle());
+        $this->assertSame('vendor/package', $advisories[1]->getPackageName());
+        $this->assertSame('= 4.10.0', $advisories[1]->getAffectedVersions());
+        $this->assertSame('https://github.com/advisories/GHSA-f7wm-x4gw-6m23', $advisories[1]->getLink());
+        $this->assertSame('CVE-2020-25768', $advisories[1]->getCve());
+        $this->assertSame('2020-09-24T16:23:54+0000', $advisories[1]->getDate()->format(\DateTimeInterface::ISO8601));
+        $this->assertSame(null, $advisories[1]->getComposerRepository());
+    }
+
+    public function testWithPagination(): void
+    {
+        $transactions = [];
+        $history = Middleware::history($transactions);
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json; charset=utf-8'], json_encode($this->getGraphQLResultFirstPage(true))),
+            new Response(200, ['Content-Type' => 'application/json; charset=utf-8'], json_encode($this->getGraphQLResultSecondPage())),
+        ]);
+        $handlerStack = HandlerStack::create($mock);
+        $handlerStack->push($history);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $source = new GitHubSecurityAdvisoriesSource($client);
+        $advisories = $source->getAdvisories(new BufferIO(), $this->getPackage('github-token'));
+
+        $this->assertCount(2, $transactions);
+        $this->assertSame('POST', $transactions[0]['request']->getMethod());
+        $this->assertSame('https://api.github.com/graphql', (string) $transactions[0]['request']->getUri());
+        $this->assertSame('Bearer github-token', $transactions[0]['request']->getHeader('Authorization')[0]);
+        $this->assertSame('{"query":"query{securityVulnerabilities(ecosystem:COMPOSER,package:\"vendor\/package\",first:100){nodes{advisory{summary,permalink,publishedAt,identifiers{type,value}},vulnerableVersionRange},pageInfo{hasNextPage,endCursor}}}"}', $transactions[0]['request']->getBody()->getContents());
+        $this->assertSame('POST', $transactions[1]['request']->getMethod());
+        $this->assertSame('https://api.github.com/graphql', (string) $transactions[1]['request']->getUri());
+        $this->assertSame('Bearer github-token', $transactions[1]['request']->getHeader('Authorization')[0]);
+        $this->assertSame('{"query":"query{securityVulnerabilities(ecosystem:COMPOSER,package:\"vendor\/package\",first:100,after:\"Y3Vyc29yOnYyOpK5MjAyMC0wOS0yNFQxODoyMzo0MyswMjowMM0T9A==\"){nodes{advisory{summary,permalink,publishedAt,identifiers{type,value}},vulnerableVersionRange},pageInfo{hasNextPage,endCursor}}}"}', $transactions[1]['request']->getBody()->getContents());
+
+        $this->assertCount(2, $advisories);
+
+        $this->assertSame('GHSA-h58v-c6rf-g9f7', $advisories[0]->getId());
+        $this->assertSame('Cross site scripting in the system log', $advisories[0]->getTitle());
+        $this->assertSame('vendor/package', $advisories[0]->getPackageName());
+        $this->assertSame('>= 4.10.0, < 4.11.5|>= 4.5.0, < 4.9.16', $advisories[0]->getAffectedVersions());
+        $this->assertSame('https://github.com/advisories/GHSA-h58v-c6rf-g9f7', $advisories[0]->getLink());
+        $this->assertSame('CVE-2021-35210', $advisories[0]->getCve());
+        $this->assertSame('2021-07-01T17:00:04+0000', $advisories[0]->getDate()->format(\DateTimeInterface::ISO8601));
+        $this->assertSame(null, $advisories[0]->getComposerRepository());
+
+        $this->assertSame('GHSA-f7wm-x4gw-6m23', $advisories[1]->getId());
+        $this->assertSame('Insert tag injection in forms', $advisories[1]->getTitle());
+        $this->assertSame('vendor/package', $advisories[1]->getPackageName());
+        $this->assertSame('= 4.10.0|< 4.11.0', $advisories[1]->getAffectedVersions());
+        $this->assertSame('https://github.com/advisories/GHSA-f7wm-x4gw-6m23', $advisories[1]->getLink());
+        $this->assertSame('CVE-2020-25768', $advisories[1]->getCve());
+        $this->assertSame('2020-09-24T16:23:54+0000', $advisories[1]->getDate()->format(\DateTimeInterface::ISO8601));
+        $this->assertSame(null, $advisories[1]->getComposerRepository());
+    }
+
+
+    private function getPackage(string $githubToken = null): Package
+    {
+        $user = new User();
+        $user->setGithubToken($githubToken);
+
+        $package = new Package();
+        $package->setName('vendor/package');
+        $package->addMaintainer($user);
+
+        return $package;
+    }
+
+    private function getGraphQLResultFirstPage(bool $hasNextPage): array
+    {
+        return [
+            'data' => [
+                'securityVulnerabilities' => [
+                    'nodes' => [
+                        [
+                            'advisory' => [
+                                'summary' => 'Cross site scripting in the system log',
+                                'permalink' => 'https://github.com/advisories/GHSA-h58v-c6rf-g9f7',
+                                'publishedAt' => '2021-07-01T17:00:04Z',
+                                'identifiers' => [
+                                    ['type' => 'GHSA', 'value' => 'GHSA-h58v-c6rf-g9f7',],
+                                    ['type' => 'CVE', 'value' => 'CVE-2021-35210'],
+                                ],
+                            ],
+                            'vulnerableVersionRange' => '>= 4.10.0, < 4.11.5',
+                        ],
+                        [
+                            'advisory' => [
+                                'summary' => 'Cross site scripting in the system log',
+                                'permalink' => 'https://github.com/advisories/GHSA-h58v-c6rf-g9f7',
+                                'publishedAt' => '2021-07-01T17:00:04Z',
+                                'identifiers' => [
+                                    ['type' => 'GHSA', 'value' => 'GHSA-h58v-c6rf-g9f7'],
+                                    ['type' => 'CVE', 'value' => 'CVE-2021-35210'],
+                                ],
+                            ],
+                            'vulnerableVersionRange' => '>= 4.5.0, < 4.9.16',
+                        ],
+                        [
+                            'advisory' => [
+                                'summary' => 'Insert tag injection in forms',
+                                'permalink' => 'https://github.com/advisories/GHSA-f7wm-x4gw-6m23',
+                                'publishedAt' => '2020-09-24T16:23:54Z',
+                                'identifiers' => [
+                                    ['type' => 'GHSA', 'value' => 'GHSA-f7wm-x4gw-6m23',],
+                                    ['type' => 'CVE', 'value' => 'CVE-2020-25768'],
+                                ],
+                            ],
+                            'vulnerableVersionRange' => '= 4.10.0',
+                        ],
+                    ],
+                    'pageInfo' => [
+                        'hasNextPage' => $hasNextPage,
+                        'endCursor' => 'Y3Vyc29yOnYyOpK5MjAyMC0wOS0yNFQxODoyMzo0MyswMjowMM0T9A==',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function getGraphQLResultSecondPage(): array
+    {
+        return [
+            'data' => [
+                'securityVulnerabilities' => [
+                    'nodes' => [
+                        [
+                            'advisory' => [
+                                'summary' => 'Insert tag injection in forms',
+                                'permalink' => 'https://github.com/advisories/GHSA-f7wm-x4gw-6m23',
+                                'publishedAt' => '2020-09-24T16:23:54Z',
+                                'identifiers' => [
+                                    ['type' => 'GHSA', 'value' => 'GHSA-f7wm-x4gw-6m23',],
+                                    ['type' => 'CVE', 'value' => 'CVE-2020-25768'],
+                                ],
+                            ],
+                            'vulnerableVersionRange' => '< 4.11.0',
+                        ],
+                    ],
+                    'pageInfo' => [
+                        'hasNextPage' => false,
+                        'endCursor' => 'Y3Vyc29yOnYyOpK5MjAxOS0xMi0xN1QyMDozNTozMSswMTowMM0LWQ==',
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/SecurityAdvisory/RemoteSecurityAdvisoryTest.php
+++ b/tests/SecurityAdvisory/RemoteSecurityAdvisoryTest.php
@@ -71,4 +71,12 @@ class RemoteSecurityAdvisoryTest extends TestCase
 
         $this->assertSame('2019-10-08 00:00:00', $advisory->getDate()->format('Y-m-d H:i:s'));
     }
+
+    public function testWithAddedAffectedVersion(): void
+    {
+        $advisory = new RemoteSecurityAdvisory('id', 'foobar', 'foo/bar', '>=1', 'https://foobar.com', null, new \DateTime(), null);
+        $advisory = $advisory->withAddedAffectedVersion('<2');
+
+        $this->assertSame('>=1|<2', $advisory->getAffectedVersions());
+    }
 }

--- a/tests/SecurityAdvisoryWorkerTest.php
+++ b/tests/SecurityAdvisoryWorkerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests;
 
+use App\Entity\Package;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
 use App\Entity\Job;
@@ -25,6 +26,8 @@ class SecurityAdvisoryWorkerTest extends TestCase
     private $em;
     /** @var \PHPUnit\Framework\MockObject\MockObject */
     private $securityAdvisoryRepository;
+    /** @var \PHPUnit\Framework\MockObject\MockObject */
+    private $packageRepository;
 
     protected function setUp(): void
     {
@@ -44,11 +47,18 @@ class SecurityAdvisoryWorkerTest extends TestCase
             ->willReturn(true);
 
         $this->securityAdvisoryRepository = $this->getMockBuilder(EntityRepository::class)->disableOriginalConstructor()->getMock();
+        $this->packageRepository = $this->getMockBuilder(EntityRepository::class)->disableOriginalConstructor()->getMock();
 
         $doctrine
             ->method('getRepository')
-            ->with($this->equalTo(SecurityAdvisory::class))
-            ->willReturn($this->securityAdvisoryRepository);
+            ->withConsecutive(
+                [$this->equalTo(Package::class)],
+                [$this->equalTo(SecurityAdvisory::class)]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->packageRepository,
+                $this->securityAdvisoryRepository
+            );
     }
 
     public function testProcess(): void
@@ -98,11 +108,17 @@ class SecurityAdvisoryWorkerTest extends TestCase
             ->with($this->equalTo(['source' => 'test']))
             ->willReturn([$existingAdvisory1, $existingAdvisory2ToBeDeleted]);
 
+        $this->packageRepository
+            ->method('findOneBy')
+            ->with(['id' => 42])
+            ->willReturn(new Package());
+
         $job = new Job('job', 'security:advisory', ['source' => 'test']);
+        $job->setPackageId(42);
         $this->worker->process($job, SignalHandler::create());
     }
 
-    public function testProcessNone(): void
+    public function testProcessNoAdvisories(): void
     {
         $this->source
             ->expects($this->once())
@@ -118,11 +134,17 @@ class SecurityAdvisoryWorkerTest extends TestCase
             ->with($this->equalTo(['source' => 'test']))
             ->willReturn([]);
 
+        $this->packageRepository
+            ->method('findOneBy')
+            ->with(['id' => 42])
+            ->willReturn(new Package());
+
         $job = new Job('job', 'security:advisory', ['source' => 'test']);
+        $job->setPackageId(42);
         $this->worker->process($job, SignalHandler::create());
     }
 
-    public function testProcessFailed(): void
+    public function testProcessAdvisoryFailed(): void
     {
         $this->source
             ->expects($this->once())
@@ -137,7 +159,13 @@ class SecurityAdvisoryWorkerTest extends TestCase
             ->expects($this->never())
             ->method('findBy');
 
+        $this->packageRepository
+            ->method('findOneBy')
+            ->with(['id' => 42])
+            ->willReturn(new Package());
+
         $job = new Job('job', 'security:advisory', ['source' => 'test']);
+        $job->setPackageId(42);
         $this->worker->process($job, SignalHandler::create());
     }
 }


### PR DESCRIPTION
Here we go - using the GitHub token of one of the maintainers to automatically search the GitHub security advisories database 🎉 

This would allow packagist.org to become the new central place to ask for PHP vulnerabilities [via its already existing API](https://packagist.org/apidoc#list-security-advisories).
Developers who are already using the GitHub advisories feature do not need to create a PR for FriendsOfPHP/security-advisories anymore (unless you want to support software that's fetching data directly from that repo instead of the Packagist API).

I had to update the interface to pass on the package but I thought that's fine as I think that's an internal interface anyway. The same applies for a few other methods.

I have also added a simple way to run Redis as that was a missing step in the README to run the tests :-)

I hope this will further ease the process of reporting PHP vulnerabilities in a standardized manner and help to make the PHP application world a little bit safer 😊  