### PR TITLE
Fixing PHPStan issues in Command namespace

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,201 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#1 \\$command of method App\\\\Service\\\\Locker\\:\\:lockCommand\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Command/CleanIndexCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$command of method App\\\\Service\\\\Locker\\:\\:unlockCommand\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Command/CleanIndexCommand.php
-
-		-
-			message: "#^Cannot call method getName\\(\\) on mixed\\.$#"
-			count: 4
-			path: src/Command/ClearVersionsCommand.php
-
-		-
-			message: "#^Cannot call method getVersion\\(\\) on mixed\\.$#"
-			count: 2
-			path: src/Command/ClearVersionsCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$version of method App\\\\Entity\\\\VersionRepository\\:\\:remove\\(\\) expects App\\\\Entity\\\\Version, mixed given\\.$#"
-			count: 2
-			path: src/Command/ClearVersionsCommand.php
-
-		-
-			message: "#^Cannot access offset string on mixed\\.$#"
-			count: 1
-			path: src/Command/CompileStatsCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$command of method App\\\\Service\\\\Locker\\:\\:lockCommand\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Command/CompileStatsCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$command of method App\\\\Service\\\\Locker\\:\\:unlockCommand\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Command/CompileStatsCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$command of method App\\\\Service\\\\Locker\\:\\:lockCommand\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Command/DumpPackagesCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$command of method App\\\\Service\\\\Locker\\:\\:unlockCommand\\(\\) expects string, string\\|null given\\.$#"
-			count: 2
-			path: src/Command/DumpPackagesCommand.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of function ini_set expects string, int given\\.$#"
-			count: 1
-			path: src/Command/DumpPackagesCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$command of method App\\\\Service\\\\Locker\\:\\:lockCommand\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Command/DumpPackagesV2Command.php
-
-		-
-			message: "#^Parameter \\#1 \\$command of method App\\\\Service\\\\Locker\\:\\:unlockCommand\\(\\) expects string, string\\|null given\\.$#"
-			count: 2
-			path: src/Command/DumpPackagesV2Command.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of function ini_set expects string, int given\\.$#"
-			count: 1
-			path: src/Command/DumpPackagesV2Command.php
-
-		-
-			message: "#^Method App\\\\Command\\\\IndexPackagesCommand\\:\\:createSearchableProvider\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Command/IndexPackagesCommand.php
-
-		-
-			message: "#^Method App\\\\Command\\\\IndexPackagesCommand\\:\\:getProviders\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Command/IndexPackagesCommand.php
-
-		-
-			message: "#^Method App\\\\Command\\\\IndexPackagesCommand\\:\\:getTags\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Command/IndexPackagesCommand.php
-
-		-
-			message: "#^Method App\\\\Command\\\\IndexPackagesCommand\\:\\:packageToSearchableArray\\(\\) has parameter \\$tags with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Command/IndexPackagesCommand.php
-
-		-
-			message: "#^Method App\\\\Command\\\\IndexPackagesCommand\\:\\:packageToSearchableArray\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Command/IndexPackagesCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$command of method App\\\\Service\\\\Locker\\:\\:lockCommand\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Command/IndexPackagesCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$command of method App\\\\Service\\\\Locker\\:\\:unlockCommand\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Command/IndexPackagesCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$num of function log expects float, string given\\.$#"
-			count: 1
-			path: src/Command/IndexPackagesCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function strlen expects string, int\\<0, max\\> given\\.$#"
-			count: 1
-			path: src/Command/IndexPackagesCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$command of method App\\\\Service\\\\Locker\\:\\:lockCommand\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Command/MigrateDownloadCountsCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$command of method App\\\\Service\\\\Locker\\:\\:unlockCommand\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Command/MigrateDownloadCountsCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$packageId of method App\\\\Model\\\\DownloadManager\\:\\:transferDownloadsToDb\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Command/MigrateDownloadCountsCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$command of method App\\\\Service\\\\Locker\\:\\:lockCommand\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Command/MigratePhpStatsCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$command of method App\\\\Service\\\\Locker\\:\\:unlockCommand\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Command/MigratePhpStatsCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$packageId of method App\\\\Entity\\\\PhpStatRepository\\:\\:transferStatsToDb\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Command/MigratePhpStatsCommand.php
-
-		-
-			message: "#^Method App\\\\Command\\\\RegenerateMainPhpStatsCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Command/RegenerateMainPhpStatsCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$command of method App\\\\Service\\\\Locker\\:\\:lockCommand\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Command/RegenerateMainPhpStatsCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$command of method App\\\\Service\\\\Locker\\:\\:unlockCommand\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Command/RegenerateMainPhpStatsCommand.php
-
-		-
-			message: "#^Property App\\\\Command\\\\RegenerateMainPhpStatsCommand\\:\\:\\$redis is never read, only written\\.$#"
-			count: 1
-			path: src/Command/RegenerateMainPhpStatsCommand.php
-
-		-
-			message: "#^Method App\\\\Command\\\\SymlinkMetadataMirrorCommand\\:\\:__construct\\(\\) has parameter \\$awsMetadata with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Command/SymlinkMetadataMirrorCommand.php
-
-		-
-			message: "#^Property App\\\\Command\\\\SymlinkMetadataMirrorCommand\\:\\:\\$awsMeta type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Command/SymlinkMetadataMirrorCommand.php
-
-		-
-			message: "#^Property App\\\\Command\\\\SymlinkMetadataMirrorCommand\\:\\:\\$webDir \\(string\\) does not accept string\\|false\\.$#"
-			count: 1
-			path: src/Command/SymlinkMetadataMirrorCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$command of method App\\\\Service\\\\Locker\\:\\:lockCommand\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Command/UpdatePackagesCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$command of method App\\\\Service\\\\Locker\\:\\:unlockCommand\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Command/UpdatePackagesCommand.php
-
-		-
-			message: "#^Cannot access offset 'repository' on mixed\\.$#"
-			count: 1
-			path: src/Controller/ApiController.php
-
-		-
 			message: "#^Cannot call method getGithubToken\\(\\) on App\\\\Entity\\\\User\\|null\\.$#"
 			count: 2
 			path: src/Controller/ApiController.php
