### PR TITLE
use session to store 2fa secret between requests

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -301,11 +301,6 @@ parameters:
 			path: src/Command/RunWorkersCommand.php
 
 		-
-			message: "#^Cannot cast array\\<string\\>\\|bool\\|string\\|null to int\\.$#"
-			count: 1
-			path: src/Command/RunWorkersCommand.php
-
-		-
 			message: "#^Method App\\\\Command\\\\RunWorkersCommand\\:\\:configure\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: src/Command/RunWorkersCommand.php
@@ -366,11 +361,6 @@ parameters:
 			path: src/Controller/ApiController.php
 
 		-
-			message: "#^Cannot access offset 'downloads' on mixed\\.$#"
-			count: 3
-			path: src/Controller/ApiController.php
-
-		-
 			message: "#^Cannot access offset 'project' on mixed\\.$#"
 			count: 2
 			path: src/Controller/ApiController.php
@@ -423,16 +413,6 @@ parameters:
 		-
 			message: "#^Method App\\\\Controller\\\\ApiController\\:\\:getJobAction\\(\\) has no return typehint specified\\.$#"
 			count: 1
-			path: src/Controller/ApiController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\ApiController\\:\\:getPackageAndVersionId\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Controller/ApiController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\ApiController\\:\\:getPackageAndVersionId\\(\\) should return array but returns array\\<string, mixed\\>\\|false\\.$#"
-			count: 2
 			path: src/Controller/ApiController.php
 
 		-
@@ -743,11 +723,6 @@ parameters:
 		-
 			message: "#^Cannot access offset 'depth' on mixed\\.$#"
 			count: 7
-			path: src/Controller/PackageController.php
-
-		-
-			message: "#^Cannot access offset 'version' on array\\('label' \\=\\> string\\|null, 'version' \\=\\> string, 'depth' \\=\\> 'exact'\\|'major'\\|'minor'\\|'package'\\)\\|false\\.$#"
-			count: 1
 			path: src/Controller/PackageController.php
 
 		-
@@ -1136,11 +1111,6 @@ parameters:
 			path: src/Controller/ProfileController.php
 
 		-
-			message: "#^Parameter \\#2 \\$default of method Symfony\\\\Component\\\\HttpFoundation\\\\InputBag\\:\\:get\\(\\) expects string\\|null, int given\\.$#"
-			count: 1
-			path: src/Controller/ProfileController.php
-
-		-
 			message: "#^Parameter \\#2 \\$user of method App\\\\Controller\\\\ProfileController\\:\\:getUserPackages\\(\\) expects App\\\\Entity\\\\User, object given\\.$#"
 			count: 1
 			path: src/Controller/ProfileController.php
@@ -1213,6 +1183,11 @@ parameters:
 		-
 			message: "#^Cannot call method getId\\(\\) on object\\|null\\.$#"
 			count: 8
+			path: src/Controller/UserController.php
+
+		-
+			message: "#^Cannot cast mixed to string\\.$#"
+			count: 1
 			path: src/Controller/UserController.php
 
 		-
@@ -4402,11 +4377,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#3 \\$length of function substr expects int\\|null, int\\|false given\\.$#"
-			count: 1
-			path: src/Package/Updater.php
-
-		-
-			message: "#^Parameter \\#5 \\$data of method App\\\\Package\\\\Updater\\:\\:updateInformation\\(\\) expects Composer\\\\Package\\\\CompletePackageInterface, Composer\\\\Package\\\\PackageInterface given\\.$#"
 			count: 1
 			path: src/Package/Updater.php
 

--- a/src/Form/Model/EnableTwoFactorRequest.php
+++ b/src/Form/Model/EnableTwoFactorRequest.php
@@ -6,32 +6,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class EnableTwoFactorRequest
 {
-    /**
-     * @var string
-     * @Assert\NotBlank
-     */
-    protected $secret;
-
-    /**
-     * @var ?string
-     * @Assert\NotBlank
-     */
-    protected $code;
-
-    public function __construct(string $secret)
-    {
-        $this->secret = $secret;
-    }
-
-    public function getSecret(): string
-    {
-        return $this->secret;
-    }
-
-    public function setSecret(string $secret): void
-    {
-        $this->secret = $secret;
-    }
+    #[Assert\NotBlank]
+    protected ?string $code = null;
 
     public function getCode(): ?string
     {

--- a/src/Form/Type/EnableTwoFactorAuthType.php
+++ b/src/Form/Type/EnableTwoFactorAuthType.php
@@ -14,7 +14,6 @@ namespace App\Form\Type;
 
 use App\Form\Model\EnableTwoFactorRequest;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -26,7 +25,6 @@ class EnableTwoFactorAuthType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('secret', HiddenType::class);
         $builder->add('code', TextType::class);
     }
 

--- a/templates/user/enable_two_factor_auth.html.twig
+++ b/templates/user/enable_two_factor_auth.html.twig
@@ -38,7 +38,7 @@
             <p class="pull-right two-factor-key">
                 <img src="{{ qrCode }}" height="200" />
                 <br>
-                <small>TOTP Key: <code>{{ secret }}</code></small>
+                <small>TOTP Key: <code style="user-select: all">{{ user.totpAuthenticationConfiguration.secret }}</code></small>
             </p>
 
             <h3>Enabling Two-Factor Authentication</h3>


### PR DESCRIPTION
Prior to this change, user was able to change the 2FA secret into any value by manipulating hidden form field which might be a security concern. This can be fixed by temporarily using session to store the secret between requests. Please note it still generates a new secret each time you refresh the page.

I also changed the QR code writer to SVG for better resolution on Retina screens. Thanks to `user-select: all`, secret is fully selected with a single click which makes it even easier to copy, especially on mobile devices.