### PR TITLE
Add #StandWithPalestine banner to show support for Palestinian

### DIFF
--- a/src/Package/SymlinkDumper.php
+++ b/src/Package/SymlinkDumper.php
@@ -318,7 +318,7 @@ class SymlinkDumper
             $this->rootFile['providers-api'] = str_replace('VND/PKG', '%package%', $this->router->generate('view_providers', ['name' => 'VND/PKG', '_format' => 'json'], UrlGeneratorInterface::ABSOLUTE_URL));
             $this->rootFile['warning'] = 'Support for Composer 1 is deprecated and some packages will not be available. You should upgrade to Composer 2. See https://blog.packagist.com/deprecating-composer-1-support/';
             $this->rootFile['warning-versions'] = '<1.99';
-            $this->rootFile['info'] = json_decode('"\u001b[37;44m#StandWith\u001b[30;43mUkraine\u001b[0m"');
+            $this->rootFile['info'] = json_decode('"\u001b[37;44m#StandWith\u001b[30;43mUkraine\u001b[0m \u001b[97;40m#Stand\u001b[30;107mWith\u001b[37;42mPalestine\u001b[0m"');
 
             if ($verbose) {
                 echo 'Dumping individual listings'.PHP_EOL;


### PR DESCRIPTION
Actually I HATE to do this. But seeing that the main contributor of Packagist won't change their mind and remove the #StandWIthUkraine banner, I propose to add a #StandWIthPalestine banner alongside the #StandWIthUkraine banner. I feel like this is like throwing gasoline to a raging fire, but IF the creator of Packagist REALLY CARE about PEACE and HUMANITY, then they would be better to add a #StandWithPeace banner instead of creating a controversial banner.

IMO, mixing politics and software development is not a good thing. Especially if it is related to a sensitive issue. I just hope that composer and packagist be free of any politic related issue, and more about bringing better software to our world.

I am sorry if this is too heated.