### PR TITLE
More protection from account takeovers

### DIFF
--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -512,7 +512,7 @@ class ApiController extends Controller
         $updateUrl = false;
 
         // maybe url changed, look up by remoteId
-        if (!$packages) {
+        if (!$packages && $user === null) {
             $packages = $packageRepo->findBy(['remoteId' => $remoteId]);
             $updateUrl = true;
         }


### PR DESCRIPTION
Additional fixes for #1374. The user can use an api token as GitHub secret and a custom webhook payload to change the URL of a package with more than 50k downloads.