### PR TITLE
Security advisories: store severity

### DIFF
--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -1528,7 +1528,7 @@ class PackageController extends Controller
             throw new NotFoundHttpException();
         }
 
-        return $this->render('package/security_advisory.html.twig', ['advisories' => $securityAdvisories, 'id' => $id]);
+        return $this->render('package/security_advisory.html.twig', ['securityAdvisories' => $securityAdvisories, 'id' => $id]);
     }
 
     private function createAddMaintainerForm(Package $package): FormInterface

--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -1476,7 +1476,7 @@ class PackageController extends Controller
     {
         /** @var SecurityAdvisoryRepository $repo */
         $repo = $this->getEM()->getRepository(SecurityAdvisory::class);
-        $securityAdvisories = $repo->getPackageSecurityAdvisories($name);
+        $securityAdvisories = $repo->findByPackageName($name);
 
         $data = [];
         $data['name'] = $name;
@@ -1491,7 +1491,7 @@ class PackageController extends Controller
                 $versionParser = new VersionParser();
                 foreach ($securityAdvisories as $advisory) {
                     try {
-                        $affectedVersionConstraint = $versionParser->parseConstraints($advisory['affectedVersions']);
+                        $affectedVersionConstraint = $versionParser->parseConstraints($advisory->getAffectedVersions());
                     } catch (UnexpectedValueException) {
                         // ignore parsing errors, advisory must be invalid
                         continue;

--- a/src/Entity/SecurityAdvisory.php
+++ b/src/Entity/SecurityAdvisory.php
@@ -138,6 +138,10 @@ class SecurityAdvisory
         if ($initialCopy || $this->reportedAt != $advisory->date) {
             $this->reportedAt = $advisory->date;
         }
+
+        if ($initialCopy && $advisory->severity) {
+            $this->severity = $advisory->severity;
+        }
     }
 
     public function getPackagistAdvisoryId(): string

--- a/src/Entity/SecurityAdvisoryRepository.php
+++ b/src/Entity/SecurityAdvisoryRepository.php
@@ -136,7 +136,7 @@ class SecurityAdvisoryRepository extends ServiceEntityRepository
         }
 
         if (!$useCache || $filterByNames) {
-            $sql = 'SELECT s.packagistAdvisoryId as advisoryId, s.packageName, s.remoteId, s.title, s.link, s.cve, s.affectedVersions, s.source, s.reportedAt, s.composerRepository, sa.source sourceSource, sa.remoteId sourceRemoteId
+            $sql = 'SELECT s.packagistAdvisoryId as advisoryId, s.packageName, s.remoteId, s.title, s.link, s.cve, s.affectedVersions, s.source, s.reportedAt, s.composerRepository, sa.source sourceSource, sa.remoteId sourceRemoteId, s.severity
                 FROM security_advisory s
                 INNER JOIN security_advisory_source sa ON sa.securityAdvisory_id=s.id
                 WHERE s.updatedAt >= :updatedSince '.

--- a/src/Entity/SecurityAdvisoryRepository.php
+++ b/src/Entity/SecurityAdvisoryRepository.php
@@ -98,6 +98,22 @@ class SecurityAdvisoryRepository extends ServiceEntityRepository
     }
 
     /**
+     * @return list<SecurityAdvisory>
+     */
+    public function findByPackageName(string $packageName): array
+    {
+        return $this
+            ->createQueryBuilder('a')
+            ->addSelect('s')
+            ->leftJoin('a.sources', 's')
+            ->where('a.packageName = :packageName')
+            ->orderBy('a.reportedAt', 'DESC')
+            ->setParameters(['packageName' => $packageName])
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
      * @return array<string, array{advisoryId: string, packageName: string, remoteId: string, title: string, link: string|null, cve: string|null, affectedVersions: string, sources: array<array{name: string, remoteId: string}>, reportedAt: string, composerRepository: string|null}>
      */
     public function getPackageSecurityAdvisories(string $name): array

--- a/src/Entity/SecurityAdvisorySource.php
+++ b/src/Entity/SecurityAdvisorySource.php
@@ -12,6 +12,8 @@
 
 namespace App\Entity;
 
+use App\SecurityAdvisory\RemoteSecurityAdvisory;
+use App\SecurityAdvisory\Severity;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -32,11 +34,15 @@ class SecurityAdvisorySource
     #[ORM\Column(type: 'string')]
     private string $source;
 
-    public function __construct(SecurityAdvisory $securityAdvisory, string $remoteId, string $source)
+    #[ORM\Column(nullable: true)]
+    private Severity|null $severity;
+
+    public function __construct(SecurityAdvisory $securityAdvisory, string $remoteId, string $source, Severity|null $severity)
     {
         $this->securityAdvisory = $securityAdvisory;
         $this->remoteId = $remoteId;
         $this->source = $source;
+        $this->severity = $severity;
     }
 
     public function getRemoteId(): string
@@ -47,5 +53,15 @@ class SecurityAdvisorySource
     public function getSource(): string
     {
         return $this->source;
+    }
+
+    public function getSeverity(): ?Severity
+    {
+        return $this->severity;
+    }
+
+    public function update(RemoteSecurityAdvisory $advisory): void
+    {
+        $this->severity = $advisory->severity;
     }
 }

--- a/src/SecurityAdvisory/GitHubSecurityAdvisoriesSource.php
+++ b/src/SecurityAdvisory/GitHubSecurityAdvisoriesSource.php
@@ -125,6 +125,7 @@ class GitHubSecurityAdvisoriesSource implements SecurityAdvisorySourceInterface
                     $this->providerManager->packageExists($packageName) ? SecurityAdvisory::PACKAGIST_ORG : null,
                     $references,
                     self::SOURCE_NAME,
+                    Severity::fromGitHub($node['advisory']['severity']),
                 );
             }
 
