### PR TITLE
Sylius: ignore store.sylius.com issue incorrectly filed as general sylius vulnerability

### DIFF
--- a/src/SecurityAdvisory/GitHubSecurityAdvisoriesSource.php
+++ b/src/SecurityAdvisory/GitHubSecurityAdvisoriesSource.php
@@ -31,6 +31,7 @@ class GitHubSecurityAdvisoriesSource implements SecurityAdvisorySourceInterface
     private const IGNORE_CVES = [
         'CVE-2024-36611', // @see https://phpc.social/@wouterj/113588554019692959
         'CVE-2024-36610', // @see https://phpc.social/@wouterj/113588554019692959
+        'CVE-2024-57610', // store.sylius.com issue incorrectly filed as general sylius vulnerability https://github.com/nca785/CVE-2024-57610
     ];
 
     /**


### PR DESCRIPTION
GitHub Advisory: https://github.com/advisories/GHSA-2hjh-495w-hmxc
Reason to ignore, see: https://github.com/nca785/CVE-2024-57610