### PR TITLE
Avoid simple passwords (e.g. email as password)

### DIFF
--- a/src/Controller/ResetPasswordController.php
+++ b/src/Controller/ResetPasswordController.php
@@ -99,7 +99,7 @@ class ResetPasswordController extends Controller
         }
 
         // The token is valid; allow the user to change their password.
-        $form = $this->createForm(ResetPasswordFormType::class, null, ['user' => $user]);
+        $form = $this->createForm(ResetPasswordFormType::class, $user);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/Form/ChangePasswordFormType.php
+++ b/src/Form/ChangePasswordFormType.php
@@ -14,6 +14,7 @@ namespace App\Form;
 
 use App\Entity\User;
 use App\Form\Type\InvisibleRecaptchaType;
+use App\Validator\NotProhibitedPassword;
 use App\Validator\Password;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
@@ -55,6 +56,7 @@ class ChangePasswordFormType extends AbstractType
     {
         $resolver->setDefaults([
             'data_class' => User::class,
+            'constraints' => [new NotProhibitedPassword()],
         ]);
     }
 }

--- a/src/Form/RegistrationFormType.php
+++ b/src/Form/RegistrationFormType.php
@@ -13,6 +13,7 @@
 namespace App\Form;
 
 use App\Entity\User;
+use App\Validator\NotProhibitedPassword;
 use App\Validator\Password;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -53,6 +54,7 @@ class RegistrationFormType extends AbstractType
         $resolver->setDefaults([
             'data_class' => User::class,
             'validation_groups' => ['Default', 'Registration'],
+            'constraints' => new NotProhibitedPassword(),
         ]);
     }
 }

--- a/src/Form/RegistrationFormType.php
+++ b/src/Form/RegistrationFormType.php
@@ -54,7 +54,7 @@ class RegistrationFormType extends AbstractType
         $resolver->setDefaults([
             'data_class' => User::class,
             'validation_groups' => ['Default', 'Registration'],
-            'constraints' => new NotProhibitedPassword(),
+            'constraints' => [new NotProhibitedPassword()],
         ]);
     }
 }

--- a/src/Form/ResetPasswordFormType.php
+++ b/src/Form/ResetPasswordFormType.php
@@ -13,6 +13,7 @@
 namespace App\Form;
 
 use App\Entity\User;
+use App\Validator\NotProhibitedPassword;
 use App\Validator\Password;
 use App\Validator\RateLimitingRecaptcha;
 use App\Validator\TwoFactorCode;
@@ -26,10 +27,10 @@ class ResetPasswordFormType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $resolver
-            ->define('user')
-            ->allowedTypes(User::class)
-            ->required();
+        $resolver->setDefaults([
+            'data_class' => User::class,
+            'constraints' => [new NotProhibitedPassword()],
+        ]);
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
@@ -46,7 +47,7 @@ class ResetPasswordFormType extends AbstractType
             ])
         ;
 
-        if ($options['user']->isTotpAuthenticationEnabled()) {
+        if ($options['data']->isTotpAuthenticationEnabled()) {
             $builder
                 ->add('twoFactorCode', TextType::class, [
                     'label' => 'Two-Factor Code',
@@ -54,7 +55,7 @@ class ResetPasswordFormType extends AbstractType
                     'mapped' => false,
                     'constraints' => [
                         new RateLimitingRecaptcha(),
-                        new TwoFactorCode($options['user']),
+                        new TwoFactorCode($options['data']),
                     ],
                 ]);
         }

--- a/src/Validator/NotProhibitedPassword.php
+++ b/src/Validator/NotProhibitedPassword.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Packagist.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *     Nils Adermann <naderman@naderman.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Validator;
+
+use Attribute;
+use Symfony\Component\Validator\Constraint;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class NotProhibitedPassword extends Constraint
+{
+    public string $message = 'Password should not match your email or any of your names.';
+
+    public function getTargets(): string
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Validator/NotProhibitedPasswordValidator.php
+++ b/src/Validator/NotProhibitedPasswordValidator.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Packagist.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *     Nils Adermann <naderman@naderman.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Validator;
+
+use App\Entity\User;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class NotProhibitedPasswordValidator extends ConstraintValidator
+{
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof NotProhibitedPassword) {
+            throw new UnexpectedTypeException($constraint, NotProhibitedPassword::class);
+        }
+
+        if (!$value instanceof User) {
+            throw new UnexpectedTypeException($value, User::class);
+        }
+
+        $form = $this->context->getRoot();
+        if (!$form instanceof Form) {
+            throw new UnexpectedTypeException($form, Form::class);
+        }
+
+        $user = $value;
+        $password = $form->get('plainPassword')->getData();
+
+        $prohibitedPasswords = [
+            $user->getEmail(),
+            $user->getEmailCanonical(),
+            $user->getUsername(),
+            $user->getUsernameCanonical(),
+        ];
+
+        foreach ($prohibitedPasswords as $prohibitedPassword) {
+            if ($password === $prohibitedPassword) {
+                $this->context
+                    ->buildViolation($constraint->message)
+                    ->atPath('plainPassword')
+                    ->addViolation();
+
+                return;
+            }
+        }
+
+    }
+}

