### PR TITLE
SecurityAdvisory: handle temporary CVE-2022-xxx format

### DIFF
--- a/src/Entity/SecurityAdvisory.php
+++ b/src/Entity/SecurityAdvisory.php
@@ -171,7 +171,7 @@ class SecurityAdvisory
             $increase = 1;
 
             // Do not increase the score if the title was just renamed to add a CVE e.g. from CVE-2022-xxx to CVE-2022-99999999
-            if (Preg::match('#^(CVE-[0-9]{4}-[x]+:)(.*)$#', $this->getTitle(), $matches) && str_contains($advisory->getTitle(), $matches[2])) {
+            if (Preg::match('#^(CVE-[0-9x*?]{1,4}-?[0x*?]+:)(.*)$#', $this->getTitle(), $matches) && str_contains($advisory->getTitle(), $matches[2])) {
                 $increase = 0;
             }
 

--- a/src/Entity/SecurityAdvisory.php
+++ b/src/Entity/SecurityAdvisory.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\SecurityAdvisory\AdvisoryIdGenerator;
+use Composer\Pcre\Preg;
 use Doctrine\ORM\Mapping as ORM;
 use App\SecurityAdvisory\RemoteSecurityAdvisory;
 
@@ -137,6 +138,11 @@ class SecurityAdvisory
 
     public function getCve(): ?string
     {
+        // Cleanup invalid CVE ids stored in the database
+        if ($this->cve && !Preg::match('#^CVE-[0-9]{4}-[0-9]{4,}$#', $this->cve)) {
+            $this->cve = null;
+        }
+
         return $this->cve;
     }
 
@@ -162,7 +168,14 @@ class SecurityAdvisory
         }
 
         if ($advisory->getTitle() !== $this->getTitle()) {
-            $score++;
+            $increase = 1;
+
+            // Do not increase the score if the title was just renamed to add a CVE e.g. from CVE-2022-xxx to CVE-2022-99999999
+            if (Preg::match('#^(CVE-[0-9]{4}-[x]+:)(.*)$#', $this->getTitle(), $matches) && str_contains($advisory->getTitle(), $matches[2])) {
+                $increase = 0;
+            }
+
+            $score += $increase;
         }
 
         if ($advisory->getLink() !== $this->getLink()) {
@@ -186,7 +199,7 @@ class SecurityAdvisory
             $score++;
         }
 
-        if ($advisory->getDate() !== $this->reportedAt) {
+        if ($advisory->getDate() != $this->reportedAt) {
             $score++;
         }
 

--- a/src/SecurityAdvisory/RemoteSecurityAdvisory.php
+++ b/src/SecurityAdvisory/RemoteSecurityAdvisory.php
@@ -119,13 +119,18 @@ class RemoteSecurityAdvisory
             }
         }
 
+        $cve = null;
+        if ($info['cve'] && Preg::match('#^CVE-[0-9]{4}-[0-9]{4,}$#', $info['cve'])) {
+            $cve = $info['cve'];
+        }
+
         return new RemoteSecurityAdvisory(
             $fileNameWithPath,
             $info['title'],
             str_replace('composer://', '', $info['reference']),
             implode('|', $affectedVersions),
             $info['link'],
-            $info['cve'] ?? null,
+            $cve,
             $date,
             $composerRepository
         );

--- a/tests/Entity/SecurityAdvisoryTest.php
+++ b/tests/Entity/SecurityAdvisoryTest.php
@@ -10,7 +10,7 @@ class SecurityAdvisoryTest extends TestCase
 {
     public function testCalculateDifferenceScore(): void
     {
-        $remoteAdvisory = RemoteSecurityAdvisory::createFromFriendsOfPhp('3f/pygmentize/2017-05-15.yaml', [
+        $data = [
             'title' => 'Remote Code Execution',
             'link' => 'https://github.com/dedalozzo/pygmentize/issues/1',
             'cve' => null,
@@ -21,11 +21,14 @@ class SecurityAdvisoryTest extends TestCase
                 ],
             ],
             'reference' => 'composer://3f/pygmentize'
-        ]);
+        ];
+
+        $remoteAdvisory = RemoteSecurityAdvisory::createFromFriendsOfPhp('3f/pygmentize/2017-05-15.yaml', $data);
+        $updatedAdvisory = RemoteSecurityAdvisory::createFromFriendsOfPhp('3f/pygmentize/2017-05-15.yaml', $data);
 
         $advisory = new SecurityAdvisory($remoteAdvisory, 'source');
 
