### PR TITLE
GitHub Security Advisories: import available advisories via single worker run

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ These steps are provided for development purposes only.
    ```
 6. Start Redis:
    ```bash
-   docker compose up -d
+   docker compose up -d # or somehow run redis on localhost without docker
    ```
 7. Run a CRON job `bin/console packagist:run-workers` to make sure packages update.
-7. Run `npm run build` or `npm run dev` to build (or build&watch) css/js files.
+8. Run `npm run build` or `npm run dev` to build (or build&watch) css/js files.
 
 You should now be able to access the site, create a user, etc.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ These steps are provided for development purposes only.
    ```bash
    symfony serve
    ```
-6. Run a CRON job `bin/console packagist:run-workers` to make sure packages update.
+6. Start Redis:
+   ```bash
+   docker compose up -d
+   ```
+7. Run a CRON job `bin/console packagist:run-workers` to make sure packages update.
 7. Run `npm run build` or `npm run dev` to build (or build&watch) css/js files.
 
 You should now be able to access the site, create a user, etc.

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -124,6 +124,7 @@ services:
         bind:
             $sources:
                 'FriendsOfPHP/security-advisories': '@App\SecurityAdvisory\FriendsOfPhpSecurityAdvisoriesSource'
+                'GitHub': '@App\SecurityAdvisory\GitHubSecurityAdvisoriesSource'
 
     Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler:
         arguments: ['@snc_redis.cache', {prefix: 'sess:', ttl: 3600}]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+    redis:
+        image: redis:6.2-alpine
+        ports:
+            - 6379:6379

--- a/src/Command/UpdateSecurityAdvisoriesCommand.php
+++ b/src/Command/UpdateSecurityAdvisoriesCommand.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace App\Command;
+
+use App\SecurityAdvisory\FriendsOfPhpSecurityAdvisoriesSource;
+use App\SecurityAdvisory\GitHubSecurityAdvisoriesSource;
+use App\Service\Locker;
+use App\Service\Scheduler;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class UpdateSecurityAdvisoriesCommand extends Command
+{
+    public function __construct(
+        private Scheduler $scheduler,
+        private Locker $locker,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('packagist:security-advisories')
+            ->setDefinition([
+                new InputArgument('source', InputArgument::REQUIRED, 'The name of the source'),
+            ])
+            ->setDescription('Updates all security advisory for a single source')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $source = $input->getArgument('source');
+        $sources = [GitHubSecurityAdvisoriesSource::SOURCE_NAME, FriendsOfPhpSecurityAdvisoriesSource::SOURCE_NAME];
+        if (!in_array($source, $sources, true)) {
+            $output->writeln('source must be one of ' . implode(', ', $sources));
+
+            return self::INVALID;
+        }
+
+        $lockAcquired = $this->locker->lockSecurityAdvisory($source);
+        if (!$lockAcquired) {
+            return 0;
+        }
+
+        $this->scheduler->scheduleSecurityAdvisory($source, 0);
+        sleep(2); // sleep to prevent running the same command on multiple machines at around the same time via cron
+
+        $this->locker->unlockSecurityAdvisory($source);
+
+        return 0;
+    }
+}

--- a/src/Entity/PackageRepository.php
+++ b/src/Entity/PackageRepository.php
@@ -13,7 +13,6 @@
 namespace App\Entity;
 
 use DateTimeImmutable;
-use Doctrine\DBAL\Connection;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Query;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
@@ -639,21 +638,5 @@ class PackageRepository extends ServiceEntityRepository
             ->orderBy('p.id', 'DESC');
 
         return $qb;
-    }
-
-    /**
-     * @param list<string> $packageNames
-     * @return list<string>
-     */
-    public function getExistingPackageNames(array $packageNames): array
-    {
-        if (count($packageNames) === 0) {
-            return [];
-        }
-
-        return array_map(
-            fn (array $row): string => \strtolower($row['name']),
-            $this->getEntityManager()->getConnection()->fetchAllAssociative('SELECT p.name FROM package p WHERE p.name IN (:packageNames)', ['packageNames' => $packageNames], ['packageNames' => Connection::PARAM_STR_ARRAY])
-        );
     }
 }

--- a/src/Entity/PackageRepository.php
+++ b/src/Entity/PackageRepository.php
@@ -13,6 +13,7 @@
 namespace App\Entity;
 
 use DateTimeImmutable;
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Query;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
@@ -638,5 +639,21 @@ class PackageRepository extends ServiceEntityRepository
             ->orderBy('p.id', 'DESC');
 
         return $qb;
+    }
+
+    /**
+     * @param list<string> $packageNames
+     * @return list<string>
+     */
+    public function getExistingPackageNames(array $packageNames): array
+    {
+        if (count($packageNames) === 0) {
+            return [];
+        }
+
+        return array_map(
+            fn (array $row): string => \strtolower($row['name']),
+            $this->getEntityManager()->getConnection()->fetchAllAssociative('SELECT p.name FROM package p WHERE p.name IN (:packageNames)', ['packageNames' => $packageNames], ['packageNames' => Connection::PARAM_STR_ARRAY])
+        );
     }
 }

--- a/src/Entity/SecurityAdvisory.php
+++ b/src/Entity/SecurityAdvisory.php
@@ -206,7 +206,7 @@ class SecurityAdvisory
         }
 
         $score = 0;
-        if ($advisory->getId() !== $this->getRemoteId()) {
+        if ($advisory->getId() !== $this->getRemoteId() && $this->getSource() === $advisory->getSource()) {
             $score++;
         }
 

--- a/src/Entity/SecurityAdvisoryRepository.php
+++ b/src/Entity/SecurityAdvisoryRepository.php
@@ -69,13 +69,24 @@ class SecurityAdvisoryRepository extends ServiceEntityRepository
 
     public function getPackageSecurityAdvisories(string $name): array
     {
-        $sql = 'SELECT s.*
+        $sql = 'SELECT s.*, sa.source
             FROM security_advisory s
+            INNER JOIN security_advisory_source sa ON sa.securityAdvisory_id=s.id
             WHERE s.packageName = :name
             ORDER BY s.reportedAt DESC, s.id DESC';
 
-        return $this->getEntityManager()->getConnection()
-            ->fetchAllAssociative($sql, ['name' => $name]);
+        $entries = $this->getEntityManager()->getConnection()->fetchAllAssociative($sql, ['name' => $name]);
+        $result = [];
+        foreach ($entries as $entry) {
+            if (!isset($result[$entry['id']])) {
+                $result[$entry['id']] = $entry;
+                $result[$entry['id']]['sources'] = [];
+            }
+
+            $result[$entry['id']]['sources'][] = $entry['source'];
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Entity/SecurityAdvisorySource.php
+++ b/src/Entity/SecurityAdvisorySource.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(
+ *     name="security_advisory_source",
+ *     indexes={
+ *         @ORM\Index(name="source_source_idx",columns={"source"})
+ *     }
+ * )
+ */
+class SecurityAdvisorySource
+{
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="SecurityAdvisory", inversedBy="sources")
+     * @ORM\JoinColumn(onDelete="CASCADE", nullable=false)
+     */
+    private SecurityAdvisory $securityAdvisory;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="string")
+     */
+    private string $remoteId;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="string")
+     */
+    private string $source;
+
+    public function __construct(SecurityAdvisory $securityAdvisory, string $remoteId, string $source)
+    {
+        $this->securityAdvisory = $securityAdvisory;
+        $this->remoteId = $remoteId;
+        $this->source = $source;
+    }
+
+    public function getRemoteId(): string
+    {
+        return $this->remoteId;
+    }
+
+    public function getSource(): string
+    {
+        return $this->source;
+    }
+}

--- a/src/SecurityAdvisory/FriendsOfPhpSecurityAdvisoriesSource.php
+++ b/src/SecurityAdvisory/FriendsOfPhpSecurityAdvisoriesSource.php
@@ -34,13 +34,10 @@ class FriendsOfPhpSecurityAdvisoriesSource implements SecurityAdvisorySourceInte
         $this->logger = $logger;
     }
 
-    public function getAdvisories(ConsoleIO $io, Package $package): ?array
+    public function getAdvisories(ConsoleIO $io): ?RemoteSecurityAdvisoryCollection
     {
-        if ($package->getName() !== self::SECURITY_PACKAGE) {
-            return null;
-        }
-
-        if (!($version = $this->doctrine->getRepository(Version::class)->findOneBy(['package' => $package->getId(), 'isDefaultBranch' => true]))) {
+        $package = $this->doctrine->getRepository(Package::class)->findOneBy(['name' => self::SECURITY_PACKAGE]);
+        if (!$package || !($version = $this->doctrine->getRepository(Version::class)->findOneBy(['package' => $package->getId(), 'isDefaultBranch' => true]))) {
             return null;
         }
 
@@ -49,14 +46,13 @@ class FriendsOfPhpSecurityAdvisoriesSource implements SecurityAdvisorySourceInte
         $composerPackage = $loader->load($version->toArray([]), CompletePackage::class);
 
         $localCwdDir = null;
-        $advisories = null;
         try {
             $localCwdDir = sys_get_temp_dir() . '/' . uniqid(self::SOURCE_NAME, true);
             $localDir = $localCwdDir . '/' . self::SOURCE_NAME;
             $config = Factory::createConfig($io, $localCwdDir);
             $process = new ProcessExecutor();
             $factory = new Factory();
-            $httpDownloader = $factory->createHttpDownloader($io, $config);
+            $httpDownloader = Factory::createHttpDownloader($io, $config);
             $loop = new Loop($httpDownloader, $process);
             $downloadManager = $factory->createDownloadManager($io, $config, $httpDownloader, $process);
             $downloader = $downloadManager->getDownloader('zip');
@@ -80,17 +76,19 @@ class FriendsOfPhpSecurityAdvisoriesSource implements SecurityAdvisorySourceInte
                 $content = Yaml::parse($yaml);
                 $advisories[] = RemoteSecurityAdvisory::createFromFriendsOfPhp($file->getRelativePathname(), $content);
             }
+
+            return new RemoteSecurityAdvisoryCollection($advisories);
         } catch (TransportException $e) {
             $this->logger->error(sprintf('Failed to download "%s" zip file', self::SECURITY_PACKAGE), [
                 'exception' => $e,
             ]);
+
+            return null;
         } finally {
             if ($localCwdDir) {
                 $filesystem = new Filesystem();
                 $filesystem->remove($localCwdDir);
             }
         }
-
-        return $advisories;
     }
 }

--- a/src/SecurityAdvisory/FriendsOfPhpSecurityAdvisoriesSource.php
+++ b/src/SecurityAdvisory/FriendsOfPhpSecurityAdvisoriesSource.php
@@ -34,10 +34,13 @@ class FriendsOfPhpSecurityAdvisoriesSource implements SecurityAdvisorySourceInte
         $this->logger = $logger;
     }
 
-    public function getAdvisories(ConsoleIO $io): ?array
+    public function getAdvisories(ConsoleIO $io, Package $package): ?array
     {
-        $package = $this->doctrine->getRepository(Package::class)->findOneBy(['name' => self::SECURITY_PACKAGE]);
-        if (!$package || !($version = $this->doctrine->getRepository(Version::class)->findOneBy(['package' => $package->getId(), 'isDefaultBranch' => true]))) {
+        if ($package->getName() !== self::SECURITY_PACKAGE) {
+            return null;
+        }
+
+        if (!($version = $this->doctrine->getRepository(Version::class)->findOneBy(['package' => $package->getId(), 'isDefaultBranch' => true]))) {
             return null;
         }
 

--- a/src/SecurityAdvisory/GitHubSecurityAdvisoriesSource.php
+++ b/src/SecurityAdvisory/GitHubSecurityAdvisoriesSource.php
@@ -1,0 +1,127 @@
+<?php
+
+
+namespace App\SecurityAdvisory;
+
+use App\Entity\Package;
+use Composer\IO\ConsoleIO;
+use GuzzleHttp\Client;
+
+/**
+ * @author Yanick Witschi <yanick.witschi@terminal42.ch>
+ */
+class GitHubSecurityAdvisoriesSource implements SecurityAdvisorySourceInterface
+{
+    public const SOURCE_NAME = 'GitHub';
+
+    private Client $guzzle;
+
+    public function __construct(Client $guzzle)
+    {
+        $this->guzzle = $guzzle;
+    }
+
+    public function getAdvisories(ConsoleIO $io, Package $package): ?array
+    {
+        $githubToken = null;
+        $maintainers = $package->getMaintainers();
+        foreach ($maintainers as $maintainer) {
+            if ($maintainer->getGithubToken()) {
+                $githubToken = $maintainer->getGithubToken();
+                break;
+            }
+        }
+
+        if (null === $githubToken) {
+            return [];
+        }
+
+        /** @var RemoteSecurityAdvisory[] $advisories */
+        $advisories = [];
+        $hasNextPage = true;
+        $after = '';
+
+        while ($hasNextPage) {
+            $opts = [
+                'headers' => ['Authorization' => 'Bearer ' . $githubToken],
+                'json' => ['query' => $this->getQuery($package->getName(), $after)],
+            ];
+
+            $response = $this->guzzle->request('POST', 'https://api.github.com/graphql', $opts);
+            $data = json_decode($response->getBody()->getContents(), true);
+            $data = $data['data'];
+
+            foreach ($data['securityVulnerabilities']['nodes'] as $node) {
+                $remoteId = null;
+                $cve = null;
+
+                foreach ($node['advisory']['identifiers'] as $identifier) {
+                    if ('GHSA' === $identifier['type']) {
+                        $remoteId = $identifier['value'];
+                        continue;
+                    }
+                    if ('CVE' === $identifier['type']) {
+                        $cve = $identifier['value'];
+                    }
+                }
+
+                if (null === $remoteId) {
+                    continue;
+                }
+
+                if (isset($advisories[$remoteId])) {
+                    $advisories[$remoteId] = $advisories[$remoteId]->withAddedAffectedVersion($node['vulnerableVersionRange']);
+                    continue;
+                }
+
+                $advisories[$remoteId] = new RemoteSecurityAdvisory(
+                    $remoteId,
+                    $node['advisory']['summary'],
+                    $package->getName(),
+                    $node['vulnerableVersionRange'],
+                    $node['advisory']['permalink'],
+                    $cve,
+                    \DateTime::createFromFormat(\DateTimeInterface::ISO8601,  $node['advisory']['publishedAt']),
+                    null
+                );
+            }
+
+            $hasNextPage = $data['securityVulnerabilities']['pageInfo']['hasNextPage'];
+            $after = $data['securityVulnerabilities']['pageInfo']['endCursor'];
+        }
+
+        return array_values($advisories);
+    }
+
+    private function getQuery(string $packageName, string $after = ''): string
+    {
+        if ('' !== $after) {
+            $after = sprintf(',after:"%s"', $after);
+        }
+
+        $query = <<<QUERY
+query {
+  securityVulnerabilities(ecosystem:COMPOSER,package:"%s",first:100%s) {
+    nodes {
+      advisory {
+        summary,
+        permalink,
+        publishedAt,
+        identifiers {
+          type,
+          value
+        }
+      },
+      vulnerableVersionRange
+    },
+    pageInfo {
+      hasNextPage,
+      endCursor
+    }
+  }
+}
+QUERY;
+
+        return preg_replace('/[ \t\n]+/', '', sprintf($query, $packageName, $after));
+    }
+}

--- a/src/SecurityAdvisory/RemoteSecurityAdvisory.php
+++ b/src/SecurityAdvisory/RemoteSecurityAdvisory.php
@@ -21,25 +21,21 @@ use DateTimeImmutable;
  */
 class RemoteSecurityAdvisory
 {
-    private string $id;
-    private string $title;
-    private string $packageName;
-    private string $affectedVersions;
-    private string $link;
-    private ?string $cve;
-    private DateTimeImmutable $date;
-    private ?string $composerRepository;
-
-    public function __construct(string $id, string $title, string $packageName, string $affectedVersions, string $link, ?string $cve, DateTimeImmutable $date, ?string $composerRepository)
-    {
-        $this->id = $id;
-        $this->title = $title;
-        $this->packageName = $packageName;
-        $this->affectedVersions = $affectedVersions;
-        $this->link = $link;
-        $this->cve = $cve;
-        $this->date = $date;
-        $this->composerRepository = $composerRepository;
+    /**
+     * @param list<string> $references
+     */
+    public function __construct(
+        private string $id,
+        private string $title,
+        private string $packageName,
+        private string $affectedVersions,
+        private string $link,
+        private ?string $cve,
+        private DateTimeImmutable $date,
+        private ?string $composerRepository,
+        private array $references,
+        private string $source,
+    ) {
     }
 
     public function getId(): string
@@ -82,6 +78,19 @@ class RemoteSecurityAdvisory
         return $this->composerRepository;
     }
 
+    /**
+     * @return list<string>
+     */
+    public function getReferences(): array
+    {
+        return $this->references;
+    }
+
+    public function getSource(): string
+    {
+        return $this->source;
+    }
+
     public function withAddedAffectedVersion(string $version): self
     {
         return new self(
@@ -92,7 +101,9 @@ class RemoteSecurityAdvisory
             $this->getLink(),
             $this->getCve(),
             $this->getDate(),
-            $this->getComposerRepository()
+            $this->getComposerRepository(),
+            $this->getReferences(),
+            $this->getSource(),
         );
     }
 
@@ -163,7 +174,9 @@ class RemoteSecurityAdvisory
             $info['link'],
             $cve,
             $date,
-            $composerRepository
+            $composerRepository,
+            [],
+            FriendsOfPhpSecurityAdvisoriesSource::SOURCE_NAME
         );
     }
 }

--- a/src/SecurityAdvisory/RemoteSecurityAdvisory.php
+++ b/src/SecurityAdvisory/RemoteSecurityAdvisory.php
@@ -82,6 +82,20 @@ class RemoteSecurityAdvisory
         return $this->composerRepository;
     }
 
+    public function withAddedAffectedVersion(string $version): self
+    {
+        return new self(
+            $this->getId(),
+            $this->getTitle(),
+            $this->getPackageName(),
+            implode('|', [$this->getAffectedVersions(), $version]),
+            $this->getLink(),
+            $this->getCve(),
+            $this->getDate(),
+            $this->getComposerRepository()
+        );
+    }
+
     /**
      * @phpstan-param FriendsOfPhpSecurityAdvisory $info
      */

--- a/src/SecurityAdvisory/RemoteSecurityAdvisoryCollection.php
+++ b/src/SecurityAdvisory/RemoteSecurityAdvisoryCollection.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace App\SecurityAdvisory;
+
+class RemoteSecurityAdvisoryCollection
+{
+    /** @var array<string, list<RemoteSecurityAdvisory>> */
+    private array $groupedSecurityAdvisories = [];
+
+    /**
+     * @param list<RemoteSecurityAdvisory> $advisories
+     */
+    public function __construct(array $advisories)
+    {
+        foreach ($advisories as $advisory) {
+            $this->groupedSecurityAdvisories[$advisory->getPackageName()][] = $advisory;
+        }
+    }
+
+    /**
+     * @return list<RemoteSecurityAdvisory>
+     */
+    public function getAdvisoriesForPackageName(string $packageName): array
+    {
+        return $this->groupedSecurityAdvisories[$packageName] ?? [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getPackageNames(): array
+    {
+        return array_keys($this->groupedSecurityAdvisories);
+    }
+}

--- a/src/SecurityAdvisory/SecurityAdvisoryResolver.php
+++ b/src/SecurityAdvisory/SecurityAdvisoryResolver.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types=1);
+
+namespace App\SecurityAdvisory;
+
+use App\Entity\SecurityAdvisory;
+
+class SecurityAdvisoryResolver
+{
+    /**
+     * @param SecurityAdvisory[] $existingAdvisories
+     * @return array{SecurityAdvisory[], SecurityAdvisory[]}
+     */
+    public function resolve(array $existingAdvisories, RemoteSecurityAdvisoryCollection $remoteAdvisories, string $sourceName): array
+    {
+        $newAdvisories = [];
+        $removedAdvisories = [];
+
+        /** @var array<string, array<string, SecurityAdvisory>> $existingSourceAdvisoryMap */
+        $existingSourceAdvisoryMap = [];
+        /** @var array<string, SecurityAdvisory[]> $unmatchedExistingAdvisories */
+        $unmatchedExistingAdvisories = [];
+        foreach ($existingAdvisories as $advisory) {
+            $sourceRemoteId = $advisory->getSourceRemoteId($sourceName);
+            if ($sourceRemoteId) {
+                $existingSourceAdvisoryMap[$advisory->getPackageName()][$sourceRemoteId] = $advisory;
+            } else {
+                $unmatchedExistingAdvisories[$advisory->getPackageName()][$advisory->getPackagistAdvisoryId()] = $advisory;
+            }
+        }
+
+        // Attempt to match existing advisories against remote id
+        $unmatchedRemoteAdvisories = [];
+        foreach ($remoteAdvisories->getPackageNames() as $packageName) {
+            foreach ($remoteAdvisories->getAdvisoriesForPackageName($packageName) as $remoteAdvisory) {
+                if (isset($existingSourceAdvisoryMap[$packageName][$remoteAdvisory->getId()])) {
+                    $existingSourceAdvisoryMap[$packageName][$remoteAdvisory->getId()]->updateAdvisory($remoteAdvisory);
+                    unset($existingSourceAdvisoryMap[$packageName][$remoteAdvisory->getId()]);
+                } else {
+                    $unmatchedRemoteAdvisories[$packageName][] = $remoteAdvisory;
+                }
+            }
+        }
+
+        foreach ($existingSourceAdvisoryMap as $packageName => $existingPackageRepositories) {
+            foreach ($existingPackageRepositories as $existingAdvisory) {
+                $unmatchedExistingAdvisories[$packageName][$existingAdvisory->getPackagistAdvisoryId()] = $existingAdvisory;
+            }
+        }
+
+        // Try to match remaining remote advisories with remaining local advisories in case the remote id changed
+        // Allow three changes e.g. filename, CVE, date on a rename
+        $requiredDifferenceScore = 3;
+        foreach ($unmatchedRemoteAdvisories as $packageName => $packageAdvisories) {
+            foreach ($packageAdvisories as $remoteAdvisory) {
+                $matchedAdvisory = null;
+                $lowestScore = 9999;
+                if (isset($unmatchedExistingAdvisories[$packageName])) {
+                    foreach ($unmatchedExistingAdvisories[$packageName] as $unmatchedAdvisory) {
+                        $score = $unmatchedAdvisory->calculateDifferenceScore($remoteAdvisory);
+                        if ($score < $lowestScore && $score <= $requiredDifferenceScore) {
+                            $matchedAdvisory = $unmatchedAdvisory;
+                            $lowestScore = $score;
+                        }
+                    }
+                }
+
+                // No similar existing advisories found. Store them as new advisories
+                if ($matchedAdvisory === null) {
+                    $newAdvisories[] = new SecurityAdvisory($remoteAdvisory, $sourceName);
+                } else {
+                    // Update advisory and make sure the new source is added
+                    $matchedAdvisory->addSource($remoteAdvisory->getId(), $sourceName);
+                    $matchedAdvisory->updateAdvisory($remoteAdvisory);
+                    unset($unmatchedExistingAdvisories[$packageName][$matchedAdvisory->getPackagistAdvisoryId()]);
+                }
+            }
+        }
+
+        foreach ($unmatchedExistingAdvisories as $packageUnmatchedAdvisories) {
+            foreach ($packageUnmatchedAdvisories as $unmatchedAdvisory) {
+                if ($unmatchedAdvisory->removeSource($sourceName) && !$unmatchedAdvisory->hasSources()) {
+                    $removedAdvisories[] = $unmatchedAdvisory;
+                }
+            }
+        }
+
+        return [$newAdvisories, $removedAdvisories];
+    }
+}

--- a/src/SecurityAdvisory/SecurityAdvisorySourceInterface.php
+++ b/src/SecurityAdvisory/SecurityAdvisorySourceInterface.php
@@ -2,6 +2,7 @@
 
 namespace App\SecurityAdvisory;
 
+use App\Entity\Package;
 use Composer\IO\ConsoleIO;
 
 interface SecurityAdvisorySourceInterface
@@ -9,5 +10,5 @@ interface SecurityAdvisorySourceInterface
     /**
      * @return null|RemoteSecurityAdvisory[]
      */
-    public function getAdvisories(ConsoleIO $io): ?array;
+    public function getAdvisories(ConsoleIO $io, Package $package): ?array;
 }

--- a/src/SecurityAdvisory/SecurityAdvisorySourceInterface.php
+++ b/src/SecurityAdvisory/SecurityAdvisorySourceInterface.php
@@ -7,8 +7,5 @@ use Composer\IO\ConsoleIO;
 
 interface SecurityAdvisorySourceInterface
 {
-    /**
-     * @return null|RemoteSecurityAdvisory[]
-     */
-    public function getAdvisories(ConsoleIO $io, Package $package): ?array;
+    public function getAdvisories(ConsoleIO $io): ?RemoteSecurityAdvisoryCollection;
 }

--- a/src/Service/Locker.php
+++ b/src/Service/Locker.php
@@ -29,18 +29,18 @@ class Locker
         $this->getConn()->fetchOne('SELECT RELEASE_LOCK(:id)', ['id' => 'package_update_'.$packageId]);
     }
 
-    public function lockSecurityAdvisory(string $source, int $timeout = 0): bool
+    public function lockSecurityAdvisory(string $processId, int $timeout = 0): bool
     {
         $this->ensurePrimaryConnection();
 
-        return (bool) $this->getConn()->fetchOne('SELECT GET_LOCK(:id, :timeout)', ['id' => 'security_advisory_'.$source, 'timeout' => $timeout]);
+        return (bool) $this->getConn()->fetchOne('SELECT GET_LOCK(:id, :timeout)', ['id' => 'security_advisory_'.$processId, 'timeout' => $timeout]);
     }
 
-    public function unlockSecurityAdvisory(string $source): void
+    public function unlockSecurityAdvisory(string $processId): void
     {
         $this->getConn()->connect();
 
-        $this->getConn()->fetchOne('SELECT RELEASE_LOCK(:id)', ['id' => 'security_advisory_'.$source]);
+        $this->getConn()->fetchOne('SELECT RELEASE_LOCK(:id)', ['id' => 'security_advisory_'.$processId]);
     }
 
     public function lockCommand(string $command, int $timeout = 0): bool

--- a/src/Service/Scheduler.php
+++ b/src/Service/Scheduler.php
@@ -57,9 +57,9 @@ class Scheduler
         return $this->createJob('githubuser:migrate', ['id' => $userId, 'old_scope' => $oldScope, 'new_scope' => $newScope], $userId);
     }
 
-    public function scheduleSecurityAdvisory(string $source, ?\DateTimeInterface $executeAfter = null): Job
+    public function scheduleSecurityAdvisory(string $source, int $packageId, ?\DateTimeInterface $executeAfter = null): Job
     {
-        return $this->createJob('security:advisory', ['source' => $source], null, $executeAfter);
+        return $this->createJob('security:advisory', ['source' => $source], $packageId, $executeAfter);
     }
 
     private function getPendingUpdateJob(int $packageId, bool $updateEqualRefs = false, bool $deleteBefore = false): ?string

--- a/src/Service/UpdaterWorker.php
+++ b/src/Service/UpdaterWorker.php
@@ -4,6 +4,7 @@ namespace App\Service;
 
 use App\Entity\User;
 use App\SecurityAdvisory\FriendsOfPhpSecurityAdvisoriesSource;
+use App\SecurityAdvisory\GitHubSecurityAdvisoriesSource;
 use Composer\Pcre\Preg;
 use Psr\Log\LoggerInterface;
 use Composer\Package\Loader\ArrayLoader;
@@ -341,7 +342,9 @@ class UpdaterWorker
         }
 
         if ($packageName === FriendsOfPhpSecurityAdvisoriesSource::SECURITY_PACKAGE) {
-            $this->scheduler->scheduleSecurityAdvisory(FriendsOfPhpSecurityAdvisoriesSource::SOURCE_NAME);
+            $this->scheduler->scheduleSecurityAdvisory(FriendsOfPhpSecurityAdvisoriesSource::SOURCE_NAME, $id);
+        } elseif (preg_match('{[@/]github.com[:/]([^/]+/[^/]+?)(\.git)?$}i', $package->getRepository())) {
+            $this->scheduler->scheduleSecurityAdvisory(GitHubSecurityAdvisoriesSource::SOURCE_NAME, $id);
         }
 
         return [

--- a/src/Service/UpdaterWorker.php
+++ b/src/Service/UpdaterWorker.php
@@ -4,7 +4,6 @@ namespace App\Service;
 
 use App\Entity\User;
 use App\SecurityAdvisory\FriendsOfPhpSecurityAdvisoriesSource;
-use App\SecurityAdvisory\GitHubSecurityAdvisoriesSource;
 use Composer\Pcre\Preg;
 use Psr\Log\LoggerInterface;
 use Composer\Package\Loader\ArrayLoader;
@@ -343,8 +342,6 @@ class UpdaterWorker
 
         if ($packageName === FriendsOfPhpSecurityAdvisoriesSource::SECURITY_PACKAGE) {
             $this->scheduler->scheduleSecurityAdvisory(FriendsOfPhpSecurityAdvisoriesSource::SOURCE_NAME, $id);
-        } elseif (preg_match('{[@/]github.com[:/]([^/]+/[^/]+?)(\.git)?$}i', $package->getRepository())) {
-            $this->scheduler->scheduleSecurityAdvisory(GitHubSecurityAdvisoriesSource::SOURCE_NAME, $id);
         }
 
         return [

--- a/templates/package/security_advisories.html.twig
+++ b/templates/package/security_advisories.html.twig
@@ -42,7 +42,7 @@
                                         <p>Affected version: {{ advisory.affectedVersions }}</p>
                                     </div>
                                     <div class="col-sm-4 col-lg-3">
-                                        <p>Reported by:<br/>{{ advisory.source }}</p>
+                                        <p>Reported by:<br/>{{ advisory.sources|join(', ') }}</p>
                                     </div>
                                 </div>
                             </div>

--- a/tests/Entity/SecurityAdvisoryTest.php
+++ b/tests/Entity/SecurityAdvisoryTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Entity;
 
 use App\Entity\SecurityAdvisory;
+use App\SecurityAdvisory\FriendsOfPhpSecurityAdvisoriesSource;
 use App\SecurityAdvisory\RemoteSecurityAdvisory;
 use PHPUnit\Framework\TestCase;
 
@@ -50,7 +51,7 @@ class SecurityAdvisoryTest extends TestCase
             'reference' => 'composer://league/flysystem'
         ]);
 
-        $advisory = new SecurityAdvisory($remoteAdvisory, 'source');
+        $advisory = new SecurityAdvisory($remoteAdvisory, FriendsOfPhpSecurityAdvisoriesSource::SOURCE_NAME);
 
         $updatedRemoteAdvisory = RemoteSecurityAdvisory::createFromFriendsOfPhp('league/flysystem/CVE-2021-32708.yaml', [
             'title' => 'TOCTOU Race Condition enabling remote code execution',
@@ -95,7 +96,7 @@ class SecurityAdvisoryTest extends TestCase
             'reference' => 'composer://symfony/framework-bundle'
         ]);
 
-        $advisory = new SecurityAdvisory($remoteAdvisory, 'source');
+        $advisory = new SecurityAdvisory($remoteAdvisory, FriendsOfPhpSecurityAdvisoriesSource::SOURCE_NAME);
 
         $updatedRemoteAdvisory = RemoteSecurityAdvisory::createFromFriendsOfPhp('symfony/framework-bundle/CVE-2022-99999999999.yaml', [
             'title' => 'CVE-2022-99999999999: CSRF token missing in forms',

--- a/tests/SecurityAdvisory/GitHubSecurityAdvisoriesSourceTest.php
+++ b/tests/SecurityAdvisory/GitHubSecurityAdvisoriesSourceTest.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace App\Tests\SecurityAdvisory;
+
+use App\Entity\Package;
+use App\Entity\User;
+use App\SecurityAdvisory\GitHubSecurityAdvisoriesSource;
+use Composer\IO\BufferIO;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Yanick Witschi <yanick.witschi@terminal42.ch>
+ */
+class GitHubSecurityAdvisoriesSourceTest extends TestCase
+{
+    public function testNoAdvisoriesIfNoMaintainerHasAnyGitHubToken(): void
+    {
+        $client = $this->createMock(Client::class);
+
+        $source = new GitHubSecurityAdvisoriesSource($client);
+        $advisories = $source->getAdvisories(new BufferIO(), $this->getPackage());
+
+        $this->assertSame([], $advisories);
+    }
+
+    public function testWithoutPagination(): void
+    {
+        $transactions = [];
+        $history = Middleware::history($transactions);
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json; charset=utf-8'], json_encode($this->getGraphQLResultFirstPage(false))),
+        ]);
+        $handlerStack = HandlerStack::create($mock);
+        $handlerStack->push($history);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $source = new GitHubSecurityAdvisoriesSource($client);
+        $advisories = $source->getAdvisories(new BufferIO(), $this->getPackage('github-token'));
+
+        $this->assertCount(1, $transactions);
+        $this->assertSame('POST', $transactions[0]['request']->getMethod());
+        $this->assertSame('https://api.github.com/graphql', (string) $transactions[0]['request']->getUri());
+        $this->assertSame('Bearer github-token', $transactions[0]['request']->getHeader('Authorization')[0]);
+        $this->assertSame('{"query":"query{securityVulnerabilities(ecosystem:COMPOSER,package:\"vendor\/package\",first:100){nodes{advisory{summary,permalink,publishedAt,identifiers{type,value}},vulnerableVersionRange},pageInfo{hasNextPage,endCursor}}}"}', $transactions[0]['request']->getBody()->getContents());
+
+        $this->assertCount(2, $advisories);
+
+        $this->assertSame('GHSA-h58v-c6rf-g9f7', $advisories[0]->getId());
+        $this->assertSame('Cross site scripting in the system log', $advisories[0]->getTitle());
+        $this->assertSame('vendor/package', $advisories[0]->getPackageName());
+        $this->assertSame('>= 4.10.0, < 4.11.5|>= 4.5.0, < 4.9.16', $advisories[0]->getAffectedVersions());
+        $this->assertSame('https://github.com/advisories/GHSA-h58v-c6rf-g9f7', $advisories[0]->getLink());
+        $this->assertSame('CVE-2021-35210', $advisories[0]->getCve());
+        $this->assertSame('2021-07-01T17:00:04+0000', $advisories[0]->getDate()->format(\DateTimeInterface::ISO8601));
+        $this->assertSame(null, $advisories[0]->getComposerRepository());
+
+        $this->assertSame('GHSA-f7wm-x4gw-6m23', $advisories[1]->getId());
+        $this->assertSame('Insert tag injection in forms', $advisories[1]->getTitle());
+        $this->assertSame('vendor/package', $advisories[1]->getPackageName());
+        $this->assertSame('= 4.10.0', $advisories[1]->getAffectedVersions());
+        $this->assertSame('https://github.com/advisories/GHSA-f7wm-x4gw-6m23', $advisories[1]->getLink());
+        $this->assertSame('CVE-2020-25768', $advisories[1]->getCve());
+        $this->assertSame('2020-09-24T16:23:54+0000', $advisories[1]->getDate()->format(\DateTimeInterface::ISO8601));
+        $this->assertSame(null, $advisories[1]->getComposerRepository());
+    }
+
+    public function testWithPagination(): void
+    {
+        $transactions = [];
+        $history = Middleware::history($transactions);
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json; charset=utf-8'], json_encode($this->getGraphQLResultFirstPage(true))),
+            new Response(200, ['Content-Type' => 'application/json; charset=utf-8'], json_encode($this->getGraphQLResultSecondPage())),
+        ]);
+        $handlerStack = HandlerStack::create($mock);
+        $handlerStack->push($history);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $source = new GitHubSecurityAdvisoriesSource($client);
+        $advisories = $source->getAdvisories(new BufferIO(), $this->getPackage('github-token'));
+
+        $this->assertCount(2, $transactions);
+        $this->assertSame('POST', $transactions[0]['request']->getMethod());
+        $this->assertSame('https://api.github.com/graphql', (string) $transactions[0]['request']->getUri());
+        $this->assertSame('Bearer github-token', $transactions[0]['request']->getHeader('Authorization')[0]);
+        $this->assertSame('{"query":"query{securityVulnerabilities(ecosystem:COMPOSER,package:\"vendor\/package\",first:100){nodes{advisory{summary,permalink,publishedAt,identifiers{type,value}},vulnerableVersionRange},pageInfo{hasNextPage,endCursor}}}"}', $transactions[0]['request']->getBody()->getContents());
+        $this->assertSame('POST', $transactions[1]['request']->getMethod());
+        $this->assertSame('https://api.github.com/graphql', (string) $transactions[1]['request']->getUri());
+        $this->assertSame('Bearer github-token', $transactions[1]['request']->getHeader('Authorization')[0]);
+        $this->assertSame('{"query":"query{securityVulnerabilities(ecosystem:COMPOSER,package:\"vendor\/package\",first:100,after:\"Y3Vyc29yOnYyOpK5MjAyMC0wOS0yNFQxODoyMzo0MyswMjowMM0T9A==\"){nodes{advisory{summary,permalink,publishedAt,identifiers{type,value}},vulnerableVersionRange},pageInfo{hasNextPage,endCursor}}}"}', $transactions[1]['request']->getBody()->getContents());
+
+        $this->assertCount(2, $advisories);
+
+        $this->assertSame('GHSA-h58v-c6rf-g9f7', $advisories[0]->getId());
+        $this->assertSame('Cross site scripting in the system log', $advisories[0]->getTitle());
+        $this->assertSame('vendor/package', $advisories[0]->getPackageName());
+        $this->assertSame('>= 4.10.0, < 4.11.5|>= 4.5.0, < 4.9.16', $advisories[0]->getAffectedVersions());
+        $this->assertSame('https://github.com/advisories/GHSA-h58v-c6rf-g9f7', $advisories[0]->getLink());
+        $this->assertSame('CVE-2021-35210', $advisories[0]->getCve());
+        $this->assertSame('2021-07-01T17:00:04+0000', $advisories[0]->getDate()->format(\DateTimeInterface::ISO8601));
+        $this->assertSame(null, $advisories[0]->getComposerRepository());
+
+        $this->assertSame('GHSA-f7wm-x4gw-6m23', $advisories[1]->getId());
+        $this->assertSame('Insert tag injection in forms', $advisories[1]->getTitle());
+        $this->assertSame('vendor/package', $advisories[1]->getPackageName());
+        $this->assertSame('= 4.10.0|< 4.11.0', $advisories[1]->getAffectedVersions());
+        $this->assertSame('https://github.com/advisories/GHSA-f7wm-x4gw-6m23', $advisories[1]->getLink());
+        $this->assertSame('CVE-2020-25768', $advisories[1]->getCve());
+        $this->assertSame('2020-09-24T16:23:54+0000', $advisories[1]->getDate()->format(\DateTimeInterface::ISO8601));
+        $this->assertSame(null, $advisories[1]->getComposerRepository());
+    }
+
+
+    private function getPackage(string $githubToken = null): Package
+    {
+        $user = new User();
+        $user->setGithubToken($githubToken);
+
+        $package = new Package();
+        $package->setName('vendor/package');
+        $package->addMaintainer($user);
+
+        return $package;
+    }
+
+    private function getGraphQLResultFirstPage(bool $hasNextPage): array
+    {
+        return [
+            'data' => [
+                'securityVulnerabilities' => [
+                    'nodes' => [
+                        [
+                            'advisory' => [
+                                'summary' => 'Cross site scripting in the system log',
+                                'permalink' => 'https://github.com/advisories/GHSA-h58v-c6rf-g9f7',
+                                'publishedAt' => '2021-07-01T17:00:04Z',
+                                'identifiers' => [
+                                    ['type' => 'GHSA', 'value' => 'GHSA-h58v-c6rf-g9f7',],
+                                    ['type' => 'CVE', 'value' => 'CVE-2021-35210'],
+                                ],
+                            ],
+                            'vulnerableVersionRange' => '>= 4.10.0, < 4.11.5',
+                        ],
+                        [
+                            'advisory' => [
+                                'summary' => 'Cross site scripting in the system log',
+                                'permalink' => 'https://github.com/advisories/GHSA-h58v-c6rf-g9f7',
+                                'publishedAt' => '2021-07-01T17:00:04Z',
+                                'identifiers' => [
+                                    ['type' => 'GHSA', 'value' => 'GHSA-h58v-c6rf-g9f7'],
+                                    ['type' => 'CVE', 'value' => 'CVE-2021-35210'],
+                                ],
+                            ],
+                            'vulnerableVersionRange' => '>= 4.5.0, < 4.9.16',
+                        ],
+                        [
+                            'advisory' => [
+                                'summary' => 'Insert tag injection in forms',
+                                'permalink' => 'https://github.com/advisories/GHSA-f7wm-x4gw-6m23',
+                                'publishedAt' => '2020-09-24T16:23:54Z',
+                                'identifiers' => [
+                                    ['type' => 'GHSA', 'value' => 'GHSA-f7wm-x4gw-6m23',],
+                                    ['type' => 'CVE', 'value' => 'CVE-2020-25768'],
+                                ],
+                            ],
+                            'vulnerableVersionRange' => '= 4.10.0',
+                        ],
+                    ],
+                    'pageInfo' => [
+                        'hasNextPage' => $hasNextPage,
+                        'endCursor' => 'Y3Vyc29yOnYyOpK5MjAyMC0wOS0yNFQxODoyMzo0MyswMjowMM0T9A==',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function getGraphQLResultSecondPage(): array
+    {
+        return [
+            'data' => [
+                'securityVulnerabilities' => [
+                    'nodes' => [
+                        [
+                            'advisory' => [
+                                'summary' => 'Insert tag injection in forms',
+                                'permalink' => 'https://github.com/advisories/GHSA-f7wm-x4gw-6m23',
+                                'publishedAt' => '2020-09-24T16:23:54Z',
+                                'identifiers' => [
+                                    ['type' => 'GHSA', 'value' => 'GHSA-f7wm-x4gw-6m23',],
+                                    ['type' => 'CVE', 'value' => 'CVE-2020-25768'],
+                                ],
+                            ],
+                            'vulnerableVersionRange' => '< 4.11.0',
+                        ],
+                    ],
+                    'pageInfo' => [
+                        'hasNextPage' => false,
+                        'endCursor' => 'Y3Vyc29yOnYyOpK5MjAxOS0xMi0xN1QyMDozNTozMSswMTowMM0LWQ==',
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/SecurityAdvisory/RemoteSecurityAdvisoryTest.php
+++ b/tests/SecurityAdvisory/RemoteSecurityAdvisoryTest.php
@@ -101,7 +101,7 @@ class RemoteSecurityAdvisoryTest extends TestCase
 
     public function testWithAddedAffectedVersion(): void
     {
-        $advisory = new RemoteSecurityAdvisory('id', 'foobar', 'foo/bar', '>=1', 'https://foobar.com', null, new \DateTimeImmutable(), null);
+        $advisory = new RemoteSecurityAdvisory('id', 'foobar', 'foo/bar', '>=1', 'https://foobar.com', null, new \DateTimeImmutable(), null, [], 'test');
         $advisory = $advisory->withAddedAffectedVersion('<2');
 
         $this->assertSame('>=1|<2', $advisory->getAffectedVersions());

--- a/tests/SecurityAdvisory/RemoteSecurityAdvisoryTest.php
+++ b/tests/SecurityAdvisory/RemoteSecurityAdvisoryTest.php
@@ -98,4 +98,12 @@ class RemoteSecurityAdvisoryTest extends TestCase
         $this->assertSame('symfony/framework-bundle/CVE-2022-xxxx.yaml', $advisory->getId());
         $this->assertNull($advisory->getCve());
     }
+
+    public function testWithAddedAffectedVersion(): void
+    {
+        $advisory = new RemoteSecurityAdvisory('id', 'foobar', 'foo/bar', '>=1', 'https://foobar.com', null, new \DateTime(), null);
+        $advisory = $advisory->withAddedAffectedVersion('<2');
+
+        $this->assertSame('>=1|<2', $advisory->getAffectedVersions());
+    }
 }

--- a/tests/SecurityAdvisory/RemoteSecurityAdvisoryTest.php
+++ b/tests/SecurityAdvisory/RemoteSecurityAdvisoryTest.php
@@ -101,7 +101,7 @@ class RemoteSecurityAdvisoryTest extends TestCase
 
     public function testWithAddedAffectedVersion(): void
     {
-        $advisory = new RemoteSecurityAdvisory('id', 'foobar', 'foo/bar', '>=1', 'https://foobar.com', null, new \DateTime(), null);
+        $advisory = new RemoteSecurityAdvisory('id', 'foobar', 'foo/bar', '>=1', 'https://foobar.com', null, new \DateTimeImmutable(), null);
         $advisory = $advisory->withAddedAffectedVersion('<2');
 
         $this->assertSame('>=1|<2', $advisory->getAffectedVersions());

--- a/tests/SecurityAdvisory/SecurityAdvisoryResolverTest.php
+++ b/tests/SecurityAdvisory/SecurityAdvisoryResolverTest.php
@@ -1,0 +1,85 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\SecurityAdvisory;
+
+use App\Entity\SecurityAdvisory;
+use App\SecurityAdvisory\RemoteSecurityAdvisory;
+use App\SecurityAdvisory\RemoteSecurityAdvisoryCollection;
+use App\SecurityAdvisory\SecurityAdvisoryResolver;
+use PHPUnit\Framework\TestCase;
+
+class SecurityAdvisoryResolverTest extends TestCase
+{
+    private SecurityAdvisoryResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new SecurityAdvisoryResolver();
+    }
+
+    public function testResolveAddNewAdvisory(): void
+    {
+        [$new, $removed] = $this->resolver->resolve([], new RemoteSecurityAdvisoryCollection([$this->createRemoteAdvisory('test')]), 'test');
+
+        $this->assertSame([], $removed);
+        $this->assertCount(1, $new);
+    }
+
+    public function testResolveRemoveOldAdvisory(): void
+    {
+        $advisory = new SecurityAdvisory($this->createRemoteAdvisory('test'), 'test');
+        [$new, $removed] = $this->resolver->resolve([$advisory], new RemoteSecurityAdvisoryCollection([]), 'test');
+
+        $this->assertSame([], $new);
+        $this->assertSame([$advisory], $removed);
+    }
+
+    public function testResolveDontRemoveAdvisoryFromOtherSource(): void
+    {
+        $advisory = new SecurityAdvisory($this->createRemoteAdvisory('other'), 'other');
+        [$new, $removed] = $this->resolver->resolve([$advisory], new RemoteSecurityAdvisoryCollection([]), 'test');
+
+        $this->assertSame([], $new);
+        $this->assertSame([], $removed);
+
+        $this->assertTrue($advisory->hasSources());
+    }
+
+    public function testResolveDontRemoveAdvisoryWithMultipleSources(): void
+    {
+        $advisory = new SecurityAdvisory($this->createRemoteAdvisory('test'), 'test');
+        $advisory->addSource('other-id', 'other');
+        [$new, $removed] = $this->resolver->resolve([$advisory], new RemoteSecurityAdvisoryCollection([]), 'test');
+
+        $this->assertSame([], $new);
+        $this->assertSame([], $removed);
+
+        $this->assertTrue($advisory->hasSources());
+    }
+
+    public function testResolveAddSourceToMatchingAdvisory(): void
+    {
+        $remoteAdvisory = $this->createRemoteAdvisory('test');
+        $advisory = new SecurityAdvisory($this->createRemoteAdvisory('other'), 'other');
+        [$new, $removed] = $this->resolver->resolve([$advisory], new RemoteSecurityAdvisoryCollection([$remoteAdvisory]), 'test');
+
+        $this->assertSame([], $new);
+        $this->assertSame([], $removed);
+
+        $this->assertNotNull($advisory->getSourceRemoteId('test'));
+        $this->assertNotNull($advisory->getSourceRemoteId('other'));
+    }
+
+    public function testResolveEmpty(): void
+    {
+        [$new, $removed] = $this->resolver->resolve([], new RemoteSecurityAdvisoryCollection([]), 'test');
+
+        $this->assertSame([], $new);
+        $this->assertSame([], $removed);
+    }
+
+    private function createRemoteAdvisory(string $source): RemoteSecurityAdvisory
+    {
+        return new RemoteSecurityAdvisory('', 'Security Advisory', 'acme/package', '^1.0', 'https://example.org', null, new \DateTimeImmutable(), null, [], $source);
+    }
+}

--- a/tests/SecurityAdvisory/SecurityAdvisoryResolverTest.php
+++ b/tests/SecurityAdvisory/SecurityAdvisoryResolverTest.php
@@ -25,6 +25,24 @@ class SecurityAdvisoryResolverTest extends TestCase
         $this->assertCount(1, $new);
     }
 
+    public function testResolveAddNewRemoveOldAdvisoryDifferentPackage(): void
+    {
+        $advisory = new SecurityAdvisory($this->createRemoteAdvisory('test', 'acme/other-package'), 'test');
+        [$new, $removed] = $this->resolver->resolve([$advisory], new RemoteSecurityAdvisoryCollection([$this->createRemoteAdvisory('test')]), 'test');
+
+        $this->assertSame([$advisory], $removed);
+        $this->assertCount(1, $new);
+    }
+
+    public function testResolveAddNewRemoveOldAdvisorySamePackage(): void
+    {
+        $advisory = new SecurityAdvisory($this->createRemoteAdvisory('test', 'acme/package', 'CVE-2022-1111'), 'test');
+        [$new, $removed] = $this->resolver->resolve([$advisory], new RemoteSecurityAdvisoryCollection([$this->createRemoteAdvisory('test', 'acme/package', 'CVE-2022-2222')]), 'test');
+
+        $this->assertSame([$advisory], $removed);
+        $this->assertCount(1, $new);
+    }
+
     public function testResolveRemoveOldAdvisory(): void
     {
         $advisory = new SecurityAdvisory($this->createRemoteAdvisory('test'), 'test');
@@ -78,8 +96,8 @@ class SecurityAdvisoryResolverTest extends TestCase
         $this->assertSame([], $removed);
     }
 
-    private function createRemoteAdvisory(string $source): RemoteSecurityAdvisory
+    private function createRemoteAdvisory(string $source, string $packageName = 'acme/package', string $cve = null): RemoteSecurityAdvisory
     {
-        return new RemoteSecurityAdvisory('', 'Security Advisory', 'acme/package', '^1.0', 'https://example.org', null, new \DateTimeImmutable(), null, [], $source);
+        return new RemoteSecurityAdvisory(uniqid('id-'), 'Security Advisory', $packageName, '^1.0', 'https://example.org', $cve, new \DateTimeImmutable(), null, [], $source);
     }
 }


### PR DESCRIPTION
This PR builds on top of https://github.com/composer/packagist/pull/1206 to add support for GitHub advisories

Unfortunately, using GitHub webhooks to get notified about new advisories might not be an option (requires GitHub App with additional permissions), so running the job after every package update might add new advisories only a while after they were created. It would also create a huge amount of unnecessary additional jobs.

Fetching all GitHub advisories in a single run limits the number of background job we generate. It also allows us to trigger them on a regular basis via a cron (every 5/10min) with the added command

Especially, the affected version range for data from the GitHub advisory database is a lot less accurate, therefore this is always using the FOPHP data if available.