### PR TITLE
Fix display URL for the package download stats example

### DIFF
--- a/templates/api_doc/index.html.twig
+++ b/templates/api_doc/index.html.twig
@@ -340,7 +340,7 @@ GET https://{{ packagist_host }}/packages/[vendor]/[package]/stats.json
   "date": "2022-09-15" # stats collection start date
 }
 </code></pre>
-<p>Working example: <code><a href="https://{{ packagist_host }}/packages/monolog/monolog/stats.json">https://{{ packagist_host }}/monolog/monolog/stats.json</a></code></p>
+<p>Working example: <code><a href="https://{{ packagist_host }}/packages/monolog/monolog/stats.json">https://{{ packagist_host }}/packages/monolog/monolog/stats.json</a></code></p>
 </section>
 
 


### PR DESCRIPTION
The actual link URL and the docs are correct, but the URL shown in the example missed the `/packages` segment.