### PR TITLE
Tests: clean up `setRepository()` calls

### DIFF
--- a/tests/Audit/VersionAuditRecordTest.php
+++ b/tests/Audit/VersionAuditRecordTest.php
@@ -18,6 +18,7 @@ use App\Entity\Package;
 use App\Entity\RequireLink;
 use App\Entity\Version;
 use App\Event\VersionReferenceChangedEvent;
+use App\Tests\Fixtures\Fixtures;
 use Doctrine\DBAL\Connection;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -26,6 +27,8 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class VersionAuditRecordTest extends KernelTestCase
 {
+    use Fixtures;
+
     protected function setUp(): void
     {
         self::bootKernel();
@@ -133,9 +136,7 @@ class VersionAuditRecordTest extends KernelTestCase
         $container = static::getContainer();
         $em = $container->get(ManagerRegistry::class)->getManager();
 
-        $package = new Package();
-        $package->setName('composer/composer');
-        $package->setRepository('https://github.com/composer/composer');
+        $package = self::createPackage('composer/composer', 'https://github.com/composer/composer');
 
         $version = new Version();
         $version->setPackage($package);

--- a/tests/Fixtures/Fixtures.php
+++ b/tests/Fixtures/Fixtures.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Tests\Fixtures;
+
+use App\Entity\Package;
+use App\Entity\User;
+
+trait Fixtures
+{
+    /**
+     * Creates a Package entity without running the slow network-based repository initialization step
+     *
+     * @param array<User> $maintainers
+     */
+    protected static function createPackage(string $name, string $repository, ?string $remoteId = null, array $maintainers = []): Package
+    {
+        $package = new Package();
+
+        $package->setName($name);
+        $package->setRemoteId($remoteId);
+        new \ReflectionProperty($package, 'repository')->setValue($package, $repository);
+        if (\count($maintainers) > 0) {
+            foreach ($maintainers as $user) {
+                $package->addMaintainer($user);
+                $user->addPackage($package);
+            }
+        }
+
+        return $package;
+    }
+
+    /**
+     * @param array<string> $roles
+     */
+    protected static function createUser(string $username = 'test', string $email = 'test@example.org', string $password = 'testtest', string $apiToken = 'api-token', string $safeApiToken = 'safe-api-token', string $githubId = '12345', bool $enabled = true, array $roles = []): User
+    {
+        $user = new User();
+        $user->setEnabled($enabled);
+        $user->setUsername($username);
+        $user->setEmail($email);
+        $user->setPassword($password);
+        $user->setApiToken($apiToken);
+        $user->setSafeApiToken($safeApiToken);
+        $user->setGithubId($githubId);
+        $user->setRoles($roles);
+
+        return $user;
+    }
+}

--- a/tests/IntegrationTestCase.php
+++ b/tests/IntegrationTestCase.php
@@ -12,8 +12,7 @@
 
 namespace App\Tests;
 
-use App\Entity\Package;
-use App\Entity\User;
+use App\Tests\Fixtures\Fixtures;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
@@ -23,6 +22,8 @@ use Symfony\Component\DomCrawler\Crawler;
 
 class IntegrationTestCase extends WebTestCase
 {
+    use Fixtures;
+
     protected KernelBrowser $client;
 
     protected function setUp(): void
@@ -74,45 +75,5 @@ class IntegrationTestCase extends WebTestCase
         }
 
         $em->flush();
-    }
-
-    /**
-     * Creates a Package entity without running the slow network-based repository initialization step
-     *
-     * @param array<User> $maintainers
-     */
-    protected static function createPackage(string $name, string $repository, ?string $remoteId = null, array $maintainers = []): Package
-    {
-        $package = new Package();
-
-        $package->setName($name);
-        $package->setRemoteId($remoteId);
-        new \ReflectionProperty($package, 'repository')->setValue($package, $repository);
-        if (\count($maintainers) > 0) {
-            foreach ($maintainers as $user) {
-                $package->addMaintainer($user);
-                $user->addPackage($package);
-            }
-        }
-
-        return $package;
-    }
-
-    /**
-     * @param array<string> $roles
-     */
-    protected static function createUser(string $username = 'test', string $email = 'test@example.org', string $password = 'testtest', string $apiToken = 'api-token', string $safeApiToken = 'safe-api-token', string $githubId = '12345', bool $enabled = true, array $roles = []): User
-    {
-        $user = new User();
-        $user->setEnabled($enabled);
-        $user->setUsername($username);
-        $user->setEmail($email);
-        $user->setPassword($password);
-        $user->setApiToken($apiToken);
-        $user->setSafeApiToken($safeApiToken);
-        $user->setGithubId($githubId);
-        $user->setRoles($roles);
-
-        return $user;
     }
 }

--- a/tests/Model/PackageManagerTest.php
+++ b/tests/Model/PackageManagerTest.php
@@ -37,8 +37,7 @@ class PackageManagerTest extends IntegrationTestCase
 
         $client = self::createClient();
 
-        $package = new Package();
-        $package->setRepository($url);
+        $package = self::createPackage('composer/composer', 'https://github.com/composer/composer');
 
         $user = new User();
         $user->addPackage($package);


### PR DESCRIPTION
Cleans up the `setRepository()` calls we recently added, so that the time to run the tests is back to normal. 

Before:

> Time: 00:21.569, Memory: 93.00 MB

After:

> Time: 00:06.524, Memory: 91.00 MB
