### PR TITLE
Improved support for GitLab

### DIFF
--- a/src/Entity/Package.php
+++ b/src/Entity/Package.php
@@ -274,6 +274,26 @@ class Package
         return $this->vendor;
     }
 
+    public function isGitHub(): array|bool
+    {
+        if (Preg::isMatchStrictGroups('{^(?:git://|git@|https?://)github.com[:/]([^/]+)/(.+?)(?:\.git|/)?$}i', $this->getRepository(), $match)) {
+            return $match;
+        }
+        else {
+            return false;
+        }
+    }
+
+    public function isGitLab(): array|bool
+    {
+        if (Preg::isMatchStrictGroups('{^(?:git://|git@|https?://)gitlab.com[:/]([^/]+)/(.+?)(?:\.git|/)?$}i', $this->getRepository(), $match)) {
+            return $match;
+        }
+        else {
+            return false;
+        }
+    }
+
     /**
      * Get package name without vendor
      */
@@ -334,6 +354,19 @@ class Package
         return $this->gitHubStars;
     }
 
+    public function getGitHubStarsUrl(): string|null
+    {
+        if ($this->isGitHub()) {
+            return $this->getBrowsableRepository() . '/stargazers';
+        }
+        else if ($this->isGitLab()) {
+            return $this->getBrowsableRepository() . '/-/starrers';
+        }
+        else {
+            return null;
+        }
+    }
+
     public function setGitHubWatches(int|null $val): void
     {
         $this->gitHubWatches = $val;
@@ -352,6 +385,19 @@ class Package
     public function getGitHubForks(): int|null
     {
         return $this->gitHubForks;
+    }
+
+    public function getGitHubForksUrl(): string|null
+    {
+        if ($this->isGitHub()) {
+            return $this->getBrowsableRepository() . '/forks';
+        }
+        else if ($this->isGitLab()) {
+            return $this->getBrowsableRepository() . '/-/forks';
+        }
+        else {
+            return null;
+        }
     }
 
     public function setGitHubOpenIssues(int|null $val): void
@@ -467,7 +513,15 @@ class Package
             return Preg::replace('{^(?:git@|https://|git://)bitbucket.org[:/](.+?)(?:\.git)?$}i', 'https://bitbucket.org/$1', $this->repository);
         }
 
-        return Preg::replace('{^(git://github.com/|git@github.com:)}', 'https://github.com/', $this->repository);
+        if (Preg::isMatch('{(://|@)github.com[:/]}i', $this->repository)) {
+            return Preg::replace('{^(git://github.com/|git@github.com:)}', 'https://github.com/', $this->repository);
+        }
+
+        if (Preg::isMatch('{(://|@)gitlab.com[:/]}i', $this->repository)) {
+            return Preg::replace('{^(git://gitlab.com/|git@gitlab.com:)}', 'https://gitlab.com/', $this->repository);
+        }
+
+        return $this->repository;
     }
 
     public function addVersion(Version $version): void

--- a/src/Entity/Package.php
+++ b/src/Entity/Package.php
@@ -274,7 +274,10 @@ class Package
         return $this->vendor;
     }
 
-    public function isGitHub(): array|bool
+    /**
+     * @return array<string> Vendor and package name
+     */
+    public function isGitHub(): array|false
     {
         if (Preg::isMatchStrictGroups('{^(?:git://|git@|https?://)github.com[:/]([^/]+)/(.+?)(?:\.git|/)?$}i', $this->getRepository(), $match)) {
             return $match;
@@ -284,7 +287,10 @@ class Package
         }
     }
 
-    public function isGitLab(): array|bool
+    /**
+     * @return array<string> Vendor and package name
+     */
+    public function isGitLab(): array|false
     {
         if (Preg::isMatchStrictGroups('{^(?:git://|git@|https?://)gitlab.com[:/]([^/]+)/(.+?)(?:\.git|/)?$}i', $this->getRepository(), $match)) {
             return $match;

--- a/src/Entity/Package.php
+++ b/src/Entity/Package.php
@@ -282,9 +282,8 @@ class Package
         if (Preg::isMatchStrictGroups('{^(?:git://|git@|https?://)github.com[:/]([^/]+)/(.+?)(?:\.git|/)?$}i', $this->getRepository(), $match)) {
             return $match;
         }
-        else {
-            return false;
-        }
+
+        return false;
     }
 
     /**
@@ -295,9 +294,8 @@ class Package
         if (Preg::isMatchStrictGroups('{^(?:git://|git@|https?://)gitlab.com[:/]([^/]+)/(.+?)(?:\.git|/)?$}i', $this->getRepository(), $match)) {
             return $match;
         }
-        else {
-            return false;
-        }
+
+        return false;
     }
 
     /**
@@ -364,13 +362,12 @@ class Package
     {
         if ($this->isGitHub()) {
             return $this->getBrowsableRepository() . '/stargazers';
-        }
-        else if ($this->isGitLab()) {
+        } 
+        if ($this->isGitLab()) {
             return $this->getBrowsableRepository() . '/-/starrers';
         }
-        else {
-            return null;
-        }
+
+        return null;
     }
 
     public function setGitHubWatches(int|null $val): void
@@ -398,12 +395,11 @@ class Package
         if ($this->isGitHub()) {
             return $this->getBrowsableRepository() . '/forks';
         }
-        else if ($this->isGitLab()) {
+        if ($this->isGitLab()) {
             return $this->getBrowsableRepository() . '/-/forks';
         }
-        else {
-            return null;
-        }
+
+        return null;
     }
 
     public function setGitHubOpenIssues(int|null $val): void

--- a/templates/package/view_package.html.twig
+++ b/templates/package/view_package.html.twig
@@ -223,10 +223,10 @@
                                     {{ securityAdvisories|number_format(0, '.', '&#8201;')|raw }}
                                 </p>
                             {% endif %}
-                            {% if 'github.com' in repoUrl and package.gitHubStars is not null %}
+                            {% if package.gitHubStars is not null %}
                                 <p>
                                     <span>
-                                        <a href="{{ repoUrl }}/stargazers">Stars</a>:
+                                        <a href="{{ package.gitHubStarsUrl }}">Stars</a>:
                                     </span>
                                     {{ package.gitHubStars|number_format(0, '.', '&#8201;')|raw }}
                                 </p>
@@ -238,10 +238,10 @@
                                     </span> {{ package.gitHubWatches|number_format(0, '.', '&#8201;')|raw }}
                                 </p>
                             {% endif %}
-                            {% if 'github.com' in repoUrl and package.gitHubForks is not null %}
+                            {% if package.gitHubForks is not null %}
                                 <p>
                                     <span>
-                                        <a href="{{ repoUrl }}/forks">Forks</a>:
+                                        <a href="{{ package.gitHubForksUrl }}">Forks</a>:
                                     </span>
                                     {{ package.gitHubForks|number_format(0, '.', '&#8201;')|raw }}
                                 </p>


### PR DESCRIPTION
This pull request refers to #1406 and depends on [this other PR for Composer](https://github.com/composer/composer/pull/11734) (merged but actually to be yet included in a versioned release).

Provides some extra support for packages hosted on gitlab.com, in particular for stars and forks counters.

Considerations:
- I kept the original naming of attributes with the "github" prefix (e.g. github_stars) to avoid breaking stuff. Inaccurate, but effective
- I've introduced `isGitHub()` and `isGitLab()` functions in `App\Entity\Package` to wrap provider's guessing based on repository URL