### PR TITLE
feat(peace): remove #StandWithUkraine

### DIFF
--- a/src/Package/SymlinkDumper.php
+++ b/src/Package/SymlinkDumper.php
@@ -318,7 +318,6 @@ class SymlinkDumper
             $this->rootFile['providers-api'] = str_replace('VND/PKG', '%package%', $this->router->generate('view_providers', ['name' => 'VND/PKG', '_format' => 'json'], UrlGeneratorInterface::ABSOLUTE_URL));
             $this->rootFile['warning'] = 'Support for Composer 1 is deprecated and some packages will not be available. You should upgrade to Composer 2. See https://blog.packagist.com/deprecating-composer-1-support/';
             $this->rootFile['warning-versions'] = '<1.99';
-            $this->rootFile['info'] = json_decode('"\u001b[37;44m#StandWith\u001b[30;43mUkraine\u001b[0m"');
 
             if ($verbose) {
                 echo 'Dumping individual listings'.PHP_EOL;


### PR DESCRIPTION
We don't want this to be on the CLI screen. Everyone wants peace, but the writing #StandWithUkraine supports one side. This word hurts the feelings of the Russian people who don't want war. We can achieve peace if we side with both sides, regardless, and that's why there is such a thing as negotiation in the political world. This article is very annoying and makes me not want to use composer. You should apologize or delete it for writing this.

I would suggest you should write this on the Repository instead of CLI.

Let's keep the CLI neutral. 

#NoStandJustUnderstandEachOther
#NeutralComposerCLI

rel: https://github.com/composer/packagist/pull/1267#issuecomment-1063636569