### PR TITLE
Security Advisory: handle friendsofphp renaming advisory files

### DIFF
--- a/src/Entity/SecurityAdvisory.php
+++ b/src/Entity/SecurityAdvisory.php
@@ -29,7 +29,7 @@ class SecurityAdvisory
     private $id;
 
     /**
-     * @ORM\Column(type="string", nullable=true)
+     * @ORM\Column(type="string", unique=true, nullable=true)
      */
     private ?string $packagistAdvisoryId = null;
 

--- a/src/Entity/SecurityAdvisory.php
+++ b/src/Entity/SecurityAdvisory.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use App\SecurityAdvisory\AdvisoryIdGenerator;
 use Doctrine\ORM\Mapping as ORM;
 use App\SecurityAdvisory\RemoteSecurityAdvisory;
 
@@ -28,9 +29,9 @@ class SecurityAdvisory
     private $id;
 
     /**
-     * @ORM\Column(type="string")
+     * @ORM\Column(type="string", nullable=true)
      */
-    private $advisoryId;
+    private ?string $packagistAdvisoryId = null;
 
     /**
      * @ORM\Column(type="string")
@@ -85,6 +86,7 @@ class SecurityAdvisory
     public function __construct(RemoteSecurityAdvisory $advisory, string $source)
     {
         $this->source = $source;
+        $this->assignPackagistAdvisoryId();
         $this->updateAdvisory($advisory);
     }
 
@@ -189,5 +191,20 @@ class SecurityAdvisory
         }
 
         return $score;
+    }
+
+    public function hasPackagistAdvisoryId(): bool
+    {
+        return (bool) $this->packagistAdvisoryId;
+    }
+
+    public function assignPackagistAdvisoryId(): void
+    {
+        if ($this->hasPackagistAdvisoryId()) {
+            throw new \RuntimeException('Packagist advisory id already assigned');
+        }
+
+        $this->updatedAt = new \DateTime();
+        $this->packagistAdvisoryId = AdvisoryIdGenerator::generate();
     }
 }

--- a/src/Entity/SecurityAdvisory.php
+++ b/src/Entity/SecurityAdvisory.php
@@ -30,6 +30,11 @@ class SecurityAdvisory
     /**
      * @ORM\Column(type="string")
      */