@@ -256,11 +61,6 @@ parameters:
 			path: src/Controller/ApiController.php
 
 		-
-			message: "#^Parameter \\#1 \\$repoUrl of method App\\\\Entity\\\\Package\\:\\:setRepository\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Controller/ApiController.php
-
-		-
 			message: "#^Parameter \\#2 \\$ip of method App\\\\Model\\\\DownloadManager\\:\\:addDownloads\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Controller/ApiController.php
@@ -279,16 +79,6 @@ parameters:
 			message: "#^Method App\\\\Controller\\\\ChangePasswordController\\:\\:changePasswordAction\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Controller/ChangePasswordController.php
-
-		-
-			message: "#^Parameter \\#2 \\$plainPassword of method Symfony\\\\Component\\\\PasswordHasher\\\\Hasher\\\\UserPasswordHasherInterface\\:\\:hashPassword\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Controller/ChangePasswordController.php
-
-		-
-			message: "#^Cannot cast mixed to int\\.$#"
-			count: 2
-			path: src/Controller/ExploreController.php
 
 		-
 			message: "#^Method App\\\\Controller\\\\ExploreController\\:\\:exploreAction\\(\\) has no return type specified\\.$#"
@@ -312,11 +102,6 @@ parameters:
 
 		-
 			message: "#^Method App\\\\Controller\\\\FeedController\\:\\:getLimitedResults\\(\\) return type has no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: src/Controller/FeedController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\FeedController\\:\\:getLimitedResults\\(\\) should return iterable but returns mixed\\.$#"
 			count: 1
 			path: src/Controller/FeedController.php
 
@@ -686,17 +471,7 @@ parameters:
 			path: src/Controller/PackageController.php
 
 		-
-			message: "#^Parameter \\#3 \\$packages of method App\\\\Controller\\\\Controller\\:\\:getPackagesMetadata\\(\\) expects iterable\\<App\\\\Entity\\\\Package\\|array\\{id\\: int\\}\\>, mixed given\\.$#"
-			count: 1
-			path: src/Controller/PackageController.php
-
-		-
 			message: "#^Parameter \\#3 \\$referenceType of method Symfony\\\\Bundle\\\\FrameworkBundle\\\\Controller\\\\AbstractController\\:\\:generateUrl\\(\\) expects int, true given\\.$#"
-			count: 1
-			path: src/Controller/PackageController.php
-
-		-
-			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, mixed given\\.$#"
 			count: 1
 			path: src/Controller/PackageController.php
 
@@ -731,24 +506,9 @@ parameters:
 			path: src/Controller/ProfileController.php
 
 		-
-			message: "#^Parameter \\#2 \\$plainPassword of method Symfony\\\\Component\\\\PasswordHasher\\\\Hasher\\\\UserPasswordHasherInterface\\:\\:hashPassword\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Controller/RegistrationController.php
-
-		-
 			message: "#^Property App\\\\Controller\\\\RegistrationController\\:\\:\\$emailVerifier has no type specified\\.$#"
 			count: 1
 			path: src/Controller/RegistrationController.php
