### PR TITLE
phpstan-dba: enable analysis of writable queries

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -13596,16 +13596,16 @@
         },
         {
             "name": "staabm/phpstan-dba",
-            "version": "0.2.42",
+            "version": "0.2.55",
             "source": {
                 "type": "git",
                 "url": "https://github.com/staabm/phpstan-dba.git",
-                "reference": "950726e0986d0f67f0aa4f6abcd67ccdf9e71348"
+                "reference": "af71a9ea81a9fa95b04b7abf304d73da8a86183c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/staabm/phpstan-dba/zipball/950726e0986d0f67f0aa4f6abcd67ccdf9e71348",
-                "reference": "950726e0986d0f67f0aa4f6abcd67ccdf9e71348",
+                "url": "https://api.github.com/repos/staabm/phpstan-dba/zipball/af71a9ea81a9fa95b04b7abf304d73da8a86183c",
+                "reference": "af71a9ea81a9fa95b04b7abf304d73da8a86183c",
                 "shasum": ""
             },
             "require": {
@@ -13615,15 +13615,18 @@
                 "phpstan/phpstan": "^1.5.6"
             },
             "require-dev": {
+                "dibi/dibi": "^4.2",
                 "doctrine/dbal": "^3.2",
                 "ext-mysqli": "*",
                 "ext-pdo": "*",
                 "friendsofphp/php-cs-fixer": "3.4.0",
                 "php-parallel-lint/php-parallel-lint": "^1.3",
+                "phpstan/extension-installer": "^1.2",
                 "phpstan/phpstan-php-parser": "^1.1",
                 "phpstan/phpstan-phpunit": "^1.0",
                 "phpstan/phpstan-strict-rules": "^1.1",
                 "phpunit/phpunit": "^9",
+                "tomasvotruba/unused-public": "^0.0.34",
                 "vlucas/phpdotenv": "^5.4"
             },
             "type": "phpstan-extension",
@@ -13645,9 +13648,9 @@
             ],
             "support": {
                 "issues": "https://github.com/staabm/phpstan-dba/issues",
-                "source": "https://github.com/staabm/phpstan-dba/tree/0.2.42"
+                "source": "https://github.com/staabm/phpstan-dba/tree/0.2.55"
             },
-            "time": "2022-07-19T10:05:36+00:00"
+            "time": "2023-01-06T19:26:33+00:00"
         },
         {
             "name": "symfony/browser-kit",

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -14,7 +14,6 @@ require_once __DIR__ . '/vendor/autoload.php';
 $cacheFile = __DIR__.'/.phpstan-dba.cache';
 $config = new RuntimeConfiguration();
 $config->stringifyTypes(false);
-$config->analyzeWriteQueries(true);
 // $config->analyzeQueryPlans(true);
 // $config->debugMode(true);
 

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -14,6 +14,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 $cacheFile = __DIR__.'/.phpstan-dba.cache';
 $config = new RuntimeConfiguration();
 $config->stringifyTypes(false);
+$config->analyzeWriteQueries(true);
 // $config->analyzeQueryPlans(true);
 // $config->debugMode(true);
 


### PR DESCRIPTION
this setting can only be enabled when we are sure phpstan-dba will only ran against a db schema/server supporting transactions (e.g. all tables use InnoDB etc).