+    private $advisoryId;
+
+    /**
+     * @ORM\Column(type="string")
+     */
     private $remoteId;
 
     /**
@@ -141,5 +146,48 @@ class SecurityAdvisory
     public function getSource(): string
     {
         return $this->source;
+    }
+
+    public function calculateDifferenceScore(RemoteSecurityAdvisory $advisory): int
+    {
+        $score = 0;
+        if ($advisory->getId() !== $this->getRemoteId()) {
+            $score++;
+        }
+
+        if ($advisory->getPackageName() !== $this->getPackageName()) {
+            $score += 99;
+        }
+
+        if ($advisory->getTitle() !== $this->getTitle()) {
+            $score++;
+        }
+
+        if ($advisory->getLink() !== $this->getLink()) {
+            $score++;
+        }
+
+        if ($advisory->getCve() !== $this->getCve()) {
+            $score++;
+
+            // CVE ID changed from not null to different not-null value
+            if ($advisory->getCve() !== null && $this->getCve() !== null) {
+                $score += 99;
+            }
+        }
+
+        if ($advisory->getAffectedVersions() !== $this->getAffectedVersions()) {
+            $score++;
+        }
+
+        if ($advisory->getComposerRepository() !== $this->composerRepository) {
+            $score++;
+        }
+
+        if ($advisory->getDate() !== $this->reportedAt) {
+            $score++;
+        }
+
+        return $score;
     }
 }

--- a/src/Entity/SecurityAdvisoryRepository.php
+++ b/src/Entity/SecurityAdvisoryRepository.php
@@ -26,7 +26,7 @@ class SecurityAdvisoryRepository extends ServiceEntityRepository
 
     public function searchSecurityAdvisories(array $packageNames, int $updatedSince): array
     {
-        $sql = 'SELECT s.packageName, s.remoteId, s.title, s.link, s.cve, s.affectedVersions, s.source, s.reportedAt, s.composerRepository
+        $sql = 'SELECT s.packagistAdvisoryId as advisoryId, s.packageName, s.remoteId, s.title, s.link, s.cve, s.affectedVersions, s.source, s.reportedAt, s.composerRepository
             FROM security_advisory s
             WHERE s.updatedAt >= :updatedSince ' .
             (count($packageNames) > 0 ? ' AND s.packageName IN (:packageNames)' : '')

--- a/src/SecurityAdvisory/AdvisoryIdGenerator.php
+++ b/src/SecurityAdvisory/AdvisoryIdGenerator.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace App\SecurityAdvisory;
+
+class AdvisoryIdGenerator
+{
+    // All alphanumeric symbols except vowels and some to avoid misspellings (I, O, l, 0), case insensitive, 34 character alphabet
+    private const ALNUM_SAFE_CI = "bcdfghjkmnpqrstvwxyz123456789";
+
+    public static function generate(): string
+    {
+        $letterPool = self::ALNUM_SAFE_CI;
+        $token = 'PKSA-';
+        $len = strlen($letterPool) - 1;
+        for ($i = 0; $i < 3; $i++) {
+            for ($j = 0; $j < 4; $j++) {
+                $token .= $letterPool[random_int(0, $len)];
+            }
+
+            $token .= '-';
+        }
+
+        return trim($token, '-');
+    }
+}

--- a/src/SecurityAdvisory/RemoteSecurityAdvisory.php
+++ b/src/SecurityAdvisory/RemoteSecurityAdvisory.php
@@ -81,10 +81,19 @@ class RemoteSecurityAdvisory
         $lowestBranchDate = null;
         foreach ($info['branches'] as $branchInfo) {
             $affectedVersions[] = implode(',', $branchInfo['versions']);
-            if (!$date && isset($branchInfo['time']) && is_int($branchInfo['time'])) {
-                $branchDate = new \DateTime('@' . $branchInfo['time']);
-                if (!$lowestBranchDate || $branchDate < $lowestBranchDate) {
-                    $lowestBranchDate = $branchDate;
+            if (!$date && isset($branchInfo['time'])) {
+                $timestamp = null;
+                if (is_int($branchInfo['time'])) {
+                    $timestamp = $branchInfo['time'];
+                } elseif (is_string($branchInfo['time'])) {
+                    $timestamp = strtotime($branchInfo['time']);
+                }
+
+                if ($timestamp) {
+                    $branchDate = new \DateTime('@' . $timestamp);
+                    if (!$lowestBranchDate || $branchDate < $lowestBranchDate) {
+                        $lowestBranchDate = $branchDate;
+                    }
                 }
             }
         }

--- a/src/Service/SecurityAdvisoryWorker.php
+++ b/src/Service/SecurityAdvisoryWorker.php
@@ -56,6 +56,11 @@ class SecurityAdvisoryWorker
         /** @var SecurityAdvisory[] $existingAdvisories */
         $existingAdvisories = $this->doctrine->getRepository(SecurityAdvisory::class)->findBy(['source' => $sourceName]);
         foreach ($existingAdvisories as $advisory) {
+            // Assign an advisory id to all existing advisories -> remove once applied everywhere
+            if (!$advisory->hasPackagistAdvisoryId()) {
+                $advisory->assignPackagistAdvisoryId();
+            }
+
             $existingAdvisoryMap[$advisory->getRemoteId()] = $advisory;
         }
 