-
-		-
-			message: "#^Parameter \\#1 \\$userEmail of method App\\\\Controller\\\\ResetPasswordController\\:\\:processSendingPasswordResetEmail\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Controller/ResetPasswordController.php
-
-		-
-			message: "#^Parameter \\#2 \\$plainPassword of method Symfony\\\\Component\\\\PasswordHasher\\\\Hasher\\\\UserPasswordHasherInterface\\:\\:hashPassword\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Controller/ResetPasswordController.php
 
 		-
 			message: "#^Method App\\\\Controller\\\\SecurityController\\:\\:logout\\(\\) has no return type specified\\.$#"
@@ -756,22 +516,7 @@ parameters:
 			path: src/Controller/SecurityController.php
 
 		-
-			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: src/Controller/UserController.php
-
-		-
 			message: "#^Cannot call method getId\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null\\.$#"
-			count: 1
-			path: src/Controller/UserController.php
-
-		-
-			message: "#^Cannot call method getVersions\\(\\) on mixed\\.$#"
-			count: 1
-			path: src/Controller/UserController.php
-
-		-
-			message: "#^Cannot cast mixed to string\\.$#"
 			count: 1
 			path: src/Controller/UserController.php
 
@@ -822,11 +567,6 @@ parameters:
 
 		-
 			message: "#^Method App\\\\Controller\\\\UserController\\:\\:triggerGitHubSyncAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/UserController.php
-
-		-
-			message: "#^Parameter \\#1 \\$package of method App\\\\Model\\\\ProviderManager\\:\\:deletePackage\\(\\) expects App\\\\Entity\\\\Package, mixed given\\.$#"
 			count: 1
 			path: src/Controller/UserController.php
 
@@ -891,11 +631,6 @@ parameters:
 			path: src/Controller/WebController.php
 
 		-
-			message: "#^Method App\\\\DataFixtures\\\\DownloadFixtures\\:\\:getLatestPackageVersion\\(\\) should return App\\\\Entity\\\\Version but returns mixed\\.$#"
-			count: 1
-			path: src/DataFixtures/DownloadFixtures.php
-
-		-
 			message: "#^Parameter \\#1 \\$object of static method DateTimeImmutable\\:\\:createFromMutable\\(\\) expects DateTime, DateTimeInterface given\\.$#"
 			count: 1
 			path: src/DataFixtures/DownloadFixtures.php
@@ -907,16 +642,6 @@ parameters:
 
 		-
 			message: "#^Method App\\\\Entity\\\\DownloadRepository\\:\\:deletePackageDownloads\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Entity/DownloadRepository.php
-
-		-
-			message: "#^Method App\\\\Entity\\\\DownloadRepository\\:\\:findDataByMajorVersion\\(\\) should return array\\<string, array\\<int, array\\<int, int\\>\\>\\> but returns array\\<string, array\\<int, mixed\\>\\>\\.$#"
-			count: 1
-			path: src/Entity/DownloadRepository.php
-
-		-
-			message: "#^Method App\\\\Entity\\\\DownloadRepository\\:\\:findDataByMajorVersions\\(\\) should return array\\<string, array\\<int, array\\<int, int\\>\\>\\> but returns array\\<string, array\\<int, mixed\\>\\>\\.$#"
 			count: 1
 			path: src/Entity/DownloadRepository.php
 
@@ -961,11 +686,6 @@ parameters:
 			path: src/Entity/Job.php
 
 		-
-			message: "#^Method App\\\\Entity\\\\JobRepository\\:\\:getLastGitHubSyncJob\\(\\) should return App\\\\Entity\\\\Job\\|null but returns mixed\\.$#"
-			count: 1
-			path: src/Entity/JobRepository.php
-
-		-
 			message: "#^Method App\\\\Entity\\\\JobRepository\\:\\:getScheduledJobIds\\(\\) return type has no value type specified in iterable type Generator\\.$#"
 			count: 1
 			path: src/Entity/JobRepository.php
@@ -996,16 +716,6 @@ parameters:
 			path: src/Entity/Package.php
 
 		-
-			message: "#^Cannot access offset 'user_id' on mixed\\.$#"
-			count: 1
-			path: src/Entity/PackageRepository.php
-
-		-
-			message: "#^Cannot cast mixed to int\\.$#"
-			count: 2
-			path: src/Entity/PackageRepository.php
-
-		-
 			message: "#^Method App\\\\Entity\\\\PackageRepository\\:\\:findProviders\\(\\) has parameter \\$name with no type specified\\.$#"
 			count: 1
 			path: src/Entity/PackageRepository.php
