### PR TITLE
[Chore][CI] Improve CI workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,8 +5,8 @@ on:
   - pull_request
 
 env:
-  COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --prefer-dist"
   APP_ENV: test
+  DATABASE_URL: "mysql://root:root@127.0.0.1:3306/packagist?serverVersion=8.0"
 
 jobs:
   tests:
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -27,24 +27,13 @@ jobs:
           tools: composer
           ini-values: apc.enable_cli=1
 
-      - name: Get composer cache directory
-        id: composercache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.composercache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
-
       - name: "Start MySQL"
-        run: |
-          sudo systemctl start mysql.service
-          echo 'DATABASE_URL="mysql://root:root@127.0.0.1:3306/packagist?serverVersion=8.0"' > .env.test.local
+        run: sudo systemctl start mysql.service
 
       - name: "Install dependencies"
-        run: "composer install ${{ env.COMPOSER_FLAGS }}"
+        uses: "ramsey/composer-install@v2"
+        with:
+            composer-options: "--ansi --no-interaction --no-progress --prefer-dist"
 
       - name: Start Redis
         uses: supercharge/redis-github-action@1.2.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -5,8 +5,8 @@ on:
   - pull_request
 
 env:
-  COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --prefer-dist"
   APP_ENV: dev
+  DATABASE_URL: "mysql://root:root@127.0.0.1:3306/packagist?serverVersion=8.0"
 
 jobs:
   tests:
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -27,24 +27,13 @@ jobs:
           tools: composer
           ini-values: apc.enable_cli=1
 
-      - name: Get composer cache directory
-        id: composercache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.composercache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
-
       - name: "Start MySQL"
-        run: |
-          sudo systemctl start mysql.service
-          echo 'DATABASE_URL="mysql://root:root@127.0.0.1:3306/packagist?serverVersion=8.0"' > .env.dev.local
+        run: sudo systemctl start mysql.service
 
       - name: "Install dependencies"
-        run: "composer install ${{ env.COMPOSER_FLAGS }}"
+        uses: "ramsey/composer-install@v2"
+        with:
+          composer-options: "--ansi --no-interaction --no-progress --prefer-dist"
 
       - name: "Setup DB"
         run: |


### PR DESCRIPTION
- Makes use of awesome https://github.com/ramsey/composer-install action, which takes care of the caching, thus removing usage of deprecated `::set-output`.
- Bumping `actions/checkout` to `v3` (v2 uses deprecated Node v12)
- Setting `DATABASE_URL` via physical `env` for clarity