### PR TITLE
Make `/` keypress focus search input

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -7,6 +7,26 @@ document.getElementById('search_query_query').addEventListener('keydown', functi
     }
 });
 
+// Add accessibility functionality:
+// "Press '/' to focus the searchbar".
+document.addEventListener('keydown', function (e) {
+    if (e.code && e.code !== 'Slash') {
+        return;
+    }
+    var searchInput = document.getElementById('search_query_query');
+    // Just ignore if we can't find the search input for some reason maybe we are on a page without it.
+    if (!searchInput) {
+        return;
+    }
+    // If we already have input focus ignore.
+    if (document.activeElement.tagName === 'INPUT') {
+        return;
+    }
+    searchInput.focus();
+    // Prevent '/' being inserted on focus.
+    e.preventDefault();
+});
+
 var searchParameters = {};
 
 if (decodeURI(location.search).match(/[<>]/)) {


### PR DESCRIPTION
#1313.

I feel like this may break stuff. I've done 10 minutes or so of testing, But I don't know packagist very well despite how much I use the public site and having this globally means accounting for a lot of things like this stealing focus from other inputs.

As an example: without the check for inputs as active elements this would break signing in (with a password that had a `/`).

Is there any chance that there could be abnormal keyboard inputs somewhere that don't use the input tag as they should?