@@ -1031,11 +741,6 @@ parameters:
 			path: src/Entity/PackageRepository.php
 
 		-
-			message: "#^Method App\\\\Entity\\\\PackageRepository\\:\\:getPackageByName\\(\\) should return App\\\\Entity\\\\Package but returns mixed\\.$#"
-			count: 1
-			path: src/Entity/PackageRepository.php
-
-		-
 			message: "#^Method App\\\\Entity\\\\PackageRepository\\:\\:getPackageNamesByType\\(\\) has parameter \\$type with no type specified\\.$#"
 			count: 1
 			path: src/Entity/PackageRepository.php
@@ -1052,11 +757,6 @@ parameters:
 
 		-
 			message: "#^Method App\\\\Entity\\\\PackageRepository\\:\\:getPartialPackageByNameWithVersions\\(\\) has parameter \\$name with no type specified\\.$#"
-			count: 1
-			path: src/Entity/PackageRepository.php
-
-		-
-			message: "#^Method App\\\\Entity\\\\PackageRepository\\:\\:getPartialPackageByNameWithVersions\\(\\) should return App\\\\Entity\\\\Package but returns mixed\\.$#"
 			count: 1
 			path: src/Entity/PackageRepository.php
 
@@ -1101,11 +801,6 @@ parameters:
 			path: src/Entity/PhpStatRepository.php
 
 		-
-			message: "#^Method App\\\\Entity\\\\PhpStatRepository\\:\\:getStatVersions\\(\\) should return array\\<int, array\\{version\\: string, depth\\: 0\\|1\\|2\\|3\\}\\> but returns array\\.$#"
-			count: 1
-			path: src/Entity/PhpStatRepository.php
-
-		-
 			message: "#^Method App\\\\Entity\\\\PhpStatRepository\\:\\:transferStatsToDb\\(\\) has parameter \\$keys with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Entity/PhpStatRepository.php
@@ -1136,62 +831,12 @@ parameters:
 			path: src/Entity/SecurityAdvisoryRepository.php
 
 		-
-			message: "#^Method App\\\\Entity\\\\Tag\\:\\:getByName\\(\\) should return App\\\\Entity\\\\Tag but returns mixed\\.$#"
-			count: 1
-			path: src/Entity/Tag.php
-
-		-
-			message: "#^Cannot access offset 'login' on mixed\\.$#"
-			count: 1
-			path: src/Entity/User.php
-
-		-
-			message: "#^Cannot use array destructuring on mixed\\.$#"
-			count: 1
-			path: src/Entity/User.php
-
-		-
-			message: "#^Method App\\\\Entity\\\\User\\:\\:getGithubUsername\\(\\) should return string\\|null but returns mixed\\.$#"
-			count: 1
-			path: src/Entity/User.php
-
-		-
 			message: "#^Method App\\\\Entity\\\\User\\:\\:setSalt\\(\\) has parameter \\$salt with no type specified\\.$#"
 			count: 1
 			path: src/Entity/User.php
 
 		-
 			message: "#^Parameter \\#1 \\$secret of class Scheb\\\\TwoFactorBundle\\\\Model\\\\Totp\\\\TotpConfiguration constructor expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Entity/User.php
-
-		-
-			message: "#^Property App\\\\Entity\\\\User\\:\\:\\$emailCanonical \\(string\\) does not accept mixed\\.$#"
-			count: 1
-			path: src/Entity/User.php
-
-		-
-			message: "#^Property App\\\\Entity\\\\User\\:\\:\\$enabled \\(bool\\) does not accept mixed\\.$#"
-			count: 1
-			path: src/Entity/User.php
-
-		-
-			message: "#^Property App\\\\Entity\\\\User\\:\\:\\$password \\(string\\) does not accept mixed\\.$#"
-			count: 1
-			path: src/Entity/User.php
-
-		-
-			message: "#^Property App\\\\Entity\\\\User\\:\\:\\$salt \\(string\\|null\\) does not accept mixed\\.$#"
-			count: 1
-			path: src/Entity/User.php
-
-		-
-			message: "#^Property App\\\\Entity\\\\User\\:\\:\\$username \\(string\\) does not accept mixed\\.$#"
-			count: 1
-			path: src/Entity/User.php
-
-		-
-			message: "#^Property App\\\\Entity\\\\User\\:\\:\\$usernameCanonical \\(string\\) does not accept mixed\\.$#"
 			count: 1
 			path: src/Entity/User.php
 
@@ -1331,11 +976,6 @@ parameters:
 			path: src/Entity/VersionRepository.php
 
 		-