@@ -157,6 +158,7 @@ query {
         permalink,
         publishedAt,
         withdrawnAt,
+        severity,
         identifiers {
           type,
           value

--- a/src/SecurityAdvisory/RemoteSecurityAdvisory.php
+++ b/src/SecurityAdvisory/RemoteSecurityAdvisory.php
@@ -35,85 +35,31 @@ class RemoteSecurityAdvisory
      * @param list<string> $references
      */
     public function __construct(
-        private string $id,
-        private string $title,
-        private string $packageName,
-        private string $affectedVersions,
-        private string $link,
-        private ?string $cve,
-        private DateTimeImmutable $date,
-        private ?string $composerRepository,
-        private array $references,
-        private string $source,
+        public readonly string $id,
+        public readonly string $title,
+        public readonly string $packageName,
+        public readonly string $affectedVersions,
+        public readonly string $link,
+        public readonly ?string $cve,
+        public readonly DateTimeImmutable $date,
+        public readonly ?string $composerRepository,
+        public readonly array $references,
+        public readonly string $source,
     ) {
     }
-
-    public function getId(): string
-    {
-        return $this->id;
-    }
-
-    public function getTitle(): string
-    {
-        return $this->title;
-    }
-
-    public function getPackageName(): string
-    {
-        return $this->packageName;
-    }
-
-    public function getAffectedVersions(): string
-    {
-        return $this->affectedVersions;
-    }
-
-    public function getLink(): string
-    {
-        return $this->link;
-    }
-
-    public function getCve(): ?string
-    {
-        return $this->cve;
-    }
-
-    public function getDate(): DateTimeImmutable
-    {
-        return $this->date;
-    }
-
-    public function getComposerRepository(): ?string
-    {
-        return $this->composerRepository;
-    }
-
-    /**
-     * @return list<string>
-     */
-    public function getReferences(): array
-    {
-        return $this->references;
-    }
-
-    public function getSource(): string
-    {
-        return $this->source;
-    }
-
     public function withAddedAffectedVersion(string $version): self
     {
         return new self(
-            $this->getId(),
-            $this->getTitle(),
-            $this->getPackageName(),
-            implode('|', [$this->getAffectedVersions(), $version]),
-            $this->getLink(),
-            $this->getCve(),
-            $this->getDate(),
-            $this->getComposerRepository(),
-            $this->getReferences(),
-            $this->getSource(),
+            $this->id,
+            $this->title,
+            $this->packageName,
+            implode('|', [$this->affectedVersions, $version]),
+            $this->link,
+            $this->cve,
+            $this->date,
+            $this->composerRepository,
+            $this->references,
+            $this->source,
         );
     }
 
@@ -186,7 +132,7 @@ class RemoteSecurityAdvisory
             $date,
             $composerRepository,
             [],
-            FriendsOfPhpSecurityAdvisoriesSource::SOURCE_NAME
+            FriendsOfPhpSecurityAdvisoriesSource::SOURCE_NAME,
         );
     }
 }

--- a/src/SecurityAdvisory/RemoteSecurityAdvisory.php
+++ b/src/SecurityAdvisory/RemoteSecurityAdvisory.php
@@ -45,6 +45,7 @@ class RemoteSecurityAdvisory
         public readonly ?string $composerRepository,
         public readonly array $references,
         public readonly string $source,
+        public readonly ?Severity $severity,
     ) {
     }
     public function withAddedAffectedVersion(string $version): self
@@ -60,6 +61,7 @@ class RemoteSecurityAdvisory
             $this->composerRepository,
             $this->references,
             $this->source,
