### PR TITLE
SecurityAdvisories: changing the remote ID for the same remote advisory should update the source remote ID

### DIFF
--- a/src/Entity/SecurityAdvisorySource.php
+++ b/src/Entity/SecurityAdvisorySource.php
@@ -62,6 +62,7 @@ class SecurityAdvisorySource
 
     public function update(RemoteSecurityAdvisory $advisory): void
     {
+        $this->remoteId = $advisory->id;
         $this->severity = $advisory->severity;
     }
 }

--- a/tests/SecurityAdvisory/SecurityAdvisoryResolverTest.php
+++ b/tests/SecurityAdvisory/SecurityAdvisoryResolverTest.php
@@ -98,6 +98,18 @@ class SecurityAdvisoryResolverTest extends TestCase
         $this->assertNotNull($advisory->getSourceRemoteId('other'));
     }
 
+    public function testResolveRemoteIdChangedSameCve(): void
+    {
+        $remoteAdvisory = $this->createRemoteAdvisory('test', cve: 'CVE-2024-9999999999');
+        $advisory = new SecurityAdvisory($this->createRemoteAdvisory('test', cve: 'CVE-2024-9999999999'), 'test');
+        [$new, $removed] = $this->resolver->resolve([$advisory], new RemoteSecurityAdvisoryCollection([$remoteAdvisory]), 'test');
+
+        $this->assertSame([], $new);
+        $this->assertSame([], $removed);
+
+        $this->assertSame($remoteAdvisory->id, $advisory->getSourceRemoteId('test'));
+    }
+
     public function testResolveEmpty(): void
     {
         [$new, $removed] = $this->resolver->resolve([], new RemoteSecurityAdvisoryCollection([]), 'test');


### PR DESCRIPTION
Happened [here](https://github.com/FriendsOfPHP/security-advisories/pull/722) for example. The filename changes but the advisory is still the same and matches.