### PR TITLE
Fix the package dependent list

### DIFF
--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -1365,13 +1365,13 @@ class PackageController extends Controller
         $depCount = $repo->getDependentCount($name, $requireType);
         $packages = $repo->getDependents($name, ($page - 1) * $perPage, $perPage, $orderBy, $requireType);
 
-        $requires = $repo->getDefaultBranchRequireFor(array_column($packages, 'name'), $name);
+        $requirements = $repo->getDefaultBranchRequireFor(array_column($packages, 'name'), $name);
         foreach ($packages as $index => $pkg) {
-            if (isset($requires[$pkg['name']])) {
+            if (isset($requirements[$pkg['name']])) {
                 if ($req->getRequestFormat() === 'json') {
-                    $packages[$index]['require'] = $requires[$pkg['name']];
+                    $packages[$index]['require'] = $requirements[$pkg['name']];
                 } else {
-                    $packages[$index]['meta'] = 'Latest version requires '.$name.' '.$requires[$pkg['name']];
+                    $packages[$index]['meta'] = 'Latest version requires '.$name.' '.$requirements[$pkg['name']];
                 }
             }
         }


### PR DESCRIPTION
The `$requires` variable name was used for 2 different variables, breaking the value passed to the template.

Fixes https://github.com/composer/packagist/issues/1673