+            $this->severity,
         );
     }
 
@@ -133,6 +135,7 @@ class RemoteSecurityAdvisory
             $composerRepository,
             [],
             FriendsOfPhpSecurityAdvisoriesSource::SOURCE_NAME,
+            null, // The FriendsOfPHP database doesn't contain severity values
         );
     }
 }

--- a/src/SecurityAdvisory/RemoteSecurityAdvisoryCollection.php
+++ b/src/SecurityAdvisory/RemoteSecurityAdvisoryCollection.php
@@ -23,7 +23,7 @@ class RemoteSecurityAdvisoryCollection
     public function __construct(array $advisories)
     {
         foreach ($advisories as $advisory) {
-            $this->groupedSecurityAdvisories[$advisory->getPackageName()][] = $advisory;
+            $this->groupedSecurityAdvisories[$advisory->packageName][] = $advisory;
         }
     }
 

--- a/src/SecurityAdvisory/SecurityAdvisoryResolver.php
+++ b/src/SecurityAdvisory/SecurityAdvisoryResolver.php
@@ -42,9 +42,9 @@ class SecurityAdvisoryResolver
         $unmatchedRemoteAdvisories = [];
         foreach ($remoteAdvisories->getPackageNames() as $packageName) {
             foreach ($remoteAdvisories->getAdvisoriesForPackageName($packageName) as $remoteAdvisory) {
-                if (isset($existingSourceAdvisoryMap[$packageName][$remoteAdvisory->getId()])) {
-                    $existingSourceAdvisoryMap[$packageName][$remoteAdvisory->getId()]->updateAdvisory($remoteAdvisory);
-                    unset($existingSourceAdvisoryMap[$packageName][$remoteAdvisory->getId()]);
+                if (isset($existingSourceAdvisoryMap[$packageName][$remoteAdvisory->id])) {
+                    $existingSourceAdvisoryMap[$packageName][$remoteAdvisory->id]->updateAdvisory($remoteAdvisory);
+                    unset($existingSourceAdvisoryMap[$packageName][$remoteAdvisory->id]);
                 } else {
                     $unmatchedRemoteAdvisories[$packageName][] = $remoteAdvisory;
                 }
@@ -79,7 +79,7 @@ class SecurityAdvisoryResolver
                     $newAdvisories[] = new SecurityAdvisory($remoteAdvisory, $sourceName);
                 } else {
                     // Update advisory and make sure the new source is added
-                    $matchedAdvisory->addSource($remoteAdvisory->getId(), $sourceName);
+                    $matchedAdvisory->addSource($remoteAdvisory->id, $sourceName);
                     $matchedAdvisory->updateAdvisory($remoteAdvisory);
                     unset($unmatchedExistingAdvisories[$packageName][$matchedAdvisory->getPackagistAdvisoryId()]);
                 }

--- a/src/SecurityAdvisory/SecurityAdvisoryResolver.php
+++ b/src/SecurityAdvisory/SecurityAdvisoryResolver.php
@@ -79,7 +79,7 @@ class SecurityAdvisoryResolver
                     $newAdvisories[] = new SecurityAdvisory($remoteAdvisory, $sourceName);
                 } else {
                     // Update advisory and make sure the new source is added
-                    $matchedAdvisory->addSource($remoteAdvisory->id, $sourceName);
+                    $matchedAdvisory->addSource($remoteAdvisory->id, $sourceName, $remoteAdvisory->severity);
                     $matchedAdvisory->updateAdvisory($remoteAdvisory);
                     unset($unmatchedExistingAdvisories[$packageName][$matchedAdvisory->getPackagistAdvisoryId()]);
                 }

--- a/src/SecurityAdvisory/Severity.php
+++ b/src/SecurityAdvisory/Severity.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace App\SecurityAdvisory;
+
+/*
+ * This file is part of Packagist.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *     Nils Adermann <naderman@naderman.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Common Vulnerability Scoring System v3
+ *
+ * - None:     0.0
+ * - Low:      0.1 - 3.9
+ * - Medium:   4.0 - 6.9
+ * - High:     7.0 - 8.9
+ * - Critical: 9.0 - 10.0
+ *
+ * @see https://www.first.org/cvss/specification-document
+ */
+enum Severity: string
+{
+    case NONE = 'none';
+    case LOW = 'low';
+    case MEDIUM = 'medium';
+    case HIGH = 'high';
+    case CRITICAL = 'critical';
+
+    /**
+     * @see https://docs.github.com/en/code-security/security-advisories/working-with-global-security-advisories-from-the-github-advisory-database/about-the-github-advisory-database#about-cvss-levels
+     */
+    public static function fromGitHub(?string $githubSeverity): ?Severity
+    {
+        if (!$githubSeverity) {
+            return null;
+        }
+
+        // GitHub uses moderate instead of medium
+        if (strtolower($githubSeverity) === 'moderate') {
+            return self::MEDIUM;
+        }
+
+        return Severity::tryFrom(strtolower($githubSeverity));
+    }
+}

--- a/templates/api_doc/index.html.twig
+++ b/templates/api_doc/index.html.twig
@@ -466,7 +466,8 @@ GET https://{{ packagist_host }}/api/security-advisories/?updatedSince=[timestam
             }
         ],
         "reportedAt": "[date the issue was reported]",
