### PR TITLE
feat: add button for rotating API token

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -51,6 +51,11 @@ import 'bootstrap';
             e.preventDefault();
         });
     });
+    $('.btn-rotate-api-token').on('click', function (e) {
+        if (!window.confirm('Are you sure? This will revoke your current API token and generate a new one.')) {
+            e.preventDefault();
+        }
+    });
 
     $('.toc a').click(function (e) {
         setTimeout(function () {

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -154,6 +154,23 @@ class ProfileController extends Controller
         ]);
     }
 
+    #[Route(path: '/profile/token/rotate', name: 'rotate_token', methods: ['POST'])]
+    public function tokenRotateAction(Request $request, UserNotifier $userNotifier): Response
+    {
+        $user = $this->getUser();
+        if (!$user instanceof User) {
+            throw $this->createAccessDeniedException('This user does not have access to this section.');
+        }
+        $user->initializeApiToken();
+
+        $userNotifier->notifyChange($user->getEmail(), 'Your API token has been rotated');
+
+        $this->getEM()->persist($user);
+        $this->getEM()->flush();
+
+        return $this->redirectToRoute('my_profile');
+    }
+
     /**
      * @return Pagerfanta<Package>
      */

--- a/templates/user/my_profile.html.twig
+++ b/templates/user/my_profile.html.twig
@@ -15,6 +15,10 @@
         </div>
 
         <p>{{ 'profile.api_token_explain'|trans({ '%path_about%':path('about') })|raw }}</p>
+        <p>{{ 'profile.api_token_rotate'|trans }}</p>
+        <form class="rotate action" action="{{ path('rotate_token') }}" method="POST">
+            <input class="btn btn-inverse btn-rotate-api-token" type="submit" value="{{ 'profile.api_token_rotate_submit'|trans }}" />
+        </form>
 
         <hr>
     {%- endif %}

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -104,6 +104,9 @@ profile:
     notify_on_failure: Notify me of package update failures
     api_token_explain: |
         You can use your API token to interact with the Packagist API, see details in <a href="%path_about%#how-to-update-packages">the docs</a>.
+    api_token_rotate: |
+        You can rotate your API token and generate a new one at any time.
+    api_token_rotate_submit: Rotate API Token
 
 stats:
     title: Install Statistics


### PR DESCRIPTION
Resolves https://github.com/composer/packagist/issues/1460 - adds a button for rotating API tokens

If you do not like how this looks, we could potentially hide the button with a query flag like `?show-rotate-api-key=1`. Please let me know what you think!

<img width="1191" alt="Screenshot 2024-07-19 at 1 09 13 PM" src="https://github.com/user-attachments/assets/db6f0e05-7028-47f6-9259-1b2dd2444b17">

And upon clicking the button:
<img width="468" alt="Screenshot 2024-07-19 at 1 09 26 PM" src="https://github.com/user-attachments/assets/3a190564-7a22-48a0-9f4e-97a22c801e0a">
