### PR TITLE
About: remove mention of unmonitored IRC channel, clean up text

### DIFF
--- a/templates/about/about.html.twig
+++ b/templates/about/about.html.twig
@@ -3,8 +3,6 @@
 {% block content %}
     <h2 class="title">What is Packagist?</h2>
     <p>Packagist is the default Composer package repository. It lets you find packages and lets Composer know where to get the code from. You can use Composer to manage your project or libraries' dependencies - read more about it on the <a href="https://getcomposer.org/">Composer website</a>.</p>
-    <p>You can find the packagist.org source on <a href="https://github.com/composer/packagist">GitHub</a>.</p>
-
     <section class="row">
         <div class="clearfix"></div>
 
@@ -20,7 +18,7 @@
         <section class="col-md-6">
             <h3 id="sponsoring">Sponsoring</h3>
             <p>The best way to financially support the hosting and maintenance of Packagist.org and Composer is by using <a href="https://packagist.com">Private Packagist</a>. It helps you install packages fast and reliably, provides you with a private package repository, and the proceeds go directly towards Packagist.org and Composer maintenance.</p>
-            <p>For other ways to sponsor the project, visit our <a href="/sponsor/">sponsors page</a>.</p>
+            <p>For other ways to sponsor the project, visit our <a href="{{ path('sponsor') }}">sponsors page</a>.</p>
         </section>
     </section>
 


### PR DESCRIPTION
Also mentions explicitly that commercial Support & Consulting are offered through Private Packagist subscription plans.