### PR TITLE
phpstan-dba: enable stringifyTypes

### DIFF
--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -15,6 +15,7 @@ $cacheFile = __DIR__.'/.phpstan-dba.cache';
 $config = new RuntimeConfiguration();
 $config->stringifyTypes(true); // TODO remove when upgrading to PHP 8.1
 // $config->debugMode(true);
+$config->stringifyTypes(true);
 
 (new Dotenv())->bootEnv(__DIR__ . '/.env');
 $dsn = parse_url($_SERVER['DATABASE_URL']);


### PR DESCRIPTION
requires at least phpstan-dba 0.2.13, but because of fixes in the latest release you should use the most recent release anyway.

required since doctrine by default returns everything as a string, see e.g. https://github.com/composer/packagist/blob/233cddb42f93ee29a7ea6fb0211017177db0571a/src/Entity/PackageRepository.php#L256