### PR TITLE
Follow up: Support BitBucket images in readme

### DIFF
--- a/src/Package/Updater.php
+++ b/src/Package/Updater.php
@@ -685,14 +685,15 @@ class Updater
             }
         }
 
-        if (in_array($host, ['github.com', 'gitlab.com'], true)) {
-            // convert relative to absolute images
+        // embed images of selected hosts by converting relative links to accessible URLs
+        if (in_array($host, ['github.com', 'gitlab.com', 'bitbucket.org'], true)) {
             $images = $dom->getElementsByTagName('img');
             foreach ($images as $img) {
                 if (!str_contains($img->getAttribute('src'), '//')) {
                     $imgSrc = match ($host) {
                         'github.com' => 'https://raw.github.com/'.$owner.'/'.$repo.'/HEAD/'.$basePath.$img->getAttribute('src'),
                         'gitlab.com' => 'https://gitlab.com/'.$owner.'/'.$repo.'/-/raw/HEAD/'.$basePath.$img->getAttribute('src'),
+                        'bitbucket.org' => 'https://bitbucket.org/'.$owner.'/'.$repo.'/raw/HEAD/'.$basePath.$img->getAttribute('src'),
                     };
                     $img->setAttribute('src', $imgSrc);
                 }


### PR DESCRIPTION
Followup for PR [1254](https://github.com/composer/packagist/pull/1254#issuecomment-1030864892)
with support for images in README files of packages hosted on BitBucket.

Tested manually on my local instance with the demo package https://bitbucket.org/pixelbrackets/composer-test,
see screenshot below.

![2022-02-09 10-54-05 screenshot bitbucket images](https://user-images.githubusercontent.com/1592995/153172178-ef90fa98-57d0-406e-ab81-e657974595ea.png)
