### PR TITLE
Add a note about the allowed characters for a package

### DIFF
--- a/templates/about/about.html.twig
+++ b/templates/about/about.html.twig
@@ -38,7 +38,7 @@ monolog/monolog-drupal-module
 // Acme is a company or person here, they can name their package with a common name (Email).
 // As long as it's in their own vendor namespace it does not conflict with anyone else.
 acme/email</code></pre>
-            <p>Vendor names on packagist are protected once a package with that name has been published. That means you can not publish packages with a vendor name that already exists on packagist without permission. To be able to publish packages for an already existing vendor name you need to be maintainer of at least one package within that vendor. Package and vendor names are allowed to contain lowercase english letters, arabic numbers, and the characters "." and "_". Each may only start with a letter or number.</p>
+            <p>Vendor names on packagist are protected once a package with that name has been published. That means you can not publish packages with a vendor name that already exists on packagist without permission. To be able to publish packages for an already existing vendor name you need to be maintainer of at least one package within that vendor. Package and vendor names are allowed to contain lowercase english letters, arabic numbers, and the characters ".", "-" and "_". Each may only start with a letter or number.</p>
         </section>
 
         <section class="col-md-6">

--- a/templates/about/about.html.twig
+++ b/templates/about/about.html.twig
@@ -38,7 +38,7 @@ monolog/monolog-drupal-module
 // Acme is a company or person here, they can name their package with a common name (Email).
 // As long as it's in their own vendor namespace it does not conflict with anyone else.
 acme/email</code></pre>
-            <p>Vendor names on packagist are protected once a package with that name has been published. That means you can not publish packages with a vendor name that already exists on packagist without permission. To be able to publish packages for an already existing vendor name you need to be maintainer of at least one package within that vendor. Package and vendor names are allowed to contain lowercase english letters, arabic numbers, and the characters ".", "-" and "_". Each may only start with a letter or number.</p>
+            <p>Vendor names on packagist are protected once a package with that name has been published. That means you can not publish packages with a vendor name that already exists on packagist without permission. To be able to publish packages for an already existing vendor name you need to be maintainer of at least one package within that vendor. Package and vendor names are allowed to contain lowercase letters (a-z), numbers (0-9), and the characters ".", "-" and "_". Each must start with a letter or number.</p>
         </section>
 
         <section class="col-md-6">

--- a/templates/about/about.html.twig
+++ b/templates/about/about.html.twig
@@ -38,7 +38,7 @@ monolog/monolog-drupal-module
 // Acme is a company or person here, they can name their package with a common name (Email).
 // As long as it's in their own vendor namespace it does not conflict with anyone else.
 acme/email</code></pre>
-            <p>Vendor names on packagist are protected once a package with that name has been published. That means you can not publish packages with a vendor name that already exists on packagist without permission. To be able to publish packages for an already existing vendor name you need to be maintainer of at least one package within that vendor.</p>
+            <p>Vendor names on packagist are protected once a package with that name has been published. That means you can not publish packages with a vendor name that already exists on packagist without permission. To be able to publish packages for an already existing vendor name you need to be maintainer of at least one package within that vendor. Package and vendor names are allowed to contain lowercase english letters, arabic numbers, and the characters "." and "_". Each may only start with a letter or number.</p>
         </section>
 
         <section class="col-md-6">


### PR DESCRIPTION
Hey all, 

I didn't see the set of allowed characters for a package mentioned anywhere on the site and after being forwarded to this regex
https://github.com/composer/packagist/blob/699c69d32f770b37b46469805e8ba9eb2ba6de6f/src/Entity/Package.php#L312

I felt that this could be helpful to document for others that end up looking. Happy to change the wording on this if need be.