### PR TITLE
Convert remaining annotations to attributes

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -66,21 +66,6 @@ services:
 
     Graze\DogStatsD\Client: ~
 
-    App\EventListener\CacheListener:
-        tags:
-            - { name: kernel.event_listener, event: kernel.response, method: onResponse }
-
-    App\EventListener\RequestStatsListener:
-        tags:
-            - { name: kernel.event_listener, event: kernel.request, method: onRequest }
-            - { name: kernel.event_listener, event: kernel.response, method: onResponse }
-
-    App\EventListener\SecurityAdvisoryUpdateListener:
-        tags:
-            - { name: 'doctrine.orm.entity_listener', event: postUpdate, entity: App\Entity\SecurityAdvisory }
-            - { name: 'doctrine.orm.entity_listener', event: postPersist, entity: App\Entity\SecurityAdvisory }
-            - { name: 'doctrine.orm.entity_listener', event: postRemove, entity: App\Entity\SecurityAdvisory }
-
     App\ArgumentResolver\:
         resource: '../src/ArgumentResolver/*.php'
         tags:

--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -209,10 +209,9 @@ class ApiController extends Controller
      *     ]
      * }
      *
-     * The version must be the normalized one
-     *
-     * @Route("/downloads/", name="track_download_batch", defaults={"_format" = "json"}, methods={"POST"})
+     * The version must be the normalized one.
      */
