### PR TITLE
readding custom chart css rules

### DIFF
--- a/css/charts.css
+++ b/css/charts.css
@@ -1,0 +1,102 @@
+.chart {
+    min-height: 300px
+}
+
+.version-stats-chart .chart {
+    min-height: 400px
+}
+
+svg.chart {
+    display: block !important;
+    width: 100% !important;
+    height: 100% !important;
+    padding-left: 0;
+    overflow: visible
+}
+
+@media (max-width: 767px) {
+    svg.chart {
+        margin-left: -10px
+    }
+}
+
+.nvd3 text {
+    font: 12px Open Sans
+}
+
+.nv-x text {
+    baseline-shift: -10px
+}
+
+.nv-context .nv-x text {
+    baseline-shift: -5px
+}
+
+.nvd3 .nv-axis .domain {
+    display: none
+}
+
+.nvd3 .nv-axis .nv-axisMaxMin text {
+    font-weight: 400 !important
+}
+
+.nvd3 .nv-y .nv-axis .nv-axisMaxMin:last-child {
+    display: none
+}
+
+.nvd3 .nv-x .nv-axis .nv-axisMaxMin:last-child text {
+    text-anchor: end !important
+}
+
+.nvd3.nv-scatter.nv-single-point .nv-groups .nv-point {
+    fill-opacity: 0 !important;
+    stroke-opacity: 0 !important
+}
+
+.nvtooltip tr.highlight {
+    border-top: 2px solid #333;
+    border-bottom: 2px solid #333;
+    background: #fff
+}
+
+.package-installs dt {
+    float: left;
+    min-width: 125px;
+    text-align: right;
+    margin-right: 20px
+}
+
+.package-installs dl {
+    margin-bottom: 5px
+}
+
+.version-stats.package .package-aside.versions-wrapper {
+    margin-top: 0
+}
+
+.version-stats.package .package-aside.versions-wrapper .group-separator {
+    border-top: 1px solid #ec971f;
+    width: 100%;
+    height: 2px;
+    display: block;
+    margin: 2px 0 1px
+}
+
+.version-stats-chart {
+    width: 70%;
+    margin-right: 5%;
+    position: relative
+}
+
+.stats-toggle-wrapper {
+    display: flex
+}
+
+.stats-toggle-wrapper a {
+    flex: 1;
+    padding: 2px 15px
+}
+
+.stats-toggle-wrapper a.open {
+    color: #000
+}


### PR DESCRIPTION
after 89a051568141faab8258571d6274cbb45687ff30 I had first this ...

![Bildschirmfoto von 2022-02-06 15-49-05](https://user-images.githubusercontent.com/2852185/152687214-702157d1-f5aa-42f9-b254-4d76ab75de9f.png)

and after removing the broken reference, i got this ...

![Bildschirmfoto von 2022-02-06 16-07-04](https://user-images.githubusercontent.com/2852185/152687246-b6abf434-0044-44d3-bd93-a275d9c24a2d.png)

so i readded a `charts.css` - not sure if that's the right way to address this ...