### PR TITLE
Unify user formats and ensure actor is always set explicitly

### DIFF
--- a/src/Audit/Display/AuditLogDisplayFactory.php
+++ b/src/Audit/Display/AuditLogDisplayFactory.php
@@ -15,7 +15,6 @@ namespace App\Audit\Display;
 use App\Audit\AuditRecordType;
 use App\Audit\UserRegistrationMethod;
 use App\Entity\AuditRecord;
-use App\Audit\Display\TwoFaDeactivatedDisplay;
 use App\Entity\User;
 use Symfony\Bundle\SecurityBundle\Security;
 
@@ -120,38 +119,38 @@ class AuditLogDisplayFactory
             ),
             AuditRecordType::UserCreated => new UserCreatedDisplay(
                 $record->datetime,
-                $record->attributes['username'],
+                $record->attributes['user']['username'],
                 UserRegistrationMethod::from($record->attributes['method']),
-                $this->buildActor(null),
+                $this->buildActor('self'),
             ),
             AuditRecordType::TwoFaAuthenticationActivated => new GenericUserDisplay(
                 $record->type,
                 $record->datetime,
-                $record->attributes['username'],
+                $record->attributes['user']['username'],
                 $this->buildActor($record->attributes['actor']),
             ),
             AuditRecordType::TwoFaAuthenticationDeactivated => new TwoFaDeactivatedDisplay(
                 $record->datetime,
-                $record->attributes['username'],
+                $record->attributes['user']['username'],
                 $record->attributes['reason'],
                 $this->buildActor($record->attributes['actor']),
             ),
             AuditRecordType::PasswordResetRequested, AuditRecordType::PasswordReset, AuditRecordType::PasswordChanged => new GenericUserDisplay(
                 $record->type,
                 $record->datetime,
-                $record->attributes['user']['username'] ?? 'unknown',
-                $this->buildACtor($record->attributes['actor'] ?? null),
+                $record->attributes['user']['username'],
+                $this->buildActor($record->attributes['actor']),
             ),
             AuditRecordType::UserVerified => new UserVerifiedDisplay(
                 $record->datetime,
-                $this->buildActor($record->attributes['user'] ?? null),
-                $this->obfuscateEmail($record->attributes['email'], $record->attributes['user']['id'] ?? null),
-                $this->buildActor(null),
+                $record->attributes['user']['username'],
+                $this->obfuscateEmail($record->attributes['email'], $record->attributes['user']['id']),
+                $this->buildActor($record->attributes['actor']),
             ),
             AuditRecordType::UserDeleted => new UserDeletedDisplay(
                 $record->datetime,
-                $record->attributes['user']['username'] ?? 'unknown',
-                $this->buildActor($record->attributes['actor'] ?? null),
+                $record->attributes['user']['username'],
+                $this->buildActor($record->attributes['actor']),
             ),
             default => throw new \LogicException(sprintf('Unsupported audit record type: %s', $record->type->value)),
         };

