### PR TITLE
SecurityAdvisories: GitHub updating the severity of an advisory should store the updated severity

### DIFF
--- a/src/Entity/SecurityAdvisory.php
+++ b/src/Entity/SecurityAdvisory.php
@@ -98,7 +98,8 @@ class SecurityAdvisory
         $this->findSecurityAdvisorySource($advisory->source)?->update($advisory);
 
         $now = new DateTimeImmutable();
-        if (!$this->severity && $advisory->severity) {
+        $allSeverities = $this->sources->map(fn (SecurityAdvisorySource $source) => $source->getSeverity())->toArray();
+        if ($advisory->severity && (!$this->severity || !in_array($this->severity, $allSeverities, true))) {
             $this->updatedAt = $now;
             $this->severity = $advisory->severity;
         }

--- a/tests/Entity/SecurityAdvisoryTest.php
+++ b/tests/Entity/SecurityAdvisoryTest.php
@@ -105,18 +105,18 @@ class SecurityAdvisoryTest extends TestCase
         $this->assertNull($advisory->getSeverity(), "FriendsOfPHP doesn't provide severity information");
         $advisory->addSource($gitHubRemoteAdvisor->id, GitHubSecurityAdvisoriesSource::SOURCE_NAME, null);
         $advisory->updateAdvisory($this->generateGitHubAdvisory(Severity::HIGH));
-        $this->assertSame(Severity::HIGH, $advisory->getSeverity(), "GitHub should update the severity severity");
+        $this->assertSame(Severity::HIGH, $advisory->getSeverity(), "GitHub should update the advisory severity");
         $this->assertSame(Severity::HIGH, $advisory->findSecurityAdvisorySource(GitHubSecurityAdvisoriesSource::SOURCE_NAME)?->getSeverity(), 'GitHub should update the source data');
 
         $advisory->updateAdvisory($this->generateGitHubAdvisory(Severity::MEDIUM));
-        $this->assertSame(Severity::MEDIUM, $advisory->getSeverity(), "GitHub should update the severity severity");
+        $this->assertSame(Severity::MEDIUM, $advisory->getSeverity(), "GitHub should update the advisory severity");
         $this->assertSame(Severity::MEDIUM, $advisory->findSecurityAdvisorySource(GitHubSecurityAdvisoriesSource::SOURCE_NAME)?->getSeverity(), 'GitHub should update the source data');
 
         $advisory->updateAdvisory($friendsOfPhpRemoteAdvisory);
         $this->assertSame(Severity::MEDIUM, $advisory->getSeverity(), "FriendsOfPHP shouldn't reset the severity information");
 
         $advisory->updateAdvisory($this->generateGitHubAdvisory(Severity::HIGH));
-        $this->assertSame(Severity::HIGH, $advisory->getSeverity(), "GitHub should update the severity severity");
+        $this->assertSame(Severity::HIGH, $advisory->getSeverity(), "GitHub should update the advisory severity");
         $this->assertSame(Severity::HIGH, $advisory->findSecurityAdvisorySource(GitHubSecurityAdvisoriesSource::SOURCE_NAME)?->getSeverity(), 'GitHub should update the source data');
     }
 

--- a/tests/Entity/SecurityAdvisoryTest.php
+++ b/tests/Entity/SecurityAdvisoryTest.php
@@ -108,8 +108,16 @@ class SecurityAdvisoryTest extends TestCase
         $this->assertSame(Severity::HIGH, $advisory->getSeverity(), "GitHub should update the severity severity");
         $this->assertSame(Severity::HIGH, $advisory->findSecurityAdvisorySource(GitHubSecurityAdvisoriesSource::SOURCE_NAME)?->getSeverity(), 'GitHub should update the source data');
 
+        $advisory->updateAdvisory($this->generateGitHubAdvisory(Severity::MEDIUM));
+        $this->assertSame(Severity::MEDIUM, $advisory->getSeverity(), "GitHub should update the severity severity");
+        $this->assertSame(Severity::MEDIUM, $advisory->findSecurityAdvisorySource(GitHubSecurityAdvisoriesSource::SOURCE_NAME)?->getSeverity(), 'GitHub should update the source data');
+
         $advisory->updateAdvisory($friendsOfPhpRemoteAdvisory);
-        $this->assertSame(Severity::HIGH, $advisory->getSeverity(), "FriendsOfPHP shouldn't reset the severity information");
+        $this->assertSame(Severity::MEDIUM, $advisory->getSeverity(), "FriendsOfPHP shouldn't reset the severity information");
+
+        $advisory->updateAdvisory($this->generateGitHubAdvisory(Severity::HIGH));
+        $this->assertSame(Severity::HIGH, $advisory->getSeverity(), "GitHub should update the severity severity");
+        $this->assertSame(Severity::HIGH, $advisory->findSecurityAdvisorySource(GitHubSecurityAdvisoriesSource::SOURCE_NAME)?->getSeverity(), 'GitHub should update the source data');
     }
 
     private function generateGitHubAdvisory(Severity|null $severity): RemoteSecurityAdvisory


### PR DESCRIPTION
This currently kept calling `$this->updatedAt = $now;` in the big if block because the severity didn't match, but it didn't actually update the severity.

Should resolve https://github.com/composer/packagist/issues/1508