### PR TITLE
Add Rector and use PHP 8 attributes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,6 +89,7 @@
         "phpstan/phpstan-doctrine": "^1",
         "phpstan/phpstan-symfony": "^1.1",
         "phpunit/phpunit": "^9.5",
+        "rector/rector": "^0.13.9",
         "staabm/phpstan-dba": "^0.2",
         "symfony/browser-kit": "^5.2",
         "symfony/css-selector": "^5.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "58bb63ebb840140a625b98be04f78350",
+    "content-hash": "16ab8efb8054d9d4f1640cda80090531",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -11858,16 +11858,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.7.2",
+            "version": "1.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "c602f80d66ba425943b0f4aaa27010c822dd8f87"
+                "reference": "c53312ecc575caf07b0e90dee43883fdf90ca67c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c602f80d66ba425943b0f4aaa27010c822dd8f87",
-                "reference": "c602f80d66ba425943b0f4aaa27010c822dd8f87",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c53312ecc575caf07b0e90dee43883fdf90ca67c",
+                "reference": "c53312ecc575caf07b0e90dee43883fdf90ca67c",
                 "shasum": ""
             },
             "require": {
@@ -11893,7 +11893,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.7.2"
+                "source": "https://github.com/phpstan/phpstan/tree/1.8.2"
             },
             "funding": [
                 {
@@ -11913,7 +11913,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-26T12:59:20+00:00"
+            "time": "2022-07-20T09:57:31+00:00"
         },
         {
             "name": "phpstan/phpstan-doctrine",
@@ -12474,6 +12474,66 @@
                 }
             ],
             "time": "2022-03-15T09:57:31+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "0.13.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "d6319ec783876579b608840cdfe1d8b566c72f74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/d6319ec783876579b608840cdfe1d8b566c72f74",
+                "reference": "d6319ec783876579b608840cdfe1d8b566c72f74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0",
+                "phpstan/phpstan": "^1.8.2"
+            },
+            "conflict": {
+                "phpstan/phpdoc-parser": "<1.6.2",
+                "rector/rector-cakephp": "*",
+                "rector/rector-doctrine": "*",
+                "rector/rector-laravel": "*",
+                "rector/rector-nette": "*",
+                "rector/rector-phpoffice": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-prefixed": "*",
+                "rector/rector-symfony": "*"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.13-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/0.13.9"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-07-23T10:55:44+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
     "name": "packagist.org",
+    "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "packagist.org",
             "dependencies": {
-                "bootstrap": "^3.3.5",
+                "bootstrap": "3.3.5",
                 "d3": "^3.5.17",
                 "instantsearch.js": "^2.7.4",
                 "jquery": "^3.6.0",
@@ -62,6 +63,7 @@
             "version": "2.26.0",
             "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-2.26.0.tgz",
             "integrity": "sha512-Yt9ARVC2eY48G2UdxCG+qGTGufh0+mQD2jh9qXTraQKunTSQGj+4Ah5OotuaUVdUBEBRRE3cvUoK+pZpwidQ0Q==",
+            "deprecated": "3.7.3",
             "dependencies": {
                 "events": "^1.1.1",
                 "lodash": "^4.17.5",
@@ -197,7 +199,7 @@
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
             "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-            "deprecated": "core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js."
+            "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js."
         },
         "node_modules/css-tree": {
             "version": "1.1.3",
@@ -2229,7 +2231,8 @@
         "nvd3": {
             "version": "1.8.6",
             "resolved": "https://registry.npmjs.org/nvd3/-/nvd3-1.8.6.tgz",
-            "integrity": "sha1-LT66dL8zNjtRAevx0JPFmlOuc8Q="
+            "integrity": "sha1-LT66dL8zNjtRAevx0JPFmlOuc8Q=",
+            "requires": {}
         },
         "object-assign": {
             "version": "4.1.1",
@@ -2317,7 +2320,8 @@
         "preact-transition-group": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/preact-transition-group/-/preact-transition-group-1.1.1.tgz",
-            "integrity": "sha1-8KSTJ+pRXs406ivoZMSn0p5dbhA="
+            "integrity": "sha1-8KSTJ+pRXs406ivoZMSn0p5dbhA=",
+            "requires": {}
         },
         "pretty-format": {
             "version": "3.8.0",

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Validator\Copyright;
+use App\Validator\Password;
+use App\Validator\TypoSquatters;
+use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
+use Rector\Config\RectorConfig;
+use Rector\Doctrine\Set\DoctrineSetList;
+use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
+use Rector\Php80\ValueObject\AnnotationToAttribute;
+use Rector\PHPUnit\Set\PHPUnitLevelSetList;
+use Rector\Symfony\Set\SymfonySetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ]);
+
+    // register a single rule
+    $rectorConfig->rule(InlineConstructorDefaultToPropertyRector::class);
+
+    $rectorConfig->ruleWithConfiguration(AnnotationToAttributeRector::class, [
+        new AnnotationToAttribute(Password::class),
+        new AnnotationToAttribute(TypoSquatters::class),
+        new AnnotationToAttribute(Copyright::class),
+    ]);
+
+    // define sets of rules
+    $rectorConfig->sets([
+        SymfonySetList::SYMFONY_54,
+        DoctrineSetList::DOCTRINE_ORM_29,
+        PHPUnitLevelSetList::UP_TO_PHPUNIT_90,
+    ]);
+};

--- a/src/Validator/Copyright.php
+++ b/src/Validator/Copyright.php
@@ -2,9 +2,11 @@
 
 namespace App\Validator;
 
+use Attribute;
 use Symfony\Component\Validator\Constraint;
 
 /** @Annotation() */
+#[Attribute(Attribute::TARGET_CLASS)]
 class Copyright extends Constraint
 {
     /** @readonly */

--- a/src/Validator/Password.php
+++ b/src/Validator/Password.php
@@ -2,12 +2,14 @@
 
 namespace App\Validator;
 
+use Attribute;
 use Symfony\Component\Validator\Constraints\Compound;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @Annotation
  */
+#[Attribute(Attribute::TARGET_PROPERTY)]
 class Password extends Compound
 {
     /**

--- a/src/Validator/TypoSquatters.php
+++ b/src/Validator/TypoSquatters.php
@@ -2,9 +2,11 @@
 
 namespace App\Validator;
 
+use Attribute;
 use Symfony\Component\Validator\Constraint;
 
 /** @Annotation() */
+#[Attribute(Attribute::TARGET_CLASS)]
 class TypoSquatters extends Constraint
 {
     /** @readonly */


### PR DESCRIPTION
This PR adds [Rector](https://getrector.org/) which helps with PHP and libraries/frameworks upgrades.
Because the diff would be too large for manual review, I left executing the upgrade to the maintainer.

Changes include:
- Adding `rector/rector` dependency and upgrading `phpstan/phpstan`
- Adding Symfony 5.4 upgrade list - uses `#[Route]` and `#[Assert\*]` attributes instead of annotations
- Adding Doctrine ORM 2.9 list - uses PHP 8 attributes instead of annotations for entity mapping (a change is needed in `config/packages/doctrine.yaml`)
- Adding PHPUnit 9.x list - uses `$this->createMock()` where applicable
- Converting `App\Validator\*` constraints to PHP 8 attributes

Unfortunately, adding PHP 8 upgrade rules list causes Rector to crash on my machine so I didn't add it this time.