### PR TITLE
removed: `php.cnpkg.org`, reason: dead mirror

### DIFF
--- a/templates/mirrors/index.html.twig
+++ b/templates/mirrors/index.html.twig
@@ -17,7 +17,6 @@
   <li>Africa, South Africa <a href="https://packagist.co.za">packagist.co.za</a></li>
   <li>Asia, China <a href="https://mirrors.huaweicloud.com/repository/php">mirrors.huaweicloud.com/repository/php</a></li>
   <li>Asia, China <a href="https://developer.aliyun.com/composer">developer.aliyun.com/composer</a></li>
-  <li>Asia, China <a href="https://php.cnpkg.org">php.cnpkg.org</a></li>
   <li>Asia, China <a href="https://packagist.phpcomposer.com">packagist.phpcomposer.com</a></li>
   <li>Asia, China <a href="https://packagist.mirrors.sjtug.sjtu.edu.cn">packagist.mirrors.sjtug.sjtu.edu.cn</a></li>
   <li>Asia, China <a href="https://mirrors.cloud.tencent.com/help/composer.html">mirrors.cloud.tencent.com/help/composer.html</a></li>


### PR DESCRIPTION
Since [Jul 30, 2021](http://web.archive.org/web/20210601000000*/https://php.cnpkg.org/), php.cnpkg.org is offline. So please remove from mirror recommendation to avoid consumption of community time.