### PR TITLE
Avoid crashing other JS of the page if algolia is not configured

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -39,7 +39,7 @@ if (decodeURI(location.search).match(/[<>]/)) {
 }
 
 var searchThrottle = null;
-var search = instantsearch({
+var opts = {
     appId: algoliaConfig.app_id,
     apiKey: algoliaConfig.search_key,
     indexName: algoliaConfig.index_name,
@@ -112,7 +112,22 @@ var search = instantsearch({
         }, 300);
     },
     searchParameters: searchParameters
-});
+}
+// If the search does not work (for example if the environment does not have
+// algolia configured), we don't want to break the entire page, so we wrap it in
+// a try/catch.
+var search;
+try {
+    search = instantsearch(opts);
+} catch (e) {
+    console.error('Error initializing search', e);
+    // We create a dummy search object with a no-op addWidget and start function
+    // to avoid errors in the rest of the code.
+    search = {
+        addWidget: function() {},
+        start: function() {}
+    };
+}
 
 var autofocus = false;
 if (location.pathname == "/" || location.pathname == "/explore/") {


### PR DESCRIPTION
Howdy :cowboy_hat_face: 

I was setting up the project locally, and noticed that if I did not explicitly configure algolia, I would not get all of the JS of the app executed, as it would crash upon importing the search.js file.

This makes (among other things, this is just an example) the toggling of the user tokens not work, if algolia is not configured.

Realistically, this is not a problem when deploying the actual packagist.org website. But it makes for a somewhat potential frustrating, and maybe "frictionful", developer experience when attempting to start the project locally :v: 

In this PR we try catch the instantiating of the algolia search, and as a fallback configure no-ops for the methods that are about to be called in the lines following this code path. Personally I would prefer it to be possible to return early if we do not have the algolia setup, but this would make for a much "worse" diff to review, as one cannot simply return from the top level scope in an import like that :sweat_smile: 