### PR TITLE
Check that the repo ID hasn't changed to prevent repo-jacking

### DIFF
--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -556,8 +556,15 @@ class ApiController extends Controller
         }
 
         foreach ($packages as $package) {
-            if ($remoteId && !$package->getRemoteId()) {
-                $package->setRemoteId($remoteId);
+            if ($remoteId) {
+                $actualRemoteId = $package->getRemoteId();
+                if ($actualRemoteId) {
+                    if ($actualRemoteId !== $remoteId) {
+                        throw new BadRequestHttpException('The remoteId of the repo URL '.$path.' has changed from '.$remoteId.' to '.$actualRemoteId);
+                    }
+                } else {
+                    $package->setRemoteId($remoteId);
+                }
             }
         }
 


### PR DESCRIPTION
The goal of this change is to prevent "repo-jacking", which can happen if a GitHub user changes their username. It happened once last year when somebody managed to [repo-jack the phpass library](https://thehackernews.com/2022/05/pypi-package-ctx-and-php-library-phpass.html). You can defend against repo-jacking by checking that the repo ID hasn't changed.

Unfortunately I haven't been able to test this code properly. I've tried to build and run packagist in a VM, but something is wrong with my setup and I haven't been able to trigger this part of the code.