--- a/templates/api_doc/index.html.twig
+++ b/templates/api_doc/index.html.twig
@@ -393,6 +393,7 @@ GET https://{{ packagist_host }}/api/security-advisories/?updatedSince=[timestam
   "advisories": {
     "[vendor]/[package]": [
       {
+        "advisoryId": "[unique id]",
         "packageName": "[vendor]/[package]",
         "remoteId": "[unique id per source]",
         "title": "[title]",

--- a/tests/Entity/SecurityAdvisoryTest.php
+++ b/tests/Entity/SecurityAdvisoryTest.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use App\Entity\SecurityAdvisory;
+use App\SecurityAdvisory\RemoteSecurityAdvisory;
+use PHPUnit\Framework\TestCase;
+
+class SecurityAdvisoryTest extends TestCase
+{
+    public function testCalculateDifferenceScore(): void
+    {
+        $remoteAdvisory = RemoteSecurityAdvisory::createFromFriendsOfPhp('3f/pygmentize/2017-05-15.yaml', [
+            'title' => 'Remote Code Execution',
+            'link' => 'https://github.com/dedalozzo/pygmentize/issues/1',
+            'cve' => null,
+            'branches' => [
+                '1.x' => [
+                    'time' => 1494806400,
+                    'versions' => ['<1.2'],
+                ],
+            ],
+            'reference' => 'composer://3f/pygmentize'
+        ]);
+
+        $advisory = new SecurityAdvisory($remoteAdvisory, 'source');
+
+        $this->assertSame(0, $advisory->calculateDifferenceScore($remoteAdvisory));
+    }
+
+    public function testCalculateDifferenceScoreChangeNameAndCVE(): void
+    {
+        $remoteAdvisory = RemoteSecurityAdvisory::createFromFriendsOfPhp('league/flysystem/2021-06-24.yaml', [
+            'title' => 'TOCTOU Race Condition enabling remote code execution',
+            'link' => 'https://github.com/thephpleague/flysystem/security/advisories/GHSA-9f46-5r25-5wfm',
+            'cve' => null,
+            'branches' => [
+                '1.x' => [
+                    'time' => '2021-06-23 23:56:59',
+                    'versions' => ['<1.1.4'],
+                ],
+                '2.x' => [
+                    'time' => '2021-06-24 00:07:59',
+                    'versions' => ['>=2.0.0', '<2.1.1'],
+                ],
+            ],
+            'reference' => 'composer://league/flysystem'
+        ]);
+
+        $advisory = new SecurityAdvisory($remoteAdvisory, 'source');
+
+        $updatedRemoteAdvisory = RemoteSecurityAdvisory::createFromFriendsOfPhp('league/flysystem/CVE-2021-32708.yaml', [
+            'title' => 'TOCTOU Race Condition enabling remote code execution',
+            'link' => 'https://github.com/thephpleague/flysystem/security/advisories/GHSA-9f46-5r25-5wfm',
+            'cve' => 'CVE-2021-32708',
+            'branches' => [
+                '1.x' => [
+                    'time' => '2021-06-23 23:56:59',
+                    'versions' => ['<1.1.4'],
+                ],
+                '2.x' => [
+                    'time' => '2021-06-24 00:07:59',
+                    'versions' => ['>=2.0.0', '<2.1.1'],
+                ],
+            ],
+            'reference' => 'composer://league/flysystem'
+        ]);
+
+        $this->assertSame(3, $advisory->calculateDifferenceScore($updatedRemoteAdvisory));
+    }
+}

--- a/tests/SecurityAdvisoryWorkerTest.php
+++ b/tests/SecurityAdvisoryWorkerTest.php
@@ -64,6 +64,14 @@ class SecurityAdvisoryWorkerTest extends TestCase
             ->method('getId')
             ->willReturn('remote-id-1');
 
+        $advisory2New
+            ->method('getId')
+            ->willReturn('remote-id-2');
+
+        $advisory2New
+            ->method('getPackageName')
+            ->willReturn('package/new');
+
         $existingAdvisory1 = $this->getMockBuilder(SecurityAdvisory::class)->disableOriginalConstructor()->getMock();
         $existingAdvisory1
             ->method('getRemoteId')
@@ -78,6 +86,10 @@ class SecurityAdvisoryWorkerTest extends TestCase
         $existingAdvisory2ToBeDeleted
             ->method('getRemoteId')
             ->willReturn('to-be-deleted');
+
+        $existingAdvisory2ToBeDeleted
+            ->method('getPackageName')
+            ->willReturn('vendor/delete');
 
         $this->source
             ->expects($this->once())


### PR DESCRIPTION
As per https://github.com/FriendsOfPHP/security-advisories/pull/595#issuecomment-948400214 we should not rely on the filenames.

This PR
* introduces a new advisory id which can be used by API consumers
* detects renamed friendsofphp advisory files and tries to matches them to existing advisories

Follow up PR to set the advisory id to unique https://github.com/composer/packagist/pull/1216