### PR TITLE
Fix that password reset form was invalid all the time

### DIFF
--- a/src/Controller/ResetPasswordController.php
+++ b/src/Controller/ResetPasswordController.php
@@ -53,14 +53,6 @@ class ResetPasswordController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            try {
-                $recaptchaVerifier->verify();
-            } catch (RecaptchaException $e) {
-                $this->addFlash('error', 'Invalid ReCaptcha. Please try again.');
-
-                return $this->redirectToRoute('request_pwd_reset');
-            }
-
             return $this->processSendingPasswordResetEmail(
                 $form->get('email')->getData(),
                 $mailer


### PR DESCRIPTION
Since the form does now the checking we need to remove the check here.

caused by [#56ecc0a42f6d3f08b9a549152e6c0b6d79c8323e](https://github.com/pscheit/packagist-org/commit/56ecc0a42f6d3f08b9a549152e6c0b6d79c8323e)