--- a/tests/Controller/ChangePasswordControllerTest.php
+++ b/tests/Controller/ChangePasswordControllerTest.php
@@ -1,0 +1,99 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Packagist.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *     Nils Adermann <naderman@naderman.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Controller;
+
+use App\Entity\User;
+use App\Validator\NotProhibitedPassword;
+use Doctrine\DBAL\Connection;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\TestWith;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class ChangePasswordControllerTest extends WebTestCase
+{
+    private KernelBrowser $client;
+
+    public function setUp(): void
+    {
+        $this->client = self::createClient();
+        $this->client->disableReboot(); // Prevent reboot between requests
+        static::getContainer()->get(Connection::class)->beginTransaction();
+
+        parent::setUp();
+    }
+
+    public function tearDown(): void
+    {
+        static::getContainer()->get(Connection::class)->rollBack();
+
+        parent::tearDown();
+    }
+
+    #[TestWith(['SuperSecret123', 'ok'])]
+    #[TestWith(['test@example.org', 'prohibited-password-error'])]
+    public function testChangePassword(string $newPassword, string $expectedResult): void
+    {
+        $user = new User;
+        $user->setEnabled(true);
+        $user->setUsername('test');
+        $user->setEmail('test@example.org');
+        $user->setPassword('testtest');
+        $user->setApiToken('token');
+        $user->setGithubId('123456');
+
+        $currentPassword = 'current-one-123';
+        $currentPasswordHash = self::getContainer()->get(UserPasswordHasherInterface::class)->hashPassword($user, $currentPassword);
+        $user->setPassword($currentPasswordHash);
+
+        $em = static::getContainer()->get(ManagerRegistry::class)->getManager();
+        $em->persist($user);
+        $em->flush();
+
+        $this->client->loginUser($user);
+
+        $crawler = $this->client->request('GET', '/profile/change-password');
+
+        $form = $crawler->selectButton('Change password')->form();
+        $crawler = $this->client->submit($form, [
+            'change_password_form[current_password]' => $currentPassword,
+            'change_password_form[plainPassword]' => $newPassword,
+        ]);
+
+        if ($expectedResult == 'ok') {
+            $this->assertResponseStatusCodeSame(302);
+
+            $em->clear();
+            $user = $em->getRepository(User::class)->find($user->getId());
+            $this->assertNotNull($user);
+            $this->assertNotSame($currentPasswordHash, $user->getPassword());
+        }
+
+        if ($expectedResult === 'prohibited-password-error') {
+            $this->assertResponseStatusCodeSame(422);
+            $this->assertFormError((new NotProhibitedPassword)->message, $crawler);
+        }
+    }
+
+    private function assertFormError(string $message, Crawler $crawler): void
+    {
+        $formCrawler = $crawler->filter('[name="change_password_form"]');
+        $this->assertCount(
+            1,
+            $formCrawler->filter('.alert-danger:contains("' . $message . '")'),
+            $formCrawler->html()."\nShould find an .alert-danger within the form with the message: '$message'",
+        );
+    }
+}

--- a/tests/Controller/ProfileControllerTest.php
+++ b/tests/Controller/ProfileControllerTest.php
@@ -1,5 +1,15 @@
 <?php declare(strict_types=1);
 
+/*
+ * This file is part of Packagist.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *     Nils Adermann <naderman@naderman.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Tests\Controller;
 
 use App\Entity\User;
@@ -19,6 +29,13 @@ class ProfileControllerTest extends WebTestCase
         static::getContainer()->get(Connection::class)->beginTransaction();
 
         parent::setUp();
+    }
+
+    public function tearDown(): void
+    {
+        static::getContainer()->get(Connection::class)->rollBack();
+
+        parent::tearDown();
     }
 
     public function testEditProfile(): void

--- a/tests/Controller/RegistrationControllerTest.php
+++ b/tests/Controller/RegistrationControllerTest.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Packagist.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *     Nils Adermann <naderman@naderman.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Controller;
+
+use App\Entity\User;
+use App\Tests\Mock\TotpAuthenticatorStub;
+use Doctrine\DBAL\Connection;
+use Doctrine\Persistence\ManagerRegistry;
+use Scheb\TwoFactorBundle\Security\Http\Authenticator\TwoFactorAuthenticator;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+class RegistrationControllerTest extends WebTestCase
+{
+    private KernelBrowser $client;
+
+    public function setUp(): void
+    {
+        $this->client = self::createClient();
+        $this->client->disableReboot(); // Prevent reboot between requests
+        static::getContainer()->get(Connection::class)->beginTransaction();
+
+        parent::setUp();
+    }
+
+    public function tearDown(): void
+    {
+        static::getContainer()->get(Connection::class)->rollBack();
+
+        parent::tearDown();
+    }
+
+    public function testRegisterWithoutOAuth(): void
+    {
+        $crawler = $this->client->request('GET', '/register/');
+        $this->assertResponseStatusCodeSame(200);
+
+        $form = $crawler->filter('[name="registration_form"]')->form();
+        $form->setValues([
+            'registration_form[email]' => 'Max@Example.com',
+            'registration_form[username]' => 'max.example',
+            'registration_form[plainPassword]' => 'SuperSecret123',
+        ]);
+
+        $this->client->submit($form);
+        $this->assertResponseStatusCodeSame(302);
+
+        $em = static::getContainer()->get(ManagerRegistry::class)->getManager();
+        $user = $em->getRepository(User::class)->findOneBy(['username' => 'max.example']);
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertSame('max@example.com', $user->getEmailCanonical(), "user email should have been canonicalized");
+    }
+}


### PR DESCRIPTION
PR changes that you can't use your email address or your username as a password anymore.

We are aware that it's hard in general to get people to use really good passwords, but at least this crosses out the really dumb mistakes.