### PR TITLE
Fixing file path in algolia:configure command

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -40,6 +40,7 @@ services:
             $mailFromEmail: "%env(APP_MAILER_FROM_EMAIL)%"
             $mailFromName: "%env(APP_MAILER_FROM_NAME)%"
             $fallbackGhTokens: "%fallback_gh_tokens%"
+            $configDir: '%kernel.project_dir%/config/'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -66,16 +66,6 @@ parameters:
 			path: src/Command/CompileStatsCommand.php
 
 		-
-			message: "#^Method App\\\\Command\\\\ConfigureAlgoliaCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Command/ConfigureAlgoliaCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$input of static method Symfony\\\\Component\\\\Yaml\\\\Yaml\\:\\:parse\\(\\) expects string, string\\|false given\\.$#"
-			count: 1
-			path: src/Command/ConfigureAlgoliaCommand.php
-
-		-
 			message: "#^Method App\\\\Command\\\\DumpPackagesCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Command/DumpPackagesCommand.php
@@ -299,16 +289,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$command of method App\\\\Service\\\\Locker\\:\\:unlockCommand\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Command/UpdatePackagesCommand.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\AboutController\\:\\:aboutAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/AboutController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\AboutController\\:\\:aboutComposerFallbackAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/AboutController.php
 
 		-
 			message: "#^Cannot access offset 'absolute_url' on mixed\\.$#"

--- a/src/Command/ConfigureAlgoliaCommand.php
+++ b/src/Command/ConfigureAlgoliaCommand.php
@@ -13,39 +13,32 @@
 namespace App\Command;
 
 use Algolia\AlgoliaSearch\SearchClient;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Yaml\Yaml;
 
+#[AsCommand(name: 'algolia:configure', description: 'Configure Algolia index')]
 class ConfigureAlgoliaCommand extends Command
 {
-    private SearchClient $algolia;
-    private string $algoliaIndexName;
-
-    public function __construct(SearchClient $algolia, string $algoliaIndexName)
-    {
-        $this->algolia = $algolia;
-        $this->algoliaIndexName = $algoliaIndexName;
+    public function __construct(
+        private SearchClient $algolia,
+        private string $algoliaIndexName,
+        private string $configDir,
+    ) {
         parent::__construct();
-    }
-
-    /**
-     * @inheritDoc
-     */
-    protected function configure()
-    {
-        $this
-            ->setName('algolia:configure')
-            ->setDescription('Configure Algolia index')
-        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $settings = Yaml::parse(
-            file_get_contents(__DIR__.'/../config/algolia_settings.yml')
-        );
+        $yaml = file_get_contents($this->configDir.'algolia_settings.yml');
+
+        if (!$yaml) {
+            throw new \RuntimeException('Algolia config file not readable.');
+        }
+
+        $settings = Yaml::parse($yaml);
 
         $index = $this->algolia->initIndex($this->algoliaIndexName);
 


### PR DESCRIPTION
Possibly a bug introduced with #1144, ran into it while setting up algolia.

Messed up the diff though.
Bug was the relative path here: 
```php
file_get_contents(__DIR__.'/../config/algolia_settings.yml')
```