### PR TITLE
Support GitLab in README files

### DIFF
--- a/src/Package/Updater.php
+++ b/src/Package/Updater.php
@@ -701,7 +701,6 @@ class Updater
                     $imgSrc = match ($host) {
                         'github.com' => 'https://raw.github.com/'.$owner.'/'.$repo.'/HEAD/'.$basePath.$img->getAttribute('src'),
                         'gitlab.com' => 'https://gitlab.com/'.$owner.'/'.$repo.'/-/raw/HEAD/'.$basePath.$img->getAttribute('src'),
-                        default => $img->getAttribute('src'),
                     };
                     $img->setAttribute('src', $imgSrc);
                 }

--- a/src/Package/Updater.php
+++ b/src/Package/Updater.php
@@ -680,12 +680,12 @@ class Updater
                 $link->setAttribute('href', '#user-content-'.substr($link->getAttribute('href'), 1));
             } elseif ('mailto:' === substr($link->getAttribute('href'), 0, 7)) {
                 // do nothing
-            } elseif ($host === 'github.com' && false === strpos($link->getAttribute('href'), '//')) {
+            } elseif ($host === 'github.com' && !str_contains($link->getAttribute('href'), '//')) {
                 $link->setAttribute(
                     'href',
                     'https://github.com/'.$owner.'/'.$repo.'/blob/HEAD/'.$basePath.$link->getAttribute('href')
                 );
-            } elseif ($host === 'gitlab.com' && false === strpos($link->getAttribute('href'), '//')) {
+            } elseif ($host === 'gitlab.com' && !str_contains($link->getAttribute('href'), '//')) {
                 $link->setAttribute(
                     'href',
                     'https://gitlab.com/'.$owner.'/'.$repo.'/-/blob/HEAD/'.$basePath.$link->getAttribute('href')
@@ -693,14 +693,16 @@ class Updater
             }
         }
 
-        if ($host === 'github.com' || $host === 'gitlab.com') {
+        if (in_array($host, ['github.com', 'gitlab.com'], true)) {
             // convert relative to absolute images
             $images = $dom->getElementsByTagName('img');
             foreach ($images as $img) {
-                if (false === strpos($img->getAttribute('src'), '//')) {
-                    $imgSrc = ($host === 'github.com')?
-                        'https://raw.github.com/'.$owner.'/'.$repo.'/HEAD/'.$basePath.$img->getAttribute('src') :
-                        'https://gitlab.com/'.$owner.'/'.$repo.'/-/raw/HEAD/'.$basePath.$img->getAttribute('src');
+                if (!str_contains($img->getAttribute('src'), '//')) {
+                    $imgSrc = match ($host) {
+                        'github.com' => 'https://raw.github.com/'.$owner.'/'.$repo.'/HEAD/'.$basePath.$img->getAttribute('src'),
+                        'gitlab.com' => 'https://gitlab.com/'.$owner.'/'.$repo.'/-/raw/HEAD/'.$basePath.$img->getAttribute('src'),
+                        default => $img->getAttribute('src'),
+                    };
                     $img->setAttribute('src', $imgSrc);
                 }
             }


### PR DESCRIPTION
Add support for GitLab in README files as well.

- Convert relative links to absolute links,
  pointing to the right repository subdirectory

- Fix path to images sources to embed them directly

Tested manually with [example package pixelbrackets/markdown-mini-page](https://packagist.org/packages/pixelbrackets/markdown-mini-page).

Before: [Missing screenshot](https://user-images.githubusercontent.com/1592995/152661116-5078ed64-aaff-4fb1-b889-85a07970d9a3.png)
After: [Having screenshot](https://user-images.githubusercontent.com/1592995/152661117-bdf5a2b5-f342-43d8-9768-649c1134f495.png)

As suggested in issue #1223 I tried to take a look at BitBucket as well,
but it turns out they generate hashes for all embedded image paths,
which can not be guessed (see https://bitbucket.org/pixelbrackets/composer-test/).

Closes #1223