--- a/src/Audit/Display/UserVerifiedDisplay.php
+++ b/src/Audit/Display/UserVerifiedDisplay.php
@@ -19,7 +19,7 @@ readonly class UserVerifiedDisplay extends AbstractAuditLogDisplay
 {
     public function __construct(
         \DateTimeImmutable $datetime,
-        public ActorDisplay $user,
+        public string $username,
         public string $email,
         ActorDisplay $actor,
     ) {

--- a/src/Controller/ChangePasswordController.php
+++ b/src/Controller/ChangePasswordController.php
@@ -42,7 +42,7 @@ class ChangePasswordController extends Controller
             );
 
             $this->getEM()->persist($user);
-            $this->getEM()->persist(AuditRecord::passwordChanged($user));
+            $this->getEM()->persist(AuditRecord::passwordChanged($user, $user));
             $this->getEM()->flush();
 
             $userNotifier->notifyChange($user->getEmail(), 'Your password has been changed');

--- a/src/Controller/ResetPasswordController.php
+++ b/src/Controller/ResetPasswordController.php
@@ -108,7 +108,7 @@ class ResetPasswordController extends Controller
 
             $user->setPassword($encodedPassword);
             $this->getEM()->persist($user);
-            $this->getEM()->persist(AuditRecord::passwordReset($user));
+            $this->getEM()->persist(AuditRecord::passwordReset($user, $user));
             $this->getEM()->flush();
 
             try {

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -291,7 +291,7 @@ class UserController extends Controller
         if ($form->isSubmitted() && $form->isValid()) {
             $user->setTotpSecret($secret);
             $req->getSession()->remove('2fa_secret');
-            $authManager->enableTwoFactorAuth($user, $secret);
+            $authManager->enableTwoFactorAuth($user, $loggedUser, $secret);
             $backupCode = $authManager->generateAndSaveNewBackupCode($user);
 
             $this->addFlash('success', 'Two-factor authentication has been enabled.');
@@ -354,7 +354,7 @@ class UserController extends Controller
         }
 
         if ($this->isCsrfTokenValid('disable_2fa', $req->query->getString('token'))) {
-            $authManager->disableTwoFactorAuth($user, $user->getId() === $loggedUser->getId() ? 'Manually disabled' : 'Disabled on request from user');
+            $authManager->disableTwoFactorAuth($user, $loggedUser, $user->getId() === $loggedUser->getId() ? 'Manually disabled' : 'Disabled on request from user');
 
             $this->addFlash('success', 'Two-factor authentication has been disabled.');
 

--- a/src/Entity/AuditRecord.php
+++ b/src/Entity/AuditRecord.php
@@ -142,53 +142,53 @@ class AuditRecord
         return new self(
             AuditRecordType::UserCreated,
             [
-                'username' => $user->getUsernameCanonical(),
+                'user' => self::getUserData($user),
                 'method' => $method->value,
-                'actor' => 'unknown',
+                'actor' => 'self',
             ],
             userId: $user->getId(),
         );
     }
 
-    public static function twoFactorAuthenticationActivated(User $user): self
+    public static function twoFactorAuthenticationActivated(User $user, User $actor): self
     {
         return new self(
             AuditRecordType::TwoFaAuthenticationActivated,
             [
-                'username' => $user->getUsernameCanonical(),
-                'actor' => self::getUserData($user),
+                'user' => self::getUserData($user),
+                'actor' => self::getUserData($actor),
             ],
-            actorId: $user->getId(),
+            actorId: $actor->getId(),
             userId: $user->getId(),
         );
     }
 
-    public static function twoFactorAuthenticationDeactivated(User $user, string $reason): self
+    public static function twoFactorAuthenticationDeactivated(User $user, User $actor, string $reason): self
     {
         return new self(
             AuditRecordType::TwoFaAuthenticationDeactivated,
             [
-                'username' => $user->getUsernameCanonical(),
-                'actor' => self::getUserData($user),
+                'user' => self::getUserData($user),
+                'actor' => self::getUserData($actor),
                 'reason' => $reason,
             ],
-            actorId: $user->getId(),
+            actorId: $actor->getId(),
         );
     }
 
-    public static function passwordReset(User $user): self
+    public static function passwordReset(User $user, User $actor): self
     {
-        return new self(type: AuditRecordType::PasswordReset, attributes: ['user' => self::getUserData($user), 'actor' => self::getUserData($user)], actorId: $user->getId(), userId: $user->getId());
+        return new self(type: AuditRecordType::PasswordReset, attributes: ['user' => self::getUserData($user), 'actor' => self::getUserData($actor)], actorId: $user->getId(), userId: $user->getId());
     }
 
-    public static function passwordChanged(User $user): self
+    public static function passwordChanged(User $user, User $actor): self
     {
-        return new self(AuditRecordType::PasswordChanged, ['user' => self::getUserData($user), 'actor' => self::getUserData($user)], actorId: $user->getId(), userId: $user->getId());
+        return new self(AuditRecordType::PasswordChanged, ['user' => self::getUserData($user), 'actor' => self::getUserData($actor)], actorId: $actor->getId(), userId: $user->getId());
     }
 
     public static function passwordResetRequested(User $user): self
     {
-        return new self(AuditRecordType::PasswordResetRequested, ['user' => self::getUserData($user), 'actor' => self::getUserData($user)], actorId: $user->getId(), userId: $user->getId());
+        return new self(AuditRecordType::PasswordResetRequested, ['user' => self::getUserData($user), 'actor' => 'anonymous'], userId: $user->getId());
     }
 
     public static function userDeleted(User $user, ?User $actor): self
@@ -197,16 +197,16 @@ class AuditRecord
             AuditRecordType::UserDeleted,
             [
                 'user' => self::getUserData($user),
-                'actor' => self::getUserData($actor),
+                'actor' => self::getUserData($actor, 'automation'),
             ],
             actorId: $actor?->getId(),
             userId: $user->getId(),
         );
     }
 
