### PR TITLE
Local setup: ignore port

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "php": "^8.4",
         "ext-ctype": "*",
         "ext-iconv": "*",
+        "ext-apcu": "*",
         "algolia/algoliasearch-client-php": "^3.0",
         "babdev/pagerfanta-bundle": "^4.2",
         "beelab/recaptcha2-bundle": "^2.3",

--- a/src/EventListener/OriginListener.php
+++ b/src/EventListener/OriginListener.php
@@ -51,14 +51,15 @@ class OriginListener
         }
 
         // valid origin
-        $origin = $event->getRequest()->headers->get('Origin');
+        $origin = $event->getRequest()->headers->get('Origin') ?? '';
         if ($origin === 'https://'.$this->packagistHost) {
             return;
         }
 
         // valid as well with HTTP in dev
-        $parts = parse_url($origin);
-        $knownOrigin = $parts['scheme'].'://'.$parts['host'];
+        $scheme = parse_url($origin, PHP_URL_SCHEME);
+        $host = parse_url($origin, PHP_URL_HOST);
+        $knownOrigin = $scheme.'://'.$host;
         if ('dev' === $this->environment && $knownOrigin === 'http://'.$this->packagistHost) {
             return;
         }

--- a/src/EventListener/OriginListener.php
+++ b/src/EventListener/OriginListener.php
@@ -51,12 +51,15 @@ class OriginListener
         }
 
         // valid origin
-        if ($event->getRequest()->headers->get('Origin') === 'https://'.$this->packagistHost) {
+        $origin = $event->getRequest()->headers->get('Origin');
+        if ($origin === 'https://'.$this->packagistHost) {
             return;
         }
 
         // valid as well with HTTP in dev
-        if ('dev' === $this->environment && $event->getRequest()->headers->get('Origin') === 'http://'.$this->packagistHost) {
+        $parts = parse_url($origin);
+        $knownOrigin = $parts['scheme'].'://'.$parts['host'];
+        if ('dev' === $this->environment && $knownOrigin === 'http://'.$this->packagistHost) {
             return;
         }
 


### PR DESCRIPTION
Just a small change to make local setup work out of the box with the instructions in README, because `symfony serve` runs on port 8000 it won't allow POST requests. 