-        "composerRepository": "[composer repository the package can be found in]"
+        "composerRepository": "[composer repository the package can be found in]",
+        "severity": [severity if available, following the CVSS3 spec]
       }
     ]
   }

--- a/templates/package/_security_advisory_list.html.twig
+++ b/templates/package/_security_advisory_list.html.twig
@@ -1,0 +1,41 @@
+<section class="row">
+    <section class="col-md-12">
+        {% if securityAdvisories|length %}
+            <ul class="packages list-unstyled">
+                {% for advisory in securityAdvisories %}
+                    <li class="row">
+                        <div class="col-xs-12 package-item">
+                            <div class="row">
+                                <div class="col-sm-8 col-lg-9">
+                                    <h4 class="font-bold">
+                                        {% if advisory.severity %}[{{ advisory.severity.value|upper }}]{% endif %}
+                                        <a href="{{ advisory.link }}">{{ advisory.title }}</a>
+                                    </h4>
+                                    <p>
+                                        <a href="{{ path('view_advisory', {id: advisory.packagistAdvisoryId}) }}">{{ advisory.packagistAdvisoryId }}</a>
+                                        {% if advisory.cve %}
+                                            <a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name={{ advisory.cve }}">{{ advisory.cve }}</a>
+                                        {% endif %}
+                                        {% for source in advisory.sources %}
+                                            {% if source.source == 'GitHub' and source.remoteId is not empty %}
+                                                <a href="https://github.com/advisories/{{ source.remoteId }}">{{ source.remoteId }}</a>
+                                            {% endif %}
+                                        {% endfor %}
+                                    </p>
+                                    <p>Affected version: {{ advisory.affectedVersions }}</p>
+                                </div>
+                                <div class="col-sm-4 col-lg-3">
+                                    <p>Reported by:<br/>{% for source in advisory.sources %}{{ source.source }}{% if not loop.last %}, {% endif %}{% endfor %}</p>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                {% endfor %}
+            </ul>
+        {% else %}
+            <div class="alert alert-danger">
+                <p>{{ 'listing.no_security_advisories'|trans }}</p>
+            </div>
+        {% endif %}
+    </section>
+</section>

--- a/templates/package/security_advisories.html.twig
+++ b/templates/package/security_advisories.html.twig
@@ -22,45 +22,5 @@
         </div>
     </div>
 
-    <section class="row">
-        <section class="col-md-12">
-            {% if securityAdvisories|length %}
-                <ul class="packages list-unstyled">
-                    {% for advisory in securityAdvisories %}
-                        <li class="row">
-                            <div class="col-xs-12 package-item">
-                                <div class="row">
-                                    <div class="col-sm-8 col-lg-9">
-                                        <h4 class="font-bold">
-                                            {% if advisory.severity %}[{{ advisory.severity|upper }}]{% endif %}
-                                            <a href="{{ advisory.link }}">{{ advisory.title }}</a>
-                                        </h4>
-                                        <p>
-                                            <a href="{{ path('view_advisory', {id: advisory.advisoryId}) }}">{{ advisory.advisoryId }}</a>
-                                            {% if advisory.cve %}
-                                                <a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name={{ advisory.cve }}">{{ advisory.cve }}</a>
-                                            {% endif %}
-                                            {% for source in advisory.sources %}
-                                                {% if source.name == 'GitHub' and source.remoteId is not empty %}
-                                                    <a href="https://github.com/advisories/{{ source.remoteId }}">{{ source.remoteId }}</a>
-                                                {% endif %}
-                                            {% endfor %}
-                                        </p>
-                                        <p>Affected version: {{ advisory.affectedVersions }}</p>
-                                    </div>
-                                    <div class="col-sm-4 col-lg-3">
-                                        <p>Reported by:<br/>{% for source in advisory.sources %}{{ source.name }}{% if not loop.last %}, {% endif %}{% endfor %}</p>
-                                    </div>
-                                </div>
-                            </div>
-                        </li>
-                    {% endfor %}
-                </ul>
-            {% else %}
-                <div class="alert alert-danger">
-                    <p>{{ 'listing.no_security_advisories'|trans }}</p>
-                </div>
-            {% endif %}
-        </section>
-    </section>
+    {% include 'package/_security_advisory_list.html.twig' %}
 {% endblock %}

