### PR TITLE
SecurityAdvisory: handle GitHub advisories affecting multiple packages

### DIFF
--- a/src/Entity/SecurityAdvisory.php
+++ b/src/Entity/SecurityAdvisory.php
@@ -17,7 +17,7 @@ use App\SecurityAdvisory\RemoteSecurityAdvisory;
  * @ORM\Table(
  *     name="security_advisory",
  *     uniqueConstraints={
- *          @ORM\UniqueConstraint(name="source_remoteid_idx", columns={"source","remoteId"}),
+ *          @ORM\UniqueConstraint(name="source_remoteid_package_idx", columns={"source","remoteId", "packageName"}),
  *          @ORM\UniqueConstraint(name="package_name_cve_idx", columns={"packageName","cve"})
  *     },
  *     indexes={


### PR DESCRIPTION
Example: https://github.com/advisories/GHSA-xx8f-qf9f-5fgw

This currently merges the two advisories into a single one using the package name of the first and the version range of both.