### PR TITLE
TransparencyLog: fix query performance

### DIFF
--- a/src/Controller/TransparencyLogController.php
+++ b/src/Controller/TransparencyLogController.php
@@ -66,7 +66,7 @@ class TransparencyLogController extends Controller
                 AuditRecordType::TwoFaAuthenticationDeactivated->value,
             ]);
 
-        $auditLogs = new Pagerfanta(new QueryAdapter($qb, true));
+        $auditLogs = new Pagerfanta(new QueryAdapter($qb, false));
         $auditLogs->setNormalizeOutOfRangePages(true);
         $auditLogs->setMaxPerPage(20);
         $auditLogs->setCurrentPage(max(1, $request->query->getInt('page', 1)));


### PR DESCRIPTION
As long as the log query doesn't do any joins we can use a simplified version of the queries generated by Pagerfanta.

### Instead of
<img width="1015" height="730" alt="Screenshot 2026-03-04 at 10 09 59" src="https://github.com/user-attachments/assets/3d2332c2-759d-42c2-8c12-faa3553d6cb9" />

### This becomes
<img width="988" height="803" alt="Screenshot 2026-03-04 at 10 07 05" src="https://github.com/user-attachments/assets/123e2b00-75fa-42ba-8056-df197b10bcab" />
