### PR TITLE
Add vendor field to package table to avoid LIKE queries for vendor listings

### DIFF
--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -296,7 +296,7 @@ class PackageController extends Controller
     {
         $packages = $this->getEM()
             ->getRepository(Package::class)
-            ->getFilteredQueryBuilder(['vendor' => $vendor.'/%'], true)
+            ->getFilteredQueryBuilder(['vendor' => $vendor], true)
             ->getQuery()
             ->getResult();
 

--- a/src/Entity/Package.php
+++ b/src/Entity/Package.php
@@ -45,7 +45,8 @@ use DateTimeInterface;
  *         @ORM\Index(name="dumped2_idx",columns={"dumpedAtV2"}),
  *         @ORM\Index(name="repository_idx",columns={"repository"}),
  *         @ORM\Index(name="remoteid_idx",columns={"remoteId"}),
- *         @ORM\Index(name="dumped2_crawled_idx",columns={"dumpedAtV2","crawledAt"})
+ *         @ORM\Index(name="dumped2_crawled_idx",columns={"dumpedAtV2","crawledAt"}),
+ *         @ORM\Index(name="vendor_idx",columns={"vendor"})
  *     }
  * )
  * @Assert\Callback(callback="isPackageUnique", groups={"Create"})
@@ -74,6 +75,11 @@ class Package
      * @ORM\Column(length=191)
      */
     private string $name = '';
+
+    /**
+     * @ORM\Column(length=191)
+     */
+    private string $vendor = '';
 
     /**
      * @ORM\Column(nullable=true)
@@ -450,6 +456,7 @@ class Package
     public function setName(string $name): void
     {
         $this->name = $name;
+        $this->vendor = Preg::replace('{/.*$}', '', $this->name);
     }
 
     public function getName(): string
@@ -466,7 +473,7 @@ class Package
      */
     public function getVendor(): string
     {
-        return Preg::replace('{/.*$}', '', $this->name);
+        return $this->vendor;
     }
 
     /**

--- a/src/Entity/PackageRepository.php
+++ b/src/Entity/PackageRepository.php
@@ -113,8 +113,8 @@ class PackageRepository extends ServiceEntityRepository
     public function getPackageNamesByVendor($vendor): array
     {
         $query = $this->getEntityManager()
-            ->createQuery("SELECT p.name FROM App\Entity\Package p WHERE p.name LIKE :vendor AND (p.replacementPackage IS NULL OR p.replacementPackage != 'spam/spam')")
-            ->setParameters(['vendor' => $vendor.'/%']);
+            ->createQuery("SELECT p.name FROM App\Entity\Package p WHERE p.vendor = :vendor AND (p.replacementPackage IS NULL OR p.replacementPackage != 'spam/spam')")
+            ->setParameters(['vendor' => $vendor]);
 
         return $this->getPackageNamesForQuery($query);
     }
@@ -167,12 +167,7 @@ class PackageRepository extends ServiceEntityRepository
 
         $where = '(p.replacementPackage IS NULL OR p.replacementPackage != :replacement)';
         foreach ($filters as $filter => $val) {
-            if ($filter === 'vendor') {
-                $where .= ' AND p.name LIKE :'.$filter;
-                $filters[$filter] = $val.'/%';
-            } else {
-                $where .= ' AND p.'.$filter.' = :'.$filter;
-            }
+            $where .= ' AND p.'.$filter.' = :'.$filter;
         }
         $filters['replacement'] = "spam/spam";
         $query = $this->getEntityManager()
@@ -430,8 +425,8 @@ class PackageRepository extends ServiceEntityRepository
                 "SELECT p.name, m.id user_id
                 FROM App\Entity\Package p
                 JOIN p.maintainers m
-                WHERE p.name LIKE :vendor")
-            ->setParameters(['vendor' => $vendor.'/%']);
+                WHERE p.vendor = :vendor")
+            ->setParameters(['vendor' => $vendor]);
 
         $rows = $query->getArrayResult();
         if (!$rows) {
@@ -608,7 +603,7 @@ class PackageRepository extends ServiceEntityRepository
                     break;
 
                 case 'vendor':
-                    $qb->andWhere('p.name LIKE :vendor');
+                    $qb->andWhere('p.vendor = :vendor');
                     break;
 
                 default:

--- a/src/Entity/VendorRepository.php
+++ b/src/Entity/VendorRepository.php
@@ -38,8 +38,8 @@ class VendorRepository extends ServiceEntityRepository
             ['vendor' => $vendor]
         );
         $this->getEntityManager()->getConnection()->executeStatement(
-            'UPDATE package SET suspect = NULL WHERE name LIKE :vendor',
-            ['vendor' => $vendor.'/%']
+            'UPDATE package SET suspect = NULL WHERE vendor = :vendor',
+            ['vendor' => $vendor]
         );
     }
 }

--- a/src/Entity/VersionRepository.php
+++ b/src/Entity/VersionRepository.php
@@ -213,8 +213,8 @@ class VersionRepository extends ServiceEntityRepository
         }
 
         if ($vendor) {
-            $qb->andWhere('p.name LIKE ?1');
-            $qb->setParameter(1, $vendor.'/%');
+            $qb->andWhere('p.vendor = ?1');
+            $qb->setParameter(1, $vendor);
         } elseif ($package) {
             $qb->andWhere('p.name = ?1')
                 ->setParameter(1, $package);


### PR DESCRIPTION
DB migration in case anyone cares:

```
ALTER TABLE package ADD vendor VARCHAR(191) NULL;
UPDATE package SET vendor = SUBSTRING_INDEX(`name`, '/', 1) where vendor IS NULL;
ALTER TABLE package CHANGE vendor vendor VARCHAR(191) NOT NULL;
CREATE INDEX vendor_idx ON package (vendor);
```