+    #[Route(path: '/downloads/', name: 'track_download_batch', defaults: ['_format' => 'json'], methods: ['POST'])]
     public function trackDownloadsAction(Request $request, StatsDClient $statsd, string $trustedIpHeader, DownloadManager $downloadManager, VersionIdCache $versionIdCache): JsonResponse
     {
         $contents = json_decode($request->getContent(), true);

--- a/src/Controller/ChangePasswordController.php
+++ b/src/Controller/ChangePasswordController.php
@@ -23,9 +23,7 @@ use Symfony\Component\Security\Http\Attribute\CurrentUser;
 
 class ChangePasswordController extends Controller
 {
-    /**
-     * @IsGranted("ROLE_USER")
-     */
+    #[IsGranted('ROLE_USER')]
     #[Route(path: '/profile/change-password', name: 'change_password')]
     public function changePasswordAction(Request $request, UserPasswordHasherInterface $passwordHasher, #[CurrentUser] User $user): Response
     {

--- a/src/Controller/GitHubLoginController.php
+++ b/src/Controller/GitHubLoginController.php
@@ -126,16 +126,13 @@ class GitHubLoginController extends Controller
      * After going to GitHub, you're redirected back here
      * because this is the "redirect_route" you configured
      * in config/packages/knpu_oauth2_client.yaml
-     *
-     * @Route("/login/github/check", name="login_github_check", defaults={"_format"="html"})
      */
+    #[Route(path: '/login/github/check', name: 'login_github_check', defaults: ['_format' => 'html'])]
     public function loginCheck(Request $request, ClientRegistry $clientRegistry): void
     {
     }
 
-    /**
-     * @Route("/oauth/github/disconnect", name="user_github_disconnect")
-     */
+    #[Route(path: '/oauth/github/disconnect', name: 'user_github_disconnect')]
     public function disconnect(Request $req, CsrfTokenManagerInterface $csrfTokenManager, #[CurrentUser] User $user): RedirectResponse
     {
         if (!$this->isCsrfTokenValid('unlink_github', $req->query->get('token', ''))) {

--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -429,9 +429,7 @@ class PackageController extends Controller
         return $this->render('package/spam.html.twig', $data);
     }
 
-    /**
-     * @IsGranted("ROLE_ANTISPAM")
-     */
+    #[IsGranted('ROLE_ANTISPAM')]
     #[Route(path: '/spam/nospam', name: 'mark_nospam', defaults: ['_format' => 'html'], methods: ['POST'])]
     public function markSafeAction(Request $req): RedirectResponse
     {

--- a/src/Controller/ResetPasswordController.php
+++ b/src/Controller/ResetPasswordController.php
@@ -73,9 +73,8 @@ class ResetPasswordController extends Controller
 
     /**
      * Confirmation page after a user has requested a password reset.
-     *
-     * @Route("/reset-password/check-email", name="request_pwd_check_email")
      */
+    #[Route('/reset-password/check-email', name: 'request_pwd_check_email')]
     public function checkEmail(): Response
     {
         return $this->render('reset_password/check_email.html.twig');
@@ -83,9 +82,8 @@ class ResetPasswordController extends Controller
 
     /**
      * Validates and process the reset URL that the user clicked in their email.
-     *
-     * @Route("/reset-password/reset/{token}", name="do_pwd_reset")
      */
+    #[Route(path: '/reset-password/reset/{token}', name: 'do_pwd_reset')]
     public function reset(Request $request, UserPasswordHasherInterface $passwordHasher, UserChecker $userChecker, UserAuthenticatorInterface $userAuthenticator, BruteForceLoginFormAuthenticator $authenticator, ?string $token = null): Response
     {
         if (null === $token) {

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -59,9 +59,7 @@ class UserController extends Controller
         $this->scheduler = $scheduler;
     }
 
-    /**
-     * @IsGranted("ROLE_USER")
-     */
+    #[IsGranted('ROLE_USER')]
     #[Route(path: '/trigger-github-sync/', name: 'user_github_sync')]
     public function triggerGitHubSyncAction(#[CurrentUser] User $user): RedirectResponse
     {
@@ -159,9 +157,7 @@ class UserController extends Controller
         return $this->render('user/favorites.html.twig', ['packages' => $paginator, 'user' => $user]);
     }
 
-    /**
-     * @IsGranted("ROLE_USER")
-     */
+    #[IsGranted('ROLE_USER')]
     #[Route(path: '/users/{name}/favorites/', name: 'user_add_fav', defaults: ['_format' => 'json'], methods: ['POST'])]
     public function postFavoriteAction(Request $req, #[VarName('name')] User $user, #[CurrentUser] User $loggedUser, FavoriteManager $favoriteManager): Response
     {
@@ -183,9 +179,7 @@ class UserController extends Controller
         return new Response('{"status": "success"}', 201);
     }
 
-    /**
-     * @IsGranted("ROLE_USER")
-     */
+    #[IsGranted('ROLE_USER')]
     #[Route(path: '/users/{name}/favorites/{package}', name: 'user_remove_fav', defaults: ['_format' => 'json'], requirements: ['package' => '[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?'], methods: ['DELETE'])]
     public function deleteFavoriteAction(#[VarName('name')] User $user, #[CurrentUser] User $loggedUser, Package $package, FavoriteManager $favoriteManager): Response
     {
@@ -198,9 +192,7 @@ class UserController extends Controller
         return new Response('{"status": "success"}', 204);
     }
 
-    /**
-     * @IsGranted("ROLE_USER")
-     */
+    #[IsGranted('ROLE_USER')]
     #[Route(path: '/users/{name}/delete', name: 'user_delete', methods: ['POST'])]
     public function deleteUserAction(#[VarName('name')] User $user, #[CurrentUser] User $loggedUser, Request $req, TokenStorageInterface $storage, EventDispatcherInterface $mainEventDispatcher): RedirectResponse
     {
@@ -239,9 +231,7 @@ class UserController extends Controller
         return $this->redirectToRoute('user_profile', ['name' => $user->getUsername()]);
     }
 
-    /**
-     * @IsGranted("ROLE_USER")
-     */
+    #[IsGranted('ROLE_USER')]
     #[Route(path: '/users/{name}/2fa/', name: 'user_2fa_configure', methods: ['GET'])]
     public function configureTwoFactorAuthAction(#[VarName('name')] User $user, #[CurrentUser] User $loggedUser, Request $req): Response
     {
@@ -259,9 +249,7 @@ class UserController extends Controller
         );
     }
 
-    /**
-     * @IsGranted("ROLE_USER")
-     */
+    #[IsGranted('ROLE_USER')]
     #[Route(path: '/users/{name}/2fa/enable', name: 'user_2fa_enable', methods: ['GET', 'POST'])]
     public function enableTwoFactorAuthAction(Request $req, #[VarName('name')] User $user, #[CurrentUser] User $loggedUser, TotpAuthenticatorInterface $authenticator, TwoFactorAuthManager $authManager): Response
     {
@@ -325,9 +313,7 @@ class UserController extends Controller
         );
     }
 
-    /**
-     * @IsGranted("ROLE_USER")
-     */
+    #[IsGranted('ROLE_USER')]
     #[Route(path: '/users/{name}/2fa/confirm', name: 'user_2fa_confirm', methods: ['GET'])]
     public function confirmTwoFactorAuthAction(#[VarName('name')] User $user, #[CurrentUser] User $loggedUser, Request $req): Response
     {
@@ -347,9 +333,7 @@ class UserController extends Controller
         );
     }
 
-    /**
-     * @IsGranted("ROLE_USER")
-     */
+    #[IsGranted('ROLE_USER')]
     #[Route(path: '/users/{name}/2fa/disable', name: 'user_2fa_disable', methods: ['GET'])]
     public function disableTwoFactorAuthAction(Request $req, #[VarName('name')] User $user, #[CurrentUser] User $loggedUser, CsrfTokenManagerInterface $csrfTokenManager, TwoFactorAuthManager $authManager): Response
     {

--- a/src/EventListener/CacheListener.php
+++ b/src/EventListener/CacheListener.php
@@ -12,11 +12,13 @@
 
 namespace App\EventListener;
 
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 
+#[AsEventListener]
 class CacheListener
 {
-    public function onResponse(ResponseEvent $e): void
+    public function __invoke(ResponseEvent $e): void
     {
         $resp = $e->getResponse();
 

--- a/src/EventListener/RequestStatsListener.php
+++ b/src/EventListener/RequestStatsListener.php
@@ -13,6 +13,7 @@
 namespace App\EventListener;
 
 use Graze\DogStatsD\Client;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 
@@ -24,6 +25,7 @@ class RequestStatsListener
         private Client $statsd,
     ) {}
 
+    #[AsEventListener]
     public function onRequest(RequestEvent $e): void
     {
         if (!$e->isMainRequest()) {
@@ -32,6 +34,7 @@ class RequestStatsListener
         $this->pageTiming = microtime(true);
     }
 
+    #[AsEventListener]
     public function onResponse(ResponseEvent $e): void
     {
         if (!$e->isMainRequest()) {

--- a/src/EventListener/SecurityAdvisoryUpdateListener.php
+++ b/src/EventListener/SecurityAdvisoryUpdateListener.php
@@ -14,12 +14,16 @@ namespace App\EventListener;
 
 use App\Entity\SecurityAdvisory;
 use App\Util\DoctrineTrait;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManager;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Persistence\ManagerRegistry;
 use Predis\Client;
 
+#[AsEntityListener(event: 'postUpdate', entity: SecurityAdvisory::class)]
+#[AsEntityListener(event: 'postPersist', entity: SecurityAdvisory::class)]
+#[AsEntityListener(event: 'postRemove', entity: SecurityAdvisory::class)]
 class SecurityAdvisoryUpdateListener
 {
     use DoctrineTrait;


### PR DESCRIPTION
This PR converts some remaining `@Route` and `@IsGranted` annotations to attributes and uses `#[AsEventListener]` and `#[AsEntityListener]` attributes to register EventListeners and Entity listeners, reducing the amount of configuration in `services.yaml`.