-        $this->assertSame(0, $advisory->calculateDifferenceScore($remoteAdvisory));
+        $this->assertSame(0, $advisory->calculateDifferenceScore($updatedAdvisory));
     }
 
     public function testCalculateDifferenceScoreChangeNameAndCVE(): void
@@ -64,6 +67,55 @@ class SecurityAdvisoryTest extends TestCase
                 ],
             ],
             'reference' => 'composer://league/flysystem'
+        ]);
+
+        $this->assertSame(3, $advisory->calculateDifferenceScore($updatedRemoteAdvisory));
+    }
+
+    public function testCalculateDifferenceScoreCveXXXX(): void
+    {
+        $remoteAdvisory = RemoteSecurityAdvisory::createFromFriendsOfPhp('symfony/framework-bundle/CVE-2022-xxxx.yaml', [
+            'title' => 'CVE-2022-xxxx: CSRF token missing in forms',
+            'link' => 'https://symfony.com/cve-2022-xxxx',
+            'cve' => 'CVE-2022-xxxx',
+            'branches' => [
+                '5.3.x' => [
+                    'time' => '2022-01-29 12:00:00',
+                    'versions' => ['>=5.3.14', '<=5.3.14'],
+                ],
+                '5.4.x' => [
+                    'time' => '2022-01-29 12:00:00',
+                    'versions' => ['>=5.4.3', '<=5.4.3'],
+                ],
+                '6.0.x' => [
+                    'time' => '2022-01-29 12:00:00',
+                    'versions' => ['>=6.0.3', '<=6.0.3'],
+                ],
+            ],
+            'reference' => 'composer://symfony/framework-bundle'
+        ]);
+
+        $advisory = new SecurityAdvisory($remoteAdvisory, 'source');
+
+        $updatedRemoteAdvisory = RemoteSecurityAdvisory::createFromFriendsOfPhp('symfony/framework-bundle/CVE-2022-99999999999.yaml', [
+            'title' => 'CVE-2022-99999999999: CSRF token missing in forms',
+            'link' => 'https://symfony.com/cve-2022-99999999999',
+            'cve' => 'CVE-2022-99999999999',
+            'branches' => [
+                '5.3.x' => [
+                    'time' => '2022-01-29 12:00:00',
+                    'versions' => ['>=5.3.14', '<=5.3.14'],
+                ],
+                '5.4.x' => [
+                    'time' => '2022-01-29 12:00:00',
+                    'versions' => ['>=5.4.3', '<=5.4.3'],
+                ],
+                '6.0.x' => [
+                    'time' => '2022-01-29 12:00:00',
+                    'versions' => ['>=6.0.3', '<=6.0.3'],
+                ],
+            ],
+            'reference' => 'composer://symfony/framework-bundle'
         ]);
 
         $this->assertSame(3, $advisory->calculateDifferenceScore($updatedRemoteAdvisory));

--- a/tests/SecurityAdvisory/RemoteSecurityAdvisoryTest.php
+++ b/tests/SecurityAdvisory/RemoteSecurityAdvisoryTest.php
@@ -71,4 +71,31 @@ class RemoteSecurityAdvisoryTest extends TestCase
 
         $this->assertSame('2019-10-08 00:00:00', $advisory->getDate()->format('Y-m-d H:i:s'));
     }
+
+    public function testCreateFromFriendsOfPhpCVEXXXX(): void
+    {
+        $advisory = RemoteSecurityAdvisory::createFromFriendsOfPhp('symfony/framework-bundle/CVE-2022-xxxx.yaml', [
+            'title' => 'CVE-2022-xxxx: CSRF token missing in forms',
+            'link' => 'https://symfony.com/cve-2022-xxxx',
+            'cve' => 'CVE-2022-xxxx',
+            'branches' => [
+                '5.3.x' => [
+                    'time' => '2022-01-29 12:00:00',
+                    'versions' => ['>=5.3.14', '<=5.3.14'],
+                ],
+                '5.4.x' => [
+                    'time' => '2022-01-29 12:00:00',
+                    'versions' => ['>=5.4.3', '<=5.4.3'],
+                ],
+                '6.0.x' => [
+                    'time' => '2022-01-29 12:00:00',
+                    'versions' => ['>=6.0.3', '<=6.0.3'],
+                ],
+            ],
+            'reference' => 'composer://symfony/framework-bundle'
+        ]);
+
+        $this->assertSame('symfony/framework-bundle/CVE-2022-xxxx.yaml', $advisory->getId());
+        $this->assertNull($advisory->getCve());
+    }
 }


### PR DESCRIPTION
Adjusted the security advisory handling for temporary CVE ids as seen in https://github.com/FriendsOfPHP/security-advisories/pull/607/files

I wonder whether the title comparison should/can be done a bit more generic?