### PR TITLE
API: return a list of sources for every security advisory instead of only one of them

### DIFF
--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -328,7 +328,21 @@ class ApiController extends Controller
         $advisories = $this->getEM()->getRepository(SecurityAdvisory::class)->searchSecurityAdvisories($packageNames, $updatedSince);
         $response = ['advisories' => []];
         foreach ($advisories as $advisory) {
-            $response['advisories'][$advisory['packageName']][] = $advisory;
+            $source = [
+                'name' => $advisory['sourceSource'],
+                'remoteId' => $advisory['sourceRemoteId'],
+            ];
+            unset($advisory['sourceSource'], $advisory['sourceRemoteId']);
+            if (!isset($response['advisories'][$advisory['packageName']][$advisory['advisoryId']])) {
+                $advisory['sources'] = [];
+                $response['advisories'][$advisory['packageName']][$advisory['advisoryId']] = $advisory;
+            }
+
+            $response['advisories'][$advisory['packageName']][$advisory['advisoryId']]['sources'][] = $source;
+        }
+
+        foreach ($response['advisories'] as $packageName => $packageAdvisories) {
+            $response['advisories'][$packageName] = array_values($packageAdvisories);
         }
 
         return new JsonResponse($response, 200);

--- a/src/Entity/SecurityAdvisoryRepository.php
+++ b/src/Entity/SecurityAdvisoryRepository.php
@@ -96,8 +96,9 @@ class SecurityAdvisoryRepository extends ServiceEntityRepository
     {
         $filterByNames = count($packageNames) > 0;
 
-        $sql = 'SELECT s.packagistAdvisoryId as advisoryId, s.packageName, s.remoteId, s.title, s.link, s.cve, s.affectedVersions, s.source, s.reportedAt, s.composerRepository
+        $sql = 'SELECT s.packagistAdvisoryId as advisoryId, s.packageName, s.remoteId, s.title, s.link, s.cve, s.affectedVersions, s.source, s.reportedAt, s.composerRepository, sa.source sourceSource, sa.remoteId sourceRemoteId
             FROM security_advisory s
+            INNER JOIN security_advisory_source sa ON sa.securityAdvisory_id=s.id
             WHERE s.updatedAt >= :updatedSince '.
             ($filterByNames ? ' AND s.packageName IN (:packageNames)' : '')
             .' ORDER BY s.id DESC';

--- a/templates/api_doc/index.html.twig
+++ b/templates/api_doc/index.html.twig
@@ -395,12 +395,18 @@ GET https://{{ packagist_host }}/api/security-advisories/?updatedSince=[timestam
       {
         "advisoryId": "[unique id]",
         "packageName": "[vendor]/[package]",
-        "remoteId": "[unique id per source]",
+        "remoteId": "[deprecated, use sources instead]",
         "title": "[title]",
         "link": "[url to issue disclosure]",
         "cve": "[cve if available]",
         "affectedVersions": [affected version in form of a composer constraint]",
-        "source": "[source where the issue was found]",
+        "source": "[deprecated, use sources instead]",
+        "sources": [
+            {
+                "name": "[Name of the source where the advisory was found e.g. GitHub or FriendsOfPHP/security-advisories]"
+                "remoteId": "[A reference to identify the advisory in the source e.g. the GitHub advisory id]"
+            }
+        ],
         "reportedAt": "[date the issue was reported]",
         "composerRepository": "[composer repository the package can be found in]"
       }


### PR DESCRIPTION
So far, only the name of one source was exposed via the API.