--- a/templates/package/security_advisories.html.twig
+++ b/templates/package/security_advisories.html.twig
@@ -32,6 +32,7 @@
                                 <div class="row">
                                     <div class="col-sm-8 col-lg-9">
                                         <h4 class="font-bold">
+                                            {% if advisory.severity %}[{{ advisory.severity|upper }}]{% endif %}
                                             <a href="{{ advisory.link }}">{{ advisory.title }}</a>
                                         </h4>
                                         <p>

--- a/templates/package/security_advisory.html.twig
+++ b/templates/package/security_advisory.html.twig
@@ -17,39 +17,5 @@
         </div>
     </div>
 
-    <section class="row">
-        <section class="col-md-12">
-            <ul class="packages list-unstyled">
-                {% for advisory in advisories %}
-                    <li class="row">
-                        <div class="col-xs-12 package-item">
-                            <div class="row">
-                                <div class="col-sm-8 col-lg-9">
-                                    <h4 class="font-bold">
-                                        <a href="{{ advisory.link }}">{{ advisory.title }}</a>
-                                    </h4>
-                                    <p>
-                                        <a href="{{ path('view_advisory', {id: advisory.packagistAdvisoryId}) }}">{{ advisory.packagistAdvisoryId }}</a>
-                                        {% if advisory.cve %}
-                                            <a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name={{ advisory.cve }}">{{ advisory.cve }}</a>
-                                        {% endif %}
-                                        {% for source in advisory.sources %}
-                                            {% if source.source == 'GitHub' and source.remoteId is not empty %}
-                                                <a href="https://github.com/advisories/{{ source.remoteId }}">{{ source.remoteId }}</a>
-                                            {% endif %}
-                                        {% endfor %}
-                                    </p>
-                                    <p>Affected package: {% if advisory.packageName is existing_package %}<a href="{{ path('view_package', { 'name': advisory.packageName }) }}">{{ advisory.packageName }}</a>{% else %}{{ advisory.packageName }}{% endif %}</p>
-                                    <p>Affected version: {{ advisory.affectedVersions }}</p>
-                                </div>
-                                <div class="col-sm-4 col-lg-3">
-                                    <p>Reported by:<br/>{% for source in advisory.sources %}{{ source.source }}{% if not loop.last %}, {% endif %}{% endfor %}</p>
-                                </div>
-                            </div>
-                        </div>
-                    </li>
-                {% endfor %}
-            </ul>
-        </section>
-    </section>
+    {% include 'package/_security_advisory_list.html.twig' %}
 {% endblock %}

