### PR TITLE
SecurityAdvisories: skip duplicate GitHub advisories where package name and CVE matches

### DIFF
--- a/src/SecurityAdvisory/GitHubSecurityAdvisoriesSource.php
+++ b/src/SecurityAdvisory/GitHubSecurityAdvisoriesSource.php
@@ -44,6 +44,8 @@ class GitHubSecurityAdvisoriesSource implements SecurityAdvisorySourceInterface
     {
         /** @var array<string, array<string, RemoteSecurityAdvisory>> $advisoryMap */
         $advisoryMap = [];
+        /** @var array<string, array<string, true>> $foundPackageCves */
+        $foundPackageCves = [];
         $hasNextPage = true;
         $after = '';
 
@@ -100,6 +102,15 @@ class GitHubSecurityAdvisoriesSource implements SecurityAdvisorySourceInterface
                 if (isset($advisoryMap[$packageName][$remoteId])) {
                     $advisoryMap[$packageName][$remoteId] = $advisoryMap[$packageName][$remoteId]->withAddedAffectedVersion($versionRange);
                     continue;
+                }
+
+                // GitHub can have multiple advisories per CVE and package
+                if ($cve !== null) {
+                    if (isset($foundPackageCves[$packageName][$cve])) {
+                        continue;
+                    }
+
+                    $foundPackageCves[$packageName][$cve] = true;
                 }
 
                 $references = [];


### PR DESCRIPTION
Noticed for sylius/sylius which has [one](https://github.com/advisories/GHSA-mw82-6m2g-qh6c) and [two](https://github.com/advisories/GHSA-mw82-6m2g-qh6c) advisories for the same CVE

See the [GitHub response](https://github.com/github/advisory-database/issues/3085#issuecomment-1933049782) for reference.