### PR TITLE
Logout: add CSRF token and clear site data

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -33,7 +33,12 @@ security:
                 always_remember_me: false
                 secure: '%force_ssl%'
                 lifetime: 31104000 # 1y
-            logout:       true
+            logout:
+                enable_csrf: true
+                clear_site_data:
+                    - cookies
+                    - storage
+                    - cache
             lazy:         true
             two_factor:
                 auth_form_path: 2fa_login

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -26,6 +26,7 @@ services:
             $recaptchaVerifier: "@beelab_recaptcha2.verifier"
             'Monolog\Logger': '@logger'
             'Symfony\Contracts\EventDispatcher\EventDispatcherInterface $mainEventDispatcher': '@security.event_dispatcher.main'
+            'Symfony\Component\Security\Http\Logout\LogoutUrlGenerator': '@security.logout_url_generator'
 
             # params
             $dbUrl: '%env(DATABASE_URL)%'

--- a/src/Menu/MenuBuilder.php
+++ b/src/Menu/MenuBuilder.php
@@ -16,13 +16,14 @@ use App\Entity\User;
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class MenuBuilder
 {
     private string $username;
 
-    public function __construct(private FactoryInterface $factory, TokenStorageInterface $tokenStorage, private TranslatorInterface $translator)
+    public function __construct(private FactoryInterface $factory, TokenStorageInterface $tokenStorage, private TranslatorInterface $translator, private LogoutUrlGenerator $logoutUrlGenerator)
     {
         if ($tokenStorage->getToken() && $tokenStorage->getToken()->getUser() instanceof User) {
             $this->username = $tokenStorage->getToken()->getUser()->getUsername();
@@ -36,7 +37,7 @@ class MenuBuilder
 
         $this->addProfileMenu($menu);
         $menu->addChild('hr', ['label' => '<hr>', 'labelAttributes' => ['class' => 'normal'], 'extras' => ['safe_label' => true]]);
-        $menu->addChild($this->translator->trans('menu.logout'), ['label' => '<span class="icon-off"></span>' . $this->translator->trans('menu.logout'), 'route' => 'logout', 'extras' => ['safe_label' => true]]);
+        $menu->addChild($this->translator->trans('menu.logout'), ['label' => '<span class="icon-off"></span>' . $this->translator->trans('menu.logout'), 'uri' => $this->logoutUrlGenerator->getLogoutPath(), 'extras' => ['safe_label' => true]]);
 
         return $menu;
     }

--- a/templates/bundles/SchebTwoFactorBundle/Authentication/form.html.twig
+++ b/templates/bundles/SchebTwoFactorBundle/Authentication/form.html.twig
@@ -37,7 +37,7 @@
             <hr>
 
             {# The logout link gives the user a way out if they can't complete two-factor authentication #}
-            <a href="{{ logoutPath }}">{{ "cancel"|trans({}, 'SchebTwoFactorBundle') }}</a>
+            <a href="{{ logout_path() }}">{{ "cancel"|trans({}, 'SchebTwoFactorBundle') }}</a>
         </div>
         <div class="clearfix"></div>
     </section>

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -86,7 +86,7 @@
                             </li>
                             <li class="nav-user visible-xs-block">
                                 <section>
-                                    <a href="{{ path('logout') }}">Log out</a>
+                                    <a href="{{ logout_path() }}">Log out</a>
                                 </section>
                             </li>
                         {%- else %}

--- a/templates/user/login.html.twig
+++ b/templates/user/login.html.twig
@@ -5,7 +5,7 @@
 {% block user_content %}
     {% if app.user %}
         <div class="col-xs-6">
-            <p>You are logged in as {{ app.user.username }}, <a href="{{ path('logout') }}">Log out</a></p>
+            <p>You are logged in as {{ app.user.username }}, <a href="{{ logout_path() }}">Log out</a></p>
         </div>
     {% else %}
         <div class="col-xs-12">


### PR DESCRIPTION
Clears the browser cookies, cache + storage on logout. Storage is currently not used as far as I can tell.