-    public static function userVerified(User $user, string $email): self
+    public static function userVerified(User $user, User $actor, string $email): self
     {
-        return new self(AuditRecordType::UserVerified, ['user' => self::getUserdata($user), 'email' => $email, 'actor' => 'unknown'], userId: $user->getId());
+        return new self(AuditRecordType::UserVerified, ['user' => self::getUserdata($user), 'email' => $email, 'actor' => self::getUserData($actor)], userId: $user->getId(), actorId: $actor->getId());
     }
 
     /**

--- a/src/Security/EmailVerifier.php
+++ b/src/Security/EmailVerifier.php
@@ -70,7 +70,7 @@ class EmailVerifier
         $this->verifyEmailHelper->validateEmailConfirmationFromRequest($request, (string) $user->getId(), $emailToVerify);
         $user->setEnabled(true);
 
-        $this->getEM()->persist(AuditRecord::userVerified($user, $emailToVerify));
+        $this->getEM()->persist(AuditRecord::userVerified($user, $user, $emailToVerify));
         $this->getEM()->persist($user);
         $this->getEM()->flush();
     }

--- a/templates/audit_log/display/user_verified.html.twig
+++ b/templates/audit_log/display/user_verified.html.twig
@@ -1,2 +1,2 @@
-<strong>{{ display.user.username }}</strong><br>
+<strong>{{ display.username }}</strong><br>
 Email: {{ display.email }}

--- a/tests/Audit/Display/AuditLogDisplayFactoryTest.php
+++ b/tests/Audit/Display/AuditLogDisplayFactoryTest.php
@@ -373,7 +373,7 @@ class AuditLogDisplayFactoryTest extends TestCase
 
         $display = $this->factory->buildSingle($auditRecord);
         self::assertInstanceOf(UserVerifiedDisplay::class, $display);
-        self::assertSame('johndoe', $display->user->username);
+        self::assertSame('johndoe', $display->username);
         self::assertSame($expectedEmail, $display->email);
     }
 
@@ -440,7 +440,7 @@ class AuditLogDisplayFactoryTest extends TestCase
         $auditRecord = $this->createAuditRecord(
             AuditRecordType::TwoFaAuthenticationActivated,
             [
-                'username' => 'testuser',
+                'user' => ['id' => 1234, 'username' => 'testuser1234'],
                 'actor' => ['id' => 123, 'username' => 'testuser'],
             ]
         );
@@ -448,7 +448,7 @@ class AuditLogDisplayFactoryTest extends TestCase
         $display = $this->factory->buildSingle($auditRecord);
 
         self::assertInstanceOf(GenericUserDisplay::class, $display);
-        self::assertSame('testuser', $display->username);
+        self::assertSame('testuser1234', $display->username);
         self::assertSame(123, $display->actor->id);
         self::assertSame('testuser', $display->actor->username);
         self::assertSame(AuditRecordType::TwoFaAuthenticationActivated, $display->getType());
@@ -459,7 +459,7 @@ class AuditLogDisplayFactoryTest extends TestCase
         $auditRecord = $this->createAuditRecord(
             AuditRecordType::TwoFaAuthenticationDeactivated,
             [
-                'username' => 'testuser',
+                'user' => ['id' => 1234, 'username' => 'testuser1234'],
                 'reason' => 'Manually disabled',
                 'actor' => ['id' => 123, 'username' => 'testuser'],
             ]
@@ -468,7 +468,7 @@ class AuditLogDisplayFactoryTest extends TestCase
         $display = $this->factory->buildSingle($auditRecord);
 
         self::assertInstanceOf(TwoFaDeactivatedDisplay::class, $display);
-        self::assertSame('testuser', $display->username);
+        self::assertSame('testuser1234', $display->username);
         self::assertSame('Manually disabled', $display->reason);
         self::assertSame(123, $display->actor->id);
         self::assertSame('testuser', $display->actor->username);

--- a/tests/Controller/RegistrationControllerTest.php
+++ b/tests/Controller/RegistrationControllerTest.php
@@ -56,7 +56,7 @@ class RegistrationControllerTest extends IntegrationTestCase
             'userId' => $user->getId(),
         ]);
         $this->assertInstanceOf(AuditRecord::class, $log);
-        $this->assertSame($user->getUsernameCanonical(), $log->attributes['username'] ?? null);
+        $this->assertSame($user->getUsernameCanonical(), $log->attributes['user']['username']);
         $this->assertSame(UserRegistrationMethod::REGISTRATION_FORM->value, $log->attributes['method'] ?? null);
     }
 


### PR DESCRIPTION
I added $actor everywhere so the caller is forced to make a decision on who the actor is. I know in some cases like password change right now this is always going to be the same as $user, but not having it in the API means if we add another way to change password like for admins for example then it'd be easy to shoot yourself in the foot there and forget to edit the code to add an $actor argument at that point.