--- a/tests/Entity/SecurityAdvisoryTest.php
+++ b/tests/Entity/SecurityAdvisoryTest.php
@@ -131,7 +131,7 @@ class SecurityAdvisoryTest extends TestCase
 
     private function generateFriendsOfPhpRemoteAdvisory(string $title, string $link, string $cve): RemoteSecurityAdvisory
     {
-        return RemoteSecurityAdvisory::createFromFriendsOfPhp('symfony/framework-bundle/CVE-2022-xxxx.yaml', [
+        return RemoteSecurityAdvisory::createFromFriendsOfPhp(sprintf('symfony/framework-bundle/%s.yaml', $cve), [
             'title' => $title,
             'link' => $link,
             'cve' => $cve,

--- a/tests/Entity/SecurityAdvisoryTest.php
+++ b/tests/Entity/SecurityAdvisoryTest.php
@@ -14,7 +14,9 @@ namespace App\Tests\Entity;
 
 use App\Entity\SecurityAdvisory;
 use App\SecurityAdvisory\FriendsOfPhpSecurityAdvisoriesSource;
+use App\SecurityAdvisory\GitHubSecurityAdvisoriesSource;
 use App\SecurityAdvisory\RemoteSecurityAdvisory;
+use App\SecurityAdvisory\Severity;
 use PHPUnit\Framework\TestCase;
 
 class SecurityAdvisoryTest extends TestCase
@@ -85,33 +87,54 @@ class SecurityAdvisoryTest extends TestCase
 
     public function testCalculateDifferenceScoreCveXXXX(): void
     {
-        $remoteAdvisory = RemoteSecurityAdvisory::createFromFriendsOfPhp('symfony/framework-bundle/CVE-2022-xxxx.yaml', [
-            'title' => 'CVE-2022-xxxx: CSRF token missing in forms',
-            'link' => 'https://symfony.com/cve-2022-xxxx',
-            'cve' => 'CVE-2022-xxxx',
-            'branches' => [
-                '5.3.x' => [
-                    'time' => '2022-01-29 12:00:00',
-                    'versions' => ['>=5.3.14', '<=5.3.14'],
-                ],
-                '5.4.x' => [
-                    'time' => '2022-01-29 12:00:00',
-                    'versions' => ['>=5.4.3', '<=5.4.3'],
-                ],
-                '6.0.x' => [
-                    'time' => '2022-01-29 12:00:00',
-                    'versions' => ['>=6.0.3', '<=6.0.3'],
-                ],
-            ],
-            'reference' => 'composer://symfony/framework-bundle',
-        ]);
+        $remoteAdvisory = $this->generateFriendsOfPhpRemoteAdvisory('CVE-2022-xxxx: CSRF token missing in forms', 'https://symfony.com/cve-2022-xxxx', 'CVE-2022-xxxx');
 
         $advisory = new SecurityAdvisory($remoteAdvisory, FriendsOfPhpSecurityAdvisoriesSource::SOURCE_NAME);
 
-        $updatedRemoteAdvisory = RemoteSecurityAdvisory::createFromFriendsOfPhp('symfony/framework-bundle/CVE-2022-99999999999.yaml', [
-            'title' => 'CVE-2022-99999999999: CSRF token missing in forms',
-            'link' => 'https://symfony.com/cve-2022-99999999999',
-            'cve' => 'CVE-2022-99999999999',
+        $updatedRemoteAdvisory = $this->generateFriendsOfPhpRemoteAdvisory('CVE-2022-99999999999: CSRF token missing in forms', 'https://symfony.com/cve-2022-99999999999', 'CVE-2022-99999999999');
+
+        $this->assertSame(3, $advisory->calculateDifferenceScore($updatedRemoteAdvisory));
+    }
+
+    public function testStoreSeverity(): void
+    {
+        $friendsOfPhpRemoteAdvisory = $this->generateFriendsOfPhpRemoteAdvisory('CVE-2022-xxxx: CSRF token missing in forms', 'https://symfony.com/cve-2022-xxxx', 'CVE-2022-xxxx');
+        $gitHubRemoteAdvisor = $this->generateGitHubAdvisory(null);
+        $advisory = new SecurityAdvisory($friendsOfPhpRemoteAdvisory, $friendsOfPhpRemoteAdvisory->source);
+
+        $this->assertNull($advisory->getSeverity(), "FriendsOfPHP doesn't provide severity information");
+        $advisory->addSource($gitHubRemoteAdvisor->id, GitHubSecurityAdvisoriesSource::SOURCE_NAME, null);
+        $advisory->updateAdvisory($this->generateGitHubAdvisory(Severity::HIGH));
+        $this->assertSame(Severity::HIGH, $advisory->getSeverity(), "GitHub should update the severity severity");
+        $this->assertSame(Severity::HIGH, $advisory->findSecurityAdvisorySource(GitHubSecurityAdvisoriesSource::SOURCE_NAME)?->getSeverity(), 'GitHub should update the source data');
+
+        $advisory->updateAdvisory($friendsOfPhpRemoteAdvisory);
+        $this->assertSame(Severity::HIGH, $advisory->getSeverity(), "FriendsOfPHP shouldn't reset the severity information");
+    }
+
+    private function generateGitHubAdvisory(Severity|null $severity): RemoteSecurityAdvisory
+    {
+        return new RemoteSecurityAdvisory(
+            'GHSA-1234-1234-1234',
+            'Tile',
+            'symfony/framework-bundle',
+            '',
+            'https://github.com/advisories/GHSA-1234-1234-1234',
+            null,
+            new \DateTimeImmutable(),
+            null,
+            [],
+            GitHubSecurityAdvisoriesSource::SOURCE_NAME,
+            $severity,
+        );
+    }
+
+    private function generateFriendsOfPhpRemoteAdvisory(string $title, string $link, string $cve): RemoteSecurityAdvisory
+    {
+        return RemoteSecurityAdvisory::createFromFriendsOfPhp('symfony/framework-bundle/CVE-2022-xxxx.yaml', [
+            'title' => $title,
+            'link' => $link,
+            'cve' => $cve,
             'branches' => [
                 '5.3.x' => [
                     'time' => '2022-01-29 12:00:00',
@@ -128,7 +151,5 @@ class SecurityAdvisoryTest extends TestCase
             ],
             'reference' => 'composer://symfony/framework-bundle',
         ]);
-
-        $this->assertSame(3, $advisory->calculateDifferenceScore($updatedRemoteAdvisory));
     }
 }

--- a/tests/SecurityAdvisory/RemoteSecurityAdvisoryTest.php
+++ b/tests/SecurityAdvisory/RemoteSecurityAdvisoryTest.php
@@ -41,6 +41,7 @@ class RemoteSecurityAdvisoryTest extends TestCase
         $this->assertSame('3f/pygmentize', $advisory->packageName);
         $this->assertSame('2017-05-15 00:00:00', $advisory->date->format('Y-m-d H:i:s'));
         $this->assertSame(SecurityAdvisory::PACKAGIST_ORG, $advisory->composerRepository);
+        $this->assertNull($advisory->severity);
     }
 
     public function testCreateFromFriendsOfPhpOnlyYearAvailable(): void
@@ -111,7 +112,7 @@ class RemoteSecurityAdvisoryTest extends TestCase
 
     public function testWithAddedAffectedVersion(): void
     {
-        $advisory = new RemoteSecurityAdvisory('id', 'foobar', 'foo/bar', '>=1', 'https://foobar.com', null, new \DateTimeImmutable(), null, [], 'test');
+        $advisory = new RemoteSecurityAdvisory('id', 'foobar', 'foo/bar', '>=1', 'https://foobar.com', null, new \DateTimeImmutable(), null, [], 'test', null);
         $advisory = $advisory->withAddedAffectedVersion('<2');
 
         $this->assertSame('>=1|<2', $advisory->affectedVersions);

--- a/tests/SecurityAdvisory/RemoteSecurityAdvisoryTest.php
+++ b/tests/SecurityAdvisory/RemoteSecurityAdvisoryTest.php
@@ -33,14 +33,14 @@ class RemoteSecurityAdvisoryTest extends TestCase
             'reference' => 'composer://3f/pygmentize',
         ]);
 
-        $this->assertSame('3f/pygmentize/2017-05-15.yaml', $advisory->getId());
-        $this->assertSame('Remote Code Execution', $advisory->getTitle());
-        $this->assertSame('https://github.com/dedalozzo/pygmentize/issues/1', $advisory->getLink());
-        $this->assertNull($advisory->getCve());
-        $this->assertSame('<1.2', $advisory->getAffectedVersions());
-        $this->assertSame('3f/pygmentize', $advisory->getPackageName());
-        $this->assertSame('2017-05-15 00:00:00', $advisory->getDate()->format('Y-m-d H:i:s'));
-        $this->assertSame(SecurityAdvisory::PACKAGIST_ORG, $advisory->getComposerRepository());
+        $this->assertSame('3f/pygmentize/2017-05-15.yaml', $advisory->id);
+        $this->assertSame('Remote Code Execution', $advisory->title);
+        $this->assertSame('https://github.com/dedalozzo/pygmentize/issues/1', $advisory->link);
+        $this->assertNull($advisory->cve);
+        $this->assertSame('<1.2', $advisory->affectedVersions);
+        $this->assertSame('3f/pygmentize', $advisory->packageName);
+        $this->assertSame('2017-05-15 00:00:00', $advisory->date->format('Y-m-d H:i:s'));
+        $this->assertSame(SecurityAdvisory::PACKAGIST_ORG, $advisory->composerRepository);
     }
 
     public function testCreateFromFriendsOfPhpOnlyYearAvailable(): void
@@ -59,7 +59,7 @@ class RemoteSecurityAdvisoryTest extends TestCase
             'reference' => 'composer://erusev/parsedown',
         ]);
 
-        $this->assertSame('2019-01-01 00:00:00', $advisory->getDate()->format('Y-m-d H:i:s'));
+        $this->assertSame('2019-01-01 00:00:00', $advisory->date->format('Y-m-d H:i:s'));
     }
 
     public function testCreateFromFriendsOfPhpOnlyYearButBranchDatesAvailable(): void
@@ -79,7 +79,7 @@ class RemoteSecurityAdvisoryTest extends TestCase
             'composer-repository' => false,
         ]);
 
