### PR TITLE
Add pie information and pie packages to provider pages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
         "scheb/2fa-bundle": "^7",
         "scheb/2fa-totp": "^7",
         "scheb/2fa-trusted-device": "^7",
+        "scienta/doctrine-json-functions": "^6.3",
         "seld/signal-handler": "^2",
         "snc/redis-bundle": "^4.10",
         "symfony/asset": "^7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "35dc71fe24329726c909e49a98a33bb0",
+    "content-hash": "3f8875c20f1001f4de96c3a0df1dcc67",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -5628,6 +5628,78 @@
                 "source": "https://github.com/scheb/2fa-trusted-device/tree/v7.11.0"
             },
             "time": "2025-06-27T12:14:20+00:00"
+        },
+        {
+            "name": "scienta/doctrine-json-functions",
+            "version": "6.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ScientaNL/DoctrineJsonFunctions.git",
+                "reference": "554b2fd281e976a791501fc4753ffd4c5891ec62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ScientaNL/DoctrineJsonFunctions/zipball/554b2fd281e976a791501fc4753ffd4c5891ec62",
+                "reference": "554b2fd281e976a791501fc4753ffd4c5891ec62",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "^3.2 || ^4",
+                "doctrine/lexer": "^2.0 || ^3.0",
+                "doctrine/orm": "^2.19 || ^3",
+                "ext-pdo": "*",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9.0 || ^10.0 || ^11.0 || ^12.0",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^1.12",
+                "phpstan/phpstan-doctrine": "^1.4",
+                "phpstan/phpstan-phpunit": "^1.4",
+                "phpunit/phpunit": "^10.1",
+                "psalm/plugin-phpunit": "^0.18",
+                "slevomat/coding-standard": "~8",
+                "symfony/cache": "^5.4 || ^6.4 || ^7",
+                "vimeo/psalm": "^5.2",
+                "webmozart/assert": "^1.11"
+            },
+            "suggest": {
+                "dunglas/doctrine-json-odm": "To serialize / deserialize objects as JSON documents."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Scienta\\DoctrineJsonFunctions\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Doctrine Json Functions Contributors",
+                    "homepage": "https://github.com/ScientaNL/DoctrineJsonFunctions/contributors"
+                }
+            ],
+            "description": "A set of extensions to Doctrine that add support for json query functions.",
+            "keywords": [
+                "database",
+                "doctrine",
+                "dql",
+                "json",
+                "mariadb",
+                "mysql",
+                "orm",
+                "postgres",
+                "postgresql",
+                "sqlite"
+            ],
+            "support": {
+                "issues": "https://github.com/ScientaNL/DoctrineJsonFunctions/issues",
+                "source": "https://github.com/ScientaNL/DoctrineJsonFunctions/tree/6.3.0"
+            },
+            "time": "2024-11-08T12:33:19+00:00"
         },
         {
             "name": "seld/jsonlint",

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -13,6 +13,9 @@ doctrine:
         enable_lazy_ghost_objects: true
         report_fields_where_declared: true
         auto_mapping: true
+        dql:
+            string_functions:
+                JSON_EXTRACT: Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql\JsonExtract
         mappings:
             App:
                 is_bundle: false

--- a/css/app.scss
+++ b/css/app.scss
@@ -1419,6 +1419,9 @@ input:focus:invalid:focus, textarea:focus:invalid:focus, select:focus:invalid:fo
 .package .version-details .package-links .no-links {
     color: #999;
 }
+.package .version-details .pie-metadata {
+  border-top: 1px solid #f28d1a;
+}
 
 .package .requireme {
     margin-top: 15px;

--- a/src/Entity/Package.php
+++ b/src/Entity/Package.php
@@ -675,7 +675,7 @@ class Package
 
     public function getInstallCommand(?Version $version = null): string
     {
-        if (\in_array($this->getType(), ['php-ext', 'php-ext-zend'], true)) {
+        if ($this->isPiePackage()) {
             return 'pie install '.$this->getName();
         }
 
@@ -690,6 +690,11 @@ class Package
         }
 
         return \sprintf('composer %s %s', $command, $this->getName());
+    }
+
+    public function isPiePackage(): bool
+    {
+        return \in_array($this->getType(), ['php-ext', 'php-ext-zend'], true);
     }
 
     public function setRemoteId(?string $remoteId): void

--- a/src/Entity/Version.php
+++ b/src/Entity/Version.php
@@ -710,6 +710,41 @@ class Version
         $this->phpExt = $phpExt;
     }
 
+    public function getPieName(): ?string
+    {
+        if (!$this->isPiePackage()) {
+            return null;
+        }
+        $name = $this->getPhpExt()['extension-name'] ?? explode('/', $this->getName())[1];
+
+        if (!str_starts_with($name, 'ext-')) {
+            $name = 'ext-'.$name;
+        }
+
+        return $name;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getPieSupportedOS(): array
+    {
+        if (!$this->isPiePackage()) {
+            return [];
+        }
+
+        if (isset($this->phpExt['os-families'])) {
+            return $this->phpExt['os-families'];
+        }
+
+        return array_values(array_diff(["windows", "bsd", "darwin", "solaris", "linux", "unknown"], $this->phpExt['os-families-exclude'] ?? ['any']));
+    }
+
+    public function isPiePackage(): bool
+    {
+        return \in_array($this->getType(), ['php-ext', 'php-ext-zend'], true);
+    }
+
     public function isDefaultBranch(): bool
     {
         return $this->isDefaultBranch;

--- a/templates/macros.html.twig
+++ b/templates/macros.html.twig
@@ -12,7 +12,7 @@
                         <div class="col-sm-9 col-lg-10">
                             {% if package.language is defined and package.language is not empty %}<p class="pull-right language">{{ package.language }}</p>{% endif %}
                             <h4 class="font-bold">
-                                <a href="{{ packageUrl }}">{{ package.name }}</a>
+                                <a href="{{ packageUrl }}">{{ package.name }}</a>{% if package.type in ['php-ext', 'php-ext-zend'] %}<span title="PIE installable extension package">🥧</span>{% endif %}
                                 {% if package.id is not numeric %}
                                     <small>(Virtual Package)</small>
                                 {% endif %}

--- a/templates/package/version_details.html.twig
+++ b/templates/package/version_details.html.twig
@@ -63,3 +63,20 @@
         </p>
     {% endif %}
 </div>
+
+{% if version.isPiePackage() %}
+<div class="pie-metadata">
+    <p class="pie-extension">Extension name: {{ version.pieName }}</p>
+    <p class="pie-details">Supports Zend Thread Safety (ZTS): {{ version.phpExt['support-zts']|default(true)|json_encode }}</p>
+    <p class="pie-details">Supports non-Thread Safe mode (NTS): {{ version.phpExt['support-nts']|default(true)|json_encode }}</p>
+    <p class="pie-details">Supported operating systems: {% for os in version.pieSupportedOS %}{{ os }}{% if not loop.last %}, {% endif %}{% endfor %}</p>
+    {% if version.phpExt['configure-options']|default([])|length %}
+        <p class="pie-details">Configure flags:</p>
+        <ul>
+            {% for flag in version.phpExt['configure-options']|default([]) %}
+            <li><code>--{{ flag.name }}{% if flag['needs-value']|default(false) %}=&lt;value&gt;{% endif %}</code> {{ flag.description|default('') }}</li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+</div>
+{% endif %}

--- a/templates/package/view_package.html.twig
+++ b/templates/package/view_package.html.twig
@@ -270,6 +270,9 @@
                             {% if package.type is not empty and package.type != 'library' %}
                                 <p><span>Type:</span>{{ package.type }}</p>
                             {% endif %}
+                            {% if package.isPiePackage() %}
+                                <p><span>Ext name:</span>{{ version.pieName }}</p>
+                            {% endif %}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Fixes #1494, fixes #1489

cc @alcaeus @stof

<img width="1426" height="1263" alt="image" src="https://github.com/user-attachments/assets/fb43bc6e-8708-4b19-ab8c-baa12fe8881e" />

I added a pie too next to pie packages in listings

<img width="1632" height="422" alt="image" src="https://github.com/user-attachments/assets/7af01fa3-7398-47ba-9862-876620b973bd" />