-			message: "#^Method App\\\\Entity\\\\VersionRepository\\:\\:getFullVersion\\(\\) should return App\\\\Entity\\\\Version but returns mixed\\.$#"
-			count: 1
-			path: src/Entity/VersionRepository.php
-
-		-
 			message: "#^Method App\\\\Entity\\\\VersionRepository\\:\\:getLatestReleases\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Entity/VersionRepository.php
@@ -1347,11 +987,6 @@ parameters:
 
 		-
 			message: "#^Method App\\\\Entity\\\\VersionRepository\\:\\:getVersionData\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Entity/VersionRepository.php
-
-		-
-			message: "#^Method App\\\\Entity\\\\VersionRepository\\:\\:getVersionMetadataForUpdate\\(\\) should return array\\<string, array\\{id\\: numeric\\-string, version\\: string, normalizedVersion\\: string, source\\: array\\{type\\: string\\|null, url\\: string\\|null, reference\\: string\\|null\\}\\|null, softDeletedAt\\: string\\|null\\}\\> but returns array\\<string, array\\{id\\: numeric\\-string, version\\: string, normalizedVersion\\: string, source\\: mixed, softDeletedAt\\: string\\|null\\}\\>\\.$#"
 			count: 1
 			path: src/Entity/VersionRepository.php
 
@@ -1371,11 +1006,6 @@ parameters:
 			path: src/Form/Type/EnableTwoFactorAuthType.php
 
 		-
-			message: "#^Cannot call method getGithubId\\(\\) on mixed\\.$#"
-			count: 1
-			path: src/Form/Type/ProfileFormType.php
-
-		-
 			message: "#^Generator expects value type Symfony\\\\Component\\\\HttpKernel\\\\Bundle\\\\BundleInterface, object given\\.$#"
 			count: 1
 			path: src/Kernel.php
@@ -1388,26 +1018,6 @@ parameters:
 		-
 			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
 			count: 1
-			path: src/Package/SymlinkDumper.php
-
-		-
-			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 3
-			path: src/Package/SymlinkDumper.php
-
-		-
-			message: "#^Cannot access offset 'provider\\-includes' on mixed\\.$#"
-			count: 1
-			path: src/Package/SymlinkDumper.php
-
-		-
-			message: "#^Cannot access offset 'providers' on mixed\\.$#"
-			count: 1
-			path: src/Package/SymlinkDumper.php
-
-		-
-			message: "#^Cannot access offset 'sha256' on mixed\\.$#"
-			count: 2
 			path: src/Package/SymlinkDumper.php
 
 		-
@@ -1428,16 +1038,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$str of function strtr expects string, array\\|string given\\.$#"
 			count: 2
-			path: src/Package/SymlinkDumper.php
-
-		-
-			message: "#^Parameter \\#2 \\$replace of function str_replace expects array\\|string, mixed given\\.$#"
-			count: 1
-			path: src/Package/SymlinkDumper.php
-
-		-
-			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, mixed given\\.$#"
-			count: 1
 			path: src/Package/SymlinkDumper.php
 
 		-
@@ -1606,27 +1206,7 @@ parameters:
 			path: src/Service/QueueWorker.php
 
 		-
-			message: "#^Cannot access offset 'delete_before' on mixed\\.$#"
-			count: 1
-			path: src/Service/Scheduler.php
-
-		-
-			message: "#^Cannot access offset 'update_equal_refs' on mixed\\.$#"
-			count: 1
-			path: src/Service/Scheduler.php
-
-		-
 			message: "#^Method App\\\\Service\\\\Scheduler\\:\\:createJob\\(\\) has parameter \\$payload with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Service/Scheduler.php
-
-		-
-			message: "#^Method App\\\\Service\\\\Scheduler\\:\\:getJobStatus\\(\\) should return array\\{status\\: string, message\\: string\\} but returns mixed\\.$#"
-			count: 1
-			path: src/Service/Scheduler.php
-
-		-
-			message: "#^Method App\\\\Service\\\\Scheduler\\:\\:getJobsStatus\\(\\) should return array\\<string, array\\{status\\: mixed\\}\\> but returns array\\<string, mixed\\>\\.$#"
 			count: 1
 			path: src/Service/Scheduler.php
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -36,3 +36,5 @@ parameters:
         - '~Property App\\Entity\\Dependent::\$type type mapping mismatch: database can contain int but property expects~'
         - '~Property App\\Entity\\PhpStat::\$type type mapping mismatch: database can contain int but property expects~'
         - '~Property App\\Entity\\PhpStat::\$depth type mapping mismatch: database can contain int but property expects~'
