### PR TITLE
Add link to package security policy

### DIFF
--- a/src/Entity/Version.php
+++ b/src/Entity/Version.php
@@ -186,7 +186,7 @@ class Version
     private array|null $includePaths = null;
 
     /**
-     * @var array{issues?: string, forum?: string, wiki?: string, source?: string, email?: string, irc?: string, docs?: string, rss?: string, chat?: string}|null
+     * @var array{issues?: string, forum?: string, wiki?: string, source?: string, email?: string, irc?: string, docs?: string, rss?: string, chat?: string, security?: string}|null
      */
     #[ORM\Column(type: 'json', nullable: true)]
     private array|null $support = null;
@@ -535,7 +535,7 @@ class Version
     }
 
     /**
-     * @param array{issues?: string, forum?: string, wiki?: string, source?: string, email?: string, irc?: string, docs?: string, rss?: string, chat?: string}|null $support
+     * @param array{issues?: string, forum?: string, wiki?: string, source?: string, email?: string, irc?: string, docs?: string, rss?: string, chat?: string, security?: string}|null $support
      */
     public function setSupport(array|null $support): void
     {
@@ -543,7 +543,7 @@ class Version
     }
 
     /**
-     * @return array{issues?: string, forum?: string, wiki?: string, source?: string, email?: string, irc?: string, docs?: string, rss?: string, chat?: string}|null
+     * @return array{issues?: string, forum?: string, wiki?: string, source?: string, email?: string, irc?: string, docs?: string, rss?: string, chat?: string, security?: string}|null
      */
     public function getSupport(): array|null
     {

--- a/templates/package/view_package.html.twig
+++ b/templates/package/view_package.html.twig
@@ -172,6 +172,9 @@
                             {% if version and version.support.docs is defined %}
                                 <p><a rel="nofollow noopener external noindex ugc" href="{{ version.support.docs }}">Documentation</a></p>
                             {% endif %}
+                            {% if version and version.support.security is defined %}
+                                <p><a rel="nofollow noopener external noindex ugc" href="{{ version.support.security }}">Security Policy</a></p>
+                            {% endif %}
                         </div>
 
                         {% if version and version.funding and version.funding|length > 0 %}


### PR DESCRIPTION
This is a complementary feature for the security support option added in https://github.com/composer/composer/pull/11271

If the package has a security support link provided in `composer.json`, this will add a "Security Policy" link on Packagist. For example:

<img width="1344" alt="Screenshot 2023-01-14 at 13 55 22" src="https://user-images.githubusercontent.com/42941/212494171-7700a3a6-50a6-4f8c-bce9-1dc098e0241f.png">
