### PR TITLE
Email users on account security changes

### DIFF
--- a/src/Controller/ChangePasswordController.php
+++ b/src/Controller/ChangePasswordController.php
@@ -14,6 +14,7 @@ namespace App\Controller;
 
 use App\Entity\User;
 use App\Form\ChangePasswordFormType;
+use App\Security\UserNotifier;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,7 +26,7 @@ class ChangePasswordController extends Controller
 {
     #[IsGranted('ROLE_USER')]
     #[Route(path: '/profile/change-password', name: 'change_password')]
-    public function changePasswordAction(Request $request, UserPasswordHasherInterface $passwordHasher, #[CurrentUser] User $user): Response
+    public function changePasswordAction(Request $request, UserPasswordHasherInterface $passwordHasher, UserNotifier $userNotifier, #[CurrentUser] User $user): Response
     {
         $form = $this->createForm(ChangePasswordFormType::class, $user);
         $form->handleRequest($request);
@@ -41,6 +42,8 @@ class ChangePasswordController extends Controller
 
             $this->getEM()->persist($user);
             $this->getEM()->flush();
+
+            $userNotifier->notifyChange($user->getEmail(), 'Your password has been changed');
 
             return $this->redirectToRoute('my_profile');
         }

--- a/src/Controller/GitHubLoginController.php
+++ b/src/Controller/GitHubLoginController.php
@@ -13,6 +13,7 @@
 namespace App\Controller;
 
 use App\Entity\User;
+use App\Security\UserNotifier;
 use App\Service\Scheduler;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use KnpU\OAuth2ClientBundle\Exception\InvalidStateException;
@@ -72,7 +73,7 @@ class GitHubLoginController extends Controller
      * in config/packages/knpu_oauth2_client.yaml
      */
     #[Route(path: '/connect/github/check', name: 'connect_github_check')]
-    public function connectCheck(Request $request, ClientRegistry $clientRegistry, Scheduler $scheduler, #[CurrentUser] User $user): RedirectResponse
+    public function connectCheck(Request $request, ClientRegistry $clientRegistry, Scheduler $scheduler, UserNotifier $userNotifier, #[CurrentUser] User $user): RedirectResponse
     {
         /** @var \KnpU\OAuth2ClientBundle\Client\Provider\GithubClient $client */
         $client = $clientRegistry->getClient('github');
@@ -113,6 +114,7 @@ class GitHubLoginController extends Controller
             $this->getEM()->flush();
 
             $scheduler->scheduleUserScopeMigration($user->getId(), $oldScope, $user->getGithubScope() ?? '');
+            $userNotifier->notifyChange($user->getEmail(), 'A Github account has been connected to your Packagist.org account.');
 
             $this->addFlash('success', 'You have connected your GitHub account '.$ghUser->getNickname().' to your Packagist.org account.');
         } catch (IdentityProviderException | InvalidStateException $e) {
@@ -133,7 +135,7 @@ class GitHubLoginController extends Controller
     }
 
     #[Route(path: '/oauth/github/disconnect', name: 'user_github_disconnect')]
-    public function disconnect(Request $req, CsrfTokenManagerInterface $csrfTokenManager, #[CurrentUser] User $user): RedirectResponse
+    public function disconnect(Request $req, CsrfTokenManagerInterface $csrfTokenManager, UserNotifier $userNotifier, #[CurrentUser] User $user): RedirectResponse
     {
         if (!$this->isCsrfTokenValid('unlink_github', $req->query->get('token', ''))) {
             throw new AccessDeniedException('Invalid CSRF token');
@@ -143,6 +145,7 @@ class GitHubLoginController extends Controller
             $this->disconnectUser($user);
             $this->getEM()->persist($user);
             $this->getEM()->flush();
+            $userNotifier->notifyChange($user->getEmail(), 'Your GitHub account has been disconnected from your Packagist.org account.');
         }
 
         return $this->redirectToRoute('edit_profile');

--- a/src/Controller/GitHubLoginController.php
+++ b/src/Controller/GitHubLoginController.php
@@ -114,9 +114,9 @@ class GitHubLoginController extends Controller
             $this->getEM()->flush();
 
             $scheduler->scheduleUserScopeMigration($user->getId(), $oldScope, $user->getGithubScope() ?? '');
-            $userNotifier->notifyChange($user->getEmail(), 'A Github account has been connected to your Packagist.org account.');
+            $userNotifier->notifyChange($user->getEmail(), 'A GitHub account ('.$ghUser->getNickname().') has been connected to your Packagist.org account.');
 
-            $this->addFlash('success', 'You have connected your GitHub account '.$ghUser->getNickname().' to your Packagist.org account.');
+            $this->addFlash('success', 'You have connected your GitHub account ('.$ghUser->getNickname().') to your Packagist.org account.');
         } catch (IdentityProviderException | InvalidStateException $e) {
             $this->addFlash('error', 'Failed OAuth Login: '.$e->getMessage());
         }

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -128,8 +128,8 @@ class ProfileController extends Controller
 
         if ($form->isSubmitted() && $form->isValid()) {
             $diffs = array_filter([
-                $oldEmail !== $user->getEmail() ? 'email' : null,
-                $oldUsername !== $user->getUsername() ? 'username' : null,
+                $oldEmail !== $user->getEmail() ? 'email ('.$oldEmail.' => '.$user->getEmail().')' : null,
+                $oldUsername !== $user->getUsername() ? 'username ('.$oldUsername.' => '.$user->getUsername().')' : null,
             ]);
 
             if (!empty($diffs)) {

--- a/src/Security/UserNotifier.php
+++ b/src/Security/UserNotifier.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Security;
+
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
+
+/**
+ * @author Pierre Ambroise <pierre27.ambroise@gmail.com>
+ */
+class UserNotifier
+{
+    private MailerInterface $mailer;
+    private string $mailFromEmail;
+    private string $mailFromName;
+
+    public function __construct(string $mailFromEmail, string $mailFromName, MailerInterface $mailer)
+    {
+        $this->mailer = $mailer;
+        $this->mailFromEmail = $mailFromEmail;
+        $this->mailFromName = $mailFromName;
+    }
+
+    public function notifyChange(string $email, string $reason): void
+    {
+        $email = (new TemplatedEmail())
+            ->from(new Address($this->mailFromEmail, $this->mailFromName))
+            ->to($email)
+            ->subject('A change has been made to your account')
+            ->textTemplate('email/alert_change.txt.twig')
+            ->context([
+                'reason' => $reason,
+            ]);
+
+        $this->mailer->send($email);
+    }
+}

--- a/src/Security/UserNotifier.php
+++ b/src/Security/UserNotifier.php
@@ -1,4 +1,14 @@
-<?php
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Packagist.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *     Nils Adermann <naderman@naderman.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace App\Security;
 

--- a/templates/email/alert_change.txt.twig
+++ b/templates/email/alert_change.txt.twig
@@ -3,7 +3,7 @@
 A critical account security change has been made to your account:
 
 -------------------------------
-Reason: {{ reason }}
+Change: {{ reason }}
 Time: {{ 'now'|date('c') }}
 -------------------------------
 

--- a/templates/email/alert_change.txt.twig
+++ b/templates/email/alert_change.txt.twig
@@ -1,0 +1,10 @@
+{% autoescape false -%}
+
+A critical account security change has been made to your account:
+
+-------------------------------
+Reason: {{ reason }}
+Time: {{ 'now'|date('c') }}
+-------------------------------
+
+{%- endautoescape %}


### PR DESCRIPTION
Fixes #1419

Notifying:

- Username change
- Email change
- Password change
- (Dis)connect github

Move the two-factor authentication notifier in an dedicated class