+        # Will vanish with PHP 8.1
+        - '~Parameter #2 \$value of function ini_set expects string, int given.~'

--- a/src/Command/CleanIndexCommand.php
+++ b/src/Command/CleanIndexCommand.php
@@ -59,7 +59,7 @@ class CleanIndexCommand extends Command
             return 0;
         }
 
-        $lockAcquired = $this->locker->lockCommand($this->getName());
+        $lockAcquired = $this->locker->lockCommand(__CLASS__);
         if (!$lockAcquired) {
             if ($input->getOption('verbose')) {
                 $output->writeln('Aborting, another task is running already');
@@ -95,7 +95,7 @@ class CleanIndexCommand extends Command
             $page++;
         } while (count($results['hits']) >= $perPage);
 
-        $this->locker->unlockCommand($this->getName());
+        $this->locker->unlockCommand(__CLASS__);
 
         return 0;
     }

--- a/src/Command/CompileStatsCommand.php
+++ b/src/Command/CompileStatsCommand.php
@@ -51,7 +51,7 @@ class CompileStatsCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $lockAcquired = $this->locker->lockCommand($this->getName());
+        $lockAcquired = $this->locker->lockCommand(__CLASS__);
         if (!$lockAcquired) {
             if ($input->getOption('verbose')) {
                 $output->writeln('Aborting, another task is running already');
@@ -89,7 +89,7 @@ class CompileStatsCommand extends Command
         $this->redis->rename('downloads:trending:new', 'downloads:trending');
         $this->redis->rename('downloads:absolute:new', 'downloads:absolute');
 
-        $this->locker->unlockCommand($this->getName());
+        $this->locker->unlockCommand(__CLASS__);
 
         return 0;
     }

--- a/src/Command/DumpPackagesCommand.php
+++ b/src/Command/DumpPackagesCommand.php
@@ -73,7 +73,7 @@ class DumpPackagesCommand extends Command
         if ($gc) {
             $lockName .= '-gc';
         }
-        if (!$this->locker->lockCommand($lockName)) {
+        if (!$this->locker->lockCommand(__CLASS__)) {
             if ($verbose) {
                 $output->writeln('Aborting, another task is running already');
             }
@@ -84,7 +84,7 @@ class DumpPackagesCommand extends Command
             try {
                 $this->dumper->gc();
             } finally {
-                $this->locker->unlockCommand($lockName);
+                $this->locker->unlockCommand(__CLASS__);
             }
             return 0;
         }
@@ -116,7 +116,7 @@ class DumpPackagesCommand extends Command
             $ids = array_map('intval', $ids);
             $result = $this->dumper->dump($ids, $force, $verbose);
         } finally {
-            $this->locker->unlockCommand($lockName);
+            $this->locker->unlockCommand(__CLASS__);
         }
 
         return $result ? 0 : 1;

--- a/src/Command/DumpPackagesV2Command.php
+++ b/src/Command/DumpPackagesV2Command.php
@@ -73,7 +73,7 @@ class DumpPackagesV2Command extends Command
         if ($gc) {
             $lockName .= '-gc';
         }
-        if (!$this->locker->lockCommand($lockName)) {
+        if (!$this->locker->lockCommand(__CLASS__)) {
             if ($verbose) {
                 $output->writeln('Aborting, another task is running already');
             }
@@ -84,7 +84,7 @@ class DumpPackagesV2Command extends Command
             try {
                 $this->dumper->gc();
             } finally {
-                $this->locker->unlockCommand($lockName);
+                $this->locker->unlockCommand(__CLASS__);
             }
             return 0;
         }
@@ -116,7 +116,7 @@ class DumpPackagesV2Command extends Command
                 }
             }
         } finally {
-            $this->locker->unlockCommand($lockName);
+            $this->locker->unlockCommand(__CLASS__);
         }
 
         return 0;

--- a/src/Command/IndexPackagesCommand.php
+++ b/src/Command/IndexPackagesCommand.php
@@ -81,7 +81,7 @@ class IndexPackagesCommand extends Command
             return 0;
         }
 
-        $lockAcquired = $this->locker->lockCommand($this->getName());
+        $lockAcquired = $this->locker->lockCommand(__CLASS__);
         if (!$lockAcquired) {
             if ($input->getOption('verbose')) {
                 $output->writeln('Aborting, another task is running already');
@@ -184,7 +184,7 @@ class IndexPackagesCommand extends Command
             $this->updateIndexedAt($idsToUpdate, $indexTime->format('Y-m-d H:i:s'));
         }
 
-        $this->locker->unlockCommand($this->getName());
+        $this->locker->unlockCommand(__CLASS__);
 
         return 0;
     }