-        $this->assertSame('2019-10-08 00:00:00', $advisory->getDate()->format('Y-m-d H:i:s'));
+        $this->assertSame('2019-10-08 00:00:00', $advisory->date->format('Y-m-d H:i:s'));
     }
 
     public function testCreateFromFriendsOfPhpCVEXXXX(): void
@@ -105,8 +105,8 @@ class RemoteSecurityAdvisoryTest extends TestCase
             'reference' => 'composer://symfony/framework-bundle',
         ]);
 
-        $this->assertSame('symfony/framework-bundle/CVE-2022-xxxx.yaml', $advisory->getId());
-        $this->assertNull($advisory->getCve());
+        $this->assertSame('symfony/framework-bundle/CVE-2022-xxxx.yaml', $advisory->id);
+        $this->assertNull($advisory->cve);
     }
 
     public function testWithAddedAffectedVersion(): void
@@ -114,6 +114,6 @@ class RemoteSecurityAdvisoryTest extends TestCase
         $advisory = new RemoteSecurityAdvisory('id', 'foobar', 'foo/bar', '>=1', 'https://foobar.com', null, new \DateTimeImmutable(), null, [], 'test');
         $advisory = $advisory->withAddedAffectedVersion('<2');
 
-        $this->assertSame('>=1|<2', $advisory->getAffectedVersions());
+        $this->assertSame('>=1|<2', $advisory->affectedVersions);
     }
 }

