### PR TITLE
feat(search): add snapshoted latest version and date of a package

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -174,6 +174,8 @@ search.addWidget(
         <div class="col-sm-3 col-lg-2">
             {{#meta}}
                 <p class="metadata">
+                    <span class="metadata-block"><i class="glyphicon glyphicon-tags"></i> {{ meta.latest_version }}</span>
+                    <span class="metadata-block"><i class="glyphicon glyphicon-calendar"></i> {{ meta.latest_date }}</span>
                     <span class="metadata-block"><i class="glyphicon glyphicon-download"></i> {{ meta.downloads_formatted }}</span>
                     <span class="metadata-block"><i class="glyphicon glyphicon-star"></i> {{ meta.favers_formatted }}</span>
                 </p>

--- a/src/Command/IndexPackagesCommand.php
+++ b/src/Command/IndexPackagesCommand.php
@@ -233,6 +233,14 @@ class IndexPackagesCommand extends Command
             $record['replacementPackage'] = '';
         }
 
+        if (null !== $snapshotedLatestVersion = $package->getSnapshotedLatestVersion()) {
+            $snapshotedLatestVersion = \exploded('&', $snapshotedLatestVersion);
+            $record['meta'] = [
+                'latest_version' => $snapshotedLatestVersion[0],
+                'latest_date' => $snapshotedLatestVersion[1],
+            ];
+        }
+
         $record['tags'] = $tags;
 
         return $record;


### PR DESCRIPTION
Hello,

Small PR related to issues mentioned/related.

> [!NOTE]
> PR opened as is to gather feedbacks/have raw material for discussions (not finished at all)
> I am open to discuss the easiest/fastest/simplest way for introducing such data that will help a think a lot the search results

---

## Idea of display

<img width="969" alt="Capture d’écran 2024-01-08 à 18 47 42" src="https://github.com/composer/packagist/assets/1358361/3b915106-0cb8-4596-9cce-af41c4eb27e6">

---


refs:

- https://github.com/composer/packagist/issues/1320 (old one of mine)
- https://github.com/composer/packagist/issues/1290
- https://github.com/composer/packagist/issues/1368