### PR TITLE
Allow `align` attribute rendering READMEs

### DIFF
--- a/src/Package/Updater.php
+++ b/src/Package/Updater.php
@@ -631,7 +631,9 @@ class Updater
             'img.src', 'img.title', 'img.alt', 'img.width', 'img.height', 'img.style',
             'a.href', 'a.target', 'a.rel', 'a.id',
             'td.colspan', 'td.rowspan', 'th.colspan', 'th.rowspan',
-            '*.class', '*.align', 'details.open',
+            '*.class', 'details.open',
+            'th.align', 'td.align', 'div.align', 'h1.align', 'h2.align', 'h3.align',
+            'h4.align', 'h5.align', 'h6.align', 'p.align',
         ];
 
         // detect base path if the github readme is located in a subfolder like docs/README.md

--- a/src/Package/Updater.php
+++ b/src/Package/Updater.php
@@ -632,8 +632,8 @@ class Updater
             'a.href', 'a.target', 'a.rel', 'a.id',
             'td.colspan', 'td.rowspan', 'th.colspan', 'th.rowspan',
             '*.class', 'details.open',
-            'th.align', 'td.align', 'div.align', 'h1.align', 'h2.align', 'h3.align',
-            'h4.align', 'h5.align', 'h6.align', 'p.align',
+            'th.align', 'td.align', 'div.align', 'p.align',
+            'h1.align', 'h2.align', 'h3.align', 'h4.align', 'h5.align', 'h6.align',
         ];
 
         // detect base path if the github readme is located in a subfolder like docs/README.md

--- a/src/Package/Updater.php
+++ b/src/Package/Updater.php
@@ -631,7 +631,7 @@ class Updater
             'img.src', 'img.title', 'img.alt', 'img.width', 'img.height', 'img.style',
             'a.href', 'a.target', 'a.rel', 'a.id',
             'td.colspan', 'td.rowspan', 'th.colspan', 'th.rowspan',
-            '*.class', 'details.open'
+            '*.class', '*.align', 'details.open',
         ];
 
         // detect base path if the github readme is located in a subfolder like docs/README.md

--- a/src/Package/Updater.php
+++ b/src/Package/Updater.php
@@ -631,9 +631,9 @@ class Updater
             'img.src', 'img.title', 'img.alt', 'img.width', 'img.height', 'img.style',
             'a.href', 'a.target', 'a.rel', 'a.id',
             'td.colspan', 'td.rowspan', 'th.colspan', 'th.rowspan',
-            '*.class', 'details.open',
-            'th.align', 'td.align', 'div.align', 'p.align',
+            'th.align', 'td.align', 'p.align',
             'h1.align', 'h2.align', 'h3.align', 'h4.align', 'h5.align', 'h6.align',
+            '*.class', 'details.open',
         ];
 
         // detect base path if the github readme is located in a subfolder like docs/README.md


### PR DESCRIPTION
Github accepts the attribute `align` for element alignment. See the differences in elements alignment at the start between [this README on Github](https://github.com/simple-icons/simple-icons/blob/06f09a265d3c9d3dee994f3fdcb245f115e840e1/README.md) and [the same on Packagist](https://packagist.org/packages/simple-icons/simple-icons).

I'm using here the same implementation used by [Python's PYPI README renderer](https://github.com/pypa/readme_renderer).