--- a/tests/SecurityAdvisory/SecurityAdvisoryResolverTest.php
+++ b/tests/SecurityAdvisory/SecurityAdvisoryResolverTest.php
@@ -76,7 +76,7 @@ class SecurityAdvisoryResolverTest extends TestCase
     public function testResolveDontRemoveAdvisoryWithMultipleSources(): void
     {
         $advisory = new SecurityAdvisory($this->createRemoteAdvisory('test'), 'test');
-        $advisory->addSource('other-id', 'other');
+        $advisory->addSource('other-id', 'other', null);
         [$new, $removed] = $this->resolver->resolve([$advisory], new RemoteSecurityAdvisoryCollection([]), 'test');
 
         $this->assertSame([], $new);
@@ -108,6 +108,18 @@ class SecurityAdvisoryResolverTest extends TestCase
 
     private function createRemoteAdvisory(string $source, string $packageName = 'acme/package', ?string $cve = null): RemoteSecurityAdvisory
     {
-        return new RemoteSecurityAdvisory(uniqid('id-'), 'Security Advisory', $packageName, '^1.0', 'https://example.org', $cve, new \DateTimeImmutable(), null, [], $source);
+        return new RemoteSecurityAdvisory(
+            uniqid('id-'),
+            'Security Advisory',
+            $packageName,
+            '^1.0',
+            'https://example.org',
+            $cve,
+            new \DateTimeImmutable(),
+            null,
+            [],
+            $source,
+            null,
+        );
     }
 }

--- a/tests/SecurityAdvisory/SeverityTest.php
+++ b/tests/SecurityAdvisory/SeverityTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\SecurityAdvisory;
+
+/*
+ * This file is part of Packagist.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *     Nils Adermann <naderman@naderman.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use App\SecurityAdvisory\Severity;
+use PHPUnit\Framework\TestCase;
+
+class SeverityTest extends TestCase
+{
+    /**
+     * @dataProvider gitHubSeverityProvider
+     */
+    public function testFromGitHub(?string $gitHubSeverity, ?Severity $expected): void
+    {
+        $this->assertSame($expected, Severity::fromGitHub($gitHubSeverity));
+    }
+
+    public static function gitHubSeverityProvider(): iterable
+    {
+        yield ['CRITICAL', Severity::CRITICAL];
+        yield ['HIGH', Severity::HIGH];
+        yield ['MODERATE', Severity::MEDIUM];
+        yield ['LOW', Severity::LOW];
+        yield [null, null];
+    }
+}

--- a/tests/SecurityAdvisoryWorkerTest.php
+++ b/tests/SecurityAdvisoryWorkerTest.php
@@ -168,6 +168,18 @@ class SecurityAdvisoryWorkerTest extends TestCase
 
     private function createRemoteAdvisory(string $packageName, string $remoteId): RemoteSecurityAdvisory
     {
-        return new RemoteSecurityAdvisory($remoteId, 'Advisory' . $packageName, $packageName, '^1.0', 'https://example/' . $packageName, null, new \DateTimeImmutable(), null, [], 'test');
+        return new RemoteSecurityAdvisory(
+            $remoteId,
+            'Advisory' . $packageName,
+            $packageName,
+            '^1.0',
+            'https://example/' . $packageName,
+            null,
+            new \DateTimeImmutable(),
+            null,
+            [],
+            'test',
+            null,
+        );
     }
 }


### PR DESCRIPTION
This fetches the severity for each advisory from the GitHub security advisory database and make the data available for Composer to use during `composer audit`.

The severity is currently returned/shown as part of `/api/security-advisories/` (I believe this is enough for Composer?) and the UI.

I am not sure if storing the severity as part of the `SecurityAdvisorySource` is necessary. I figured if we have multiple sources reporting the severity, we can calculate a median. Happy to remove this if people think this isn't necessary.

UI Example:
<img width="1290" alt="Screenshot 2023-10-27 at 09 57 16" src="https://github.com/composer/packagist/assets/442056/67290dd2-94bf-42c8-8873-a8f074b1eba7">

