### PR TITLE
change forks url to /forks

### DIFF
--- a/templates/package/view_package.html.twig
+++ b/templates/package/view_package.html.twig
@@ -241,7 +241,7 @@
                             {% if 'github.com' in repoUrl and package.gitHubForks is not null %}
                                 <p>
                                     <span>
-                                        <a href="{{ repoUrl }}/network">Forks</a>:
+                                        <a href="{{ repoUrl }}/forks">Forks</a>:
                                     </span>
                                     {{ package.gitHubForks|number_format(0, '.', '&#8201;')|raw }}
                                 </p>


### PR DESCRIPTION
Howdy 👋 

I noticed the URL for a packages Forks goes to the Network page on GitHub. Back in February, GitHub [introduced a new page](https://github.blog/changelog/2023-02-24-new-forks-page-view/), specifically for Forks of a package. I think this link makes more sense to now point to that page.

Thanks!