### PR TITLE
Don't share private cache via CDN.

### DIFF
--- a/src/Controller/WebController.php
+++ b/src/Controller/WebController.php
@@ -211,7 +211,7 @@ class WebController extends Controller
 
         $type = $req->query->getInt('platform', 0) > 0 ? 'phpplatform' : 'php';
 
-        [$dailyData, $monthlyData] = $cache->get('php-statistics', function (CacheItemInterface $item) use ($versions, $type) {
+        [$dailyData, $monthlyData] = $cache->get('php-statistics-' . $type, function (CacheItemInterface $item) use ($versions, $type) {
             $item->expiresAfter(1800);
 
             return [


### PR DESCRIPTION
Hi. I noticed that the cache is saved html, which contains the data of the authorized user.  The data does not contain security sensitive information, but you can see the nickname of the last person who viewed this page 
It affected only `/php-statistics` page. The other pages with public cache control `NO_AUTO_CACHE_CONTROL_HEADER` is JSON not affected.

**STR**
1) Login to packagist
2) Open https://packagist.org/php-statistics
3) Open this page in incognito 

**Actual result** 
Depends on who last viewed this page when the cache was builded:

a) One the step 3. You will see the nickname of the last visited user
b) Or on step 2 you will see menu for non-authorized user
![Selection_1161](https://user-images.githubusercontent.com/21358010/211709160-fab245db-07b8-4b2e-802b-3a258b87f487.png)