--- a/src/Command/IndexPackagesCommand.php
+++ b/src/Command/IndexPackagesCommand.php
@@ -136,7 +136,7 @@ class IndexPackagesCommand extends Command
             foreach ($packages as $package) {
                 $current++;
                 if ($verbose) {
-                    $output->writeln('['.sprintf('%'.strlen($total).'d', $current).'/'.$total.'] Indexing '.$package->getName());
+                    $output->writeln('['.sprintf('%'.strlen((string)$total).'d', $current).'/'.$total.'] Indexing '.$package->getName());
                 }
 
                 // delete spam packages from the search index
@@ -189,6 +189,10 @@ class IndexPackagesCommand extends Command
         return 0;
     }
 
+    /**
+     * @param string[] $tags
+     * @return array<string, int|string|float|null|array<string, string|int>>
+     */
     private function packageToSearchableArray(Package $package, array $tags): array
     {
         $faversCount = $this->favoriteManager->getFaverCount($package);
@@ -196,7 +200,7 @@ class IndexPackagesCommand extends Command
         $downloadsLog = $downloads['monthly'] > 0 ? log($downloads['monthly'], 10) : 0;
         $starsLog = $package->getGitHubStars() > 0 ? log($package->getGitHubStars(), 10) : 0;
         $popularity = round($downloadsLog + $starsLog);
-        $trendiness = $this->redis->zscore('downloads:trending', $package->getId());
+        $trendiness = (float)$this->redis->zscore('downloads:trending', $package->getId());
 
         $record = [
             'id' => $package->getId(),
@@ -233,6 +237,9 @@ class IndexPackagesCommand extends Command
         return $record;
     }
 
+    /**
+     * @return array<string, string|int|array{}>
+     */
     private function createSearchableProvider(string $provided): array
     {
         return [
@@ -253,6 +260,9 @@ class IndexPackagesCommand extends Command
         ];
     }
 
+    /**
+     * @return array<array{packageName: string}>
+     */
     private function getProviders(Package $package): array
     {
         return $this->getEM()->getConnection()->fetchAllAssociative(
@@ -267,6 +277,9 @@ class IndexPackagesCommand extends Command
         );
     }
 
+    /**
+     * @return string[]
+     */
     private function getTags(Package $package): array
     {
         $rows = $this->getEM()->getConnection()->fetchAllAssociative(
@@ -280,7 +293,7 @@ class IndexPackagesCommand extends Command
         );
 
         $tags = [];
-        foreach ($rows as $idx => $tag) {
+        foreach ($rows as $tag) {
             $tags[] = $tag['name'];
         }
 

--- a/src/Command/MigrateDownloadCountsCommand.php
+++ b/src/Command/MigrateDownloadCountsCommand.php
@@ -107,7 +107,7 @@ class MigrateDownloadCountsCommand extends Command
             }
 
             // process last package
-            if ($buffer) {
+            if ($lastPackageId && $buffer) {
                 $this->downloadManager->transferDownloadsToDb($lastPackageId, $buffer, $now);
             }
         } finally {

--- a/src/Command/MigrateDownloadCountsCommand.php
+++ b/src/Command/MigrateDownloadCountsCommand.php
@@ -42,7 +42,7 @@ class MigrateDownloadCountsCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // another migrate command is still active
-        $lockAcquired = $this->locker->lockCommand($this->getName());
+        $lockAcquired = $this->locker->lockCommand(__CLASS__);
         if (!$lockAcquired) {
             if ($input->getOption('verbose')) {
                 $output->writeln('Aborting, another task is running already');
@@ -111,7 +111,7 @@ class MigrateDownloadCountsCommand extends Command
                 $this->downloadManager->transferDownloadsToDb($lastPackageId, $buffer, $now);
             }
         } finally {
-            $this->locker->unlockCommand($this->getName());
+            $this->locker->unlockCommand(__CLASS__);
         }
 
         return 0;

--- a/src/Command/MigratePhpStatsCommand.php
+++ b/src/Command/MigratePhpStatsCommand.php
@@ -39,7 +39,7 @@ class MigratePhpStatsCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // another migrate command is still active
-        $lockAcquired = $this->locker->lockCommand($this->getName());
+        $lockAcquired = $this->locker->lockCommand(__CLASS__);
         if (!$lockAcquired) {
             if ($input->getOption('verbose')) {
                 $output->writeln('Aborting, another task is running already');
@@ -112,7 +112,7 @@ class MigratePhpStatsCommand extends Command
                 $phpStatRepo->transferStatsToDb($lastPackageId, $buffer, $now, $yesterday);
             }
         } finally {
-            $this->locker->unlockCommand($this->getName());
+            $this->locker->unlockCommand(__CLASS__);
         }
 
         return 0;

--- a/src/Command/MigratePhpStatsCommand.php
+++ b/src/Command/MigratePhpStatsCommand.php
@@ -108,7 +108,7 @@ class MigratePhpStatsCommand extends Command
             }
 
             // process last package
-            if ($buffer) {
+            if ($lastPackageId && $buffer) {
                 $phpStatRepo->transferStatsToDb($lastPackageId, $buffer, $now, $yesterday);
             }
         } finally {

--- a/src/Command/RegenerateMainPhpStatsCommand.php
+++ b/src/Command/RegenerateMainPhpStatsCommand.php
@@ -24,12 +24,11 @@ class RegenerateMainPhpStatsCommand extends Command
         private LoggerInterface $logger,
         private Locker $locker,
         private ManagerRegistry $doctrine,
-        private Client $redis,
     ) {
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('packagist:regenerate-main-php-stats')

--- a/src/Command/RegenerateMainPhpStatsCommand.php
+++ b/src/Command/RegenerateMainPhpStatsCommand.php
@@ -41,7 +41,7 @@ class RegenerateMainPhpStatsCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // another migrate command is still active
-        $lockAcquired = $this->locker->lockCommand($this->getName());
+        $lockAcquired = $this->locker->lockCommand(__CLASS__);
         if (!$lockAcquired) {
             if ($input->getOption('verbose')) {
                 $output->writeln('Aborting, another task is running already');
@@ -84,7 +84,7 @@ class RegenerateMainPhpStatsCommand extends Command
                 }
             }
         } finally {
-            $this->locker->unlockCommand($this->getName());
+            $this->locker->unlockCommand(__CLASS__);
         }
 
         return 0;

--- a/src/Command/SymlinkMetadataMirrorCommand.php
+++ b/src/Command/SymlinkMetadataMirrorCommand.php
@@ -18,18 +18,17 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @phpstan-import-type AwsMetadata from \App\HealthCheck\MetadataDirCheck
  */
 class SymlinkMetadataMirrorCommand extends Command
 {
-    private string $webDir;
-    private string $buildDir;
-    private array $awsMeta;
-
-    public function __construct(string $webDir, string $metadataDir, array $awsMetadata)
-    {
-        $this->webDir = realpath($webDir);
-        $this->buildDir = $metadataDir;
-        $this->awsMeta = $awsMetadata;
+    public function __construct(
+        private string $webDir,
+        private string $metadataDir,
+        /** @phpstan-var AwsMetadata */
+        private array $awsMetadata
+    ) {
         parent::__construct();
     }
 
@@ -44,17 +43,17 @@ class SymlinkMetadataMirrorCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        if (empty($this->awsMeta) || !$this->awsMeta['is_web'] || $this->awsMeta['primary']) {
+        if (empty($this->awsMetadata) || !$this->awsMetadata['is_web'] || $this->awsMetadata['primary']) {
             return 0;
         }
 
         $verbose = (bool) $input->getOption('verbose');
 
         $sources = [
-            $this->buildDir.'/p',
-            $this->buildDir.'/p2',
-            $this->buildDir.'/packages.json',
-            $this->buildDir.'/packages.json.gz',
+            $this->metadataDir.'/p',
+            $this->metadataDir.'/p2',
+            $this->metadataDir.'/packages.json',
+            $this->metadataDir.'/packages.json.gz',
         ];
 
         foreach ($sources as $source) {

--- a/src/Command/UpdatePackagesCommand.php
+++ b/src/Command/UpdatePackagesCommand.php
@@ -65,7 +65,7 @@ class UpdatePackagesCommand extends Command
         $updateEqualRefs = false;
         $randomTimes = true;
 
-        if (!$this->locker->lockCommand($this->getName())) {
+        if (!$this->locker->lockCommand(__CLASS__)) {
             if ($verbose) {
                 $output->writeln('Aborting, another task is running already');
             }
@@ -115,7 +115,7 @@ class UpdatePackagesCommand extends Command
             }
         }
 
-        $this->locker->unlockCommand($this->getName());
+        $this->locker->unlockCommand(__CLASS__);
 
         return 0;
     }


### PR DESCRIPTION
This includes the proposal to use `__CLASS__` as unique identifier per command for `Locker` methods instead of `getName()` as this is nullable.

Promoted the `ini_set` issues to `phpstan.neon` - could be removed with php 8.1 update

While regerating the baseline a lot of issues dropped out of the baseline which i cannot take credit for. potentially caused by a missing update or phpstan update.