### PR TITLE
Add node/npm to compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ These steps are provided for development purposes only.
 ### Requirements
 
 - **PHP** for the web app
-- **NPM** for the frontend build
+- **NPM** (or Docker) for the frontend build
 - **[Symfony CLI](https://symfony.com/download)** to run the web server
 - **MySQL** (or Docker) for the main data store
 - **Redis** (or Docker) for some functionality (favorites, download statistics)
@@ -39,8 +39,9 @@ These steps are provided for development purposes only.
    ```
 4. Start MySQL & Redis:
    ```bash
-   docker-compose up -d # or somehow run MySQL & Redis on localhost without docker
+   docker compose up -d # or somehow run MySQL & Redis on localhost without Docker
    ```
+   This mounts the current working directory into the node container and runs npm install and npm run build automatically.
 5. Create 2 databases:
     - `packagist` - for the web app
     - `packagist_test` - for running the tests
@@ -53,7 +54,7 @@ These steps are provided for development purposes only.
    bin/console doctrine:schema:create
    ```
 7. Run a CRON job `bin/console packagist:run-workers` to make sure packages update.
-8. Run `npm run build` or `npm run dev` to build (or build&watch) css/js files.
+8. Run `npm run build` or `npm run dev` to build (or build&watch) css/js files. When using Docker run `docker-compose run node npm run dev` to watch css/js files.
 
 You should now be able to access the site, create a user, etc.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ These steps are provided for development purposes only.
    bin/console doctrine:schema:create
    ```
 7. Run a CRON job `bin/console packagist:run-workers` to make sure packages update.
-8. Run `npm run build` or `npm run dev` to build (or build&watch) css/js files. When using Docker run `docker-compose run node npm run dev` to watch css/js files.
+8. Run `npm run build` or `npm run dev` to build (or build&watch) css/js files. When using Docker run `docker compose run node npm run dev` to watch css/js files.
 
 You should now be able to access the site, create a user, etc.
 

--- a/docker-compose.node.yaml
+++ b/docker-compose.node.yaml
@@ -1,0 +1,7 @@
+services:
+    node:
+        image: 'node:20-alpine'
+        command: ['sh', '-c', 'npm install && npm run build']
+        working_dir: '/app'
+        volumes:
+            - .:/app

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
     database:
         image: mysql:8.0
@@ -9,12 +7,9 @@ services:
             MYSQL_ALLOW_EMPTY_PASSWORD: 1
             MYSQL_DATABASE: packagist
         volumes:
-            - data:/var/lib/mysql
+            - /var/lib/mysql
 
     redis:
         image: redis:6.2-alpine
         ports:
             - 6379:6379
-
-volumes:
-    data:


### PR DESCRIPTION
Does npm install and npm run build once `docker compose up` is used.

Can put this to https://docs.docker.com/compose/profiles/ if needed. But dont think so.

- `version:` is not read from compose v2 anymore (always uses the latest)
- anonymous volumes can be now created without a top level entry in volume