### PR TITLE
Profile: fix edit settings with GitHub connected account

### DIFF
--- a/src/Form/Type/ProfileFormType.php
+++ b/src/Form/Type/ProfileFormType.php
@@ -40,24 +40,25 @@ class ProfileFormType extends AbstractType
                 }
 
                 if (!$user->getGithubId()) {
-                    $event->getForm()->add('current_password', PasswordType::class, [
-                        'label' => 'Current password',
-                        'translation_domain' => 'FOSUserBundle',
-                        'mapped' => false,
-                        'constraints' => [
-                            new NotBlank(),
-                            new UserPassword(),
-                        ],
-                        'attr' => [
-                            'autocomplete' => 'current-password',
-                        ],
-                    ]);
+                    $event->getForm()
+                        ->add('current_password', PasswordType::class, [
+                            'label' => 'Current password',
+                            'translation_domain' => 'FOSUserBundle',
+                            'mapped' => false,
+                            'constraints' => [
+                                new NotBlank(),
+                                new UserPassword(),
+                            ],
+                            'attr' => [
+                                'autocomplete' => 'current-password',
+                            ],
+                        ])
+                        ->add('captcha', InvisibleRecaptchaType::class);
                 }
             });
 
         $builder
-            ->add('failureNotifications', null, ['required' => false, 'label' => 'Notify me of package update failures'])
-            ->add('captcha', InvisibleRecaptchaType::class);
+            ->add('failureNotifications', null, ['required' => false, 'label' => 'Notify me of package update failures']);
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Validator/RateLimitingRecaptchaValidator.php
+++ b/src/Validator/RateLimitingRecaptchaValidator.php
@@ -37,7 +37,7 @@ class RateLimitingRecaptchaValidator extends ConstraintValidator
         }
 
         try {
-            $this->recaptchaVerifier->verify($value);
+            $this->recaptchaVerifier->verify();
         } catch (RecaptchaException) {
             $this->context
                 ->buildViolation($context->hasRecaptcha ? RateLimitingRecaptcha::INVALID_RECAPTCHA_MESSAGE : RateLimitingRecaptcha::MISSING_RECAPTCHA_MESSAGE)


### PR DESCRIPTION
No need to pass `$value` to the verifier. The recaptcha library will extract the correct value from the request.