### PR TITLE
FilterLists: unified malware list with source property instead of multiple malware lists

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -58,7 +58,7 @@ parameters:
         PackageUpdateJob: 'array{id: int, update_equal_refs: bool, delete_before: bool, force_dump: bool, source: string}'
         GitHubUserMigrateJob: 'array{id: int, old_scope: string, new_scope: string}'
         SecurityAdvisoryJob: 'array{source: string}'
-        FilterListJob: 'array{list: string}'
+        FilterListJob: 'array{list: string, source: string}'
 
         JobResult: 'array{status: \App\Entity\Job::STATUS_*, message: string, vendor?: string, details?: string, exceptionMsg?: string, exceptionClass?: class-string<\Throwable>, results?: array{hooks_setup: int, hooks_failed: array<int, array{package: string, reason: mixed}>, hooks_ok_unchanged: int}}'
         ErroredResult: 'array{status: \App\Entity\Job::STATUS_ERRORED, message: string, exception: \Throwable}'

--- a/src/Audit/Display/AuditLogDisplayFactory.php
+++ b/src/Audit/Display/AuditLogDisplayFactory.php
@@ -17,6 +17,7 @@ use App\Audit\UserRegistrationMethod;
 use App\Entity\AuditRecord;
 use App\Entity\User;
 use App\FilterList\FilterLists;
+use App\FilterList\FilterSources;
 use Symfony\Bundle\SecurityBundle\Security;
 
 class AuditLogDisplayFactory
@@ -222,6 +223,7 @@ class AuditLogDisplayFactory
                 $record->attributes['entry']['package_name'],
                 $record->attributes['entry']['version'],
                 FilterLists::from($record->attributes['entry']['list']),
+                FilterSources::from($record->attributes['entry']['source']),
                 $record->attributes['entry']['reason'] ?? $record->attributes['entry']['category'],
                 $this->buildActor($record->attributes['actor'] ?? null),
                 $record->ip
@@ -231,6 +233,7 @@ class AuditLogDisplayFactory
                 $record->attributes['entry']['package_name'],
                 $record->attributes['entry']['version'],
                 FilterLists::from($record->attributes['entry']['list']),
+                FilterSources::from($record->attributes['entry']['source']),
                 $record->attributes['entry']['reason'] ?? $record->attributes['entry']['category'],
                 $this->buildActor($record->attributes['actor'] ?? null),
                 $record->ip

--- a/src/Audit/Display/FilterListEntryAddedDisplay.php
+++ b/src/Audit/Display/FilterListEntryAddedDisplay.php
@@ -14,6 +14,7 @@ namespace App\Audit\Display;
 
 use App\Audit\AuditRecordType;
 use App\FilterList\FilterLists;
+use App\FilterList\FilterSources;
 
 readonly class FilterListEntryAddedDisplay extends AbstractAuditLogDisplay
 {
@@ -22,6 +23,7 @@ readonly class FilterListEntryAddedDisplay extends AbstractAuditLogDisplay
         public string $packageName,
         public string $version,
         public FilterLists $list,
+        public FilterSources $source,
         public string $reason,
         ActorDisplay $actor,
         ?string $ip,

--- a/src/Audit/Display/FilterListEntryDeletedDisplay.php
+++ b/src/Audit/Display/FilterListEntryDeletedDisplay.php
@@ -14,6 +14,7 @@ namespace App\Audit\Display;
 
 use App\Audit\AuditRecordType;
 use App\FilterList\FilterLists;
+use App\FilterList\FilterSources;
 
 readonly class FilterListEntryDeletedDisplay extends AbstractAuditLogDisplay
 {
@@ -22,6 +23,7 @@ readonly class FilterListEntryDeletedDisplay extends AbstractAuditLogDisplay
         public string $packageName,
         public string $version,
         public FilterLists $list,
+        public FilterSources $source,
         public string $reason,
         ActorDisplay $actor,
         ?string $ip,

--- a/src/Command/UpdateFilterListCommand.php
+++ b/src/Command/UpdateFilterListCommand.php
@@ -13,6 +13,7 @@
 namespace App\Command;
 
 use App\FilterList\FilterLists;
+use App\FilterList\FilterSources;
 use App\Service\Locker;
 use App\Service\Scheduler;
 use Symfony\Component\Console\Command\Command;
@@ -35,8 +36,9 @@ class UpdateFilterListCommand extends Command
             ->setName('packagist:filter-list')
             ->setDefinition([
                 new InputArgument('list', InputArgument::REQUIRED, 'The name of the filter list', null, FilterLists::cases()),
+                new InputArgument('source', InputArgument::REQUIRED, 'The name of the filter source', null, FilterSources::cases()),
             ])
-            ->setDescription('Updates all entries for a single filter list')
+            ->setDescription('Updates all entries for a single filter list source')
         ;
     }
 
@@ -50,12 +52,20 @@ class UpdateFilterListCommand extends Command
             return self::INVALID;
         }
 
+        try {
+            $source = FilterSources::from($input->getArgument('source'));
+        } catch (\ValueError) {
+            $output->writeln('source must be one of '.implode(', ', array_map(fn (FilterSources $source) => $source->value, FilterSources::cases())));
+
+            return self::INVALID;
+        }
+
         $lockAcquired = $this->locker->lockFilterList($list->value);
         if (!$lockAcquired) {
             return 0;
         }
 
-        $this->scheduler->scheduleFilterList($list, 0);
+        $this->scheduler->scheduleFilterList($list, $source, 0);
         sleep(2); // sleep to prevent running the same command on multiple machines at around the same time via cron
 
         $this->locker->unlockFilterList($list->value);

--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -31,6 +31,7 @@ use App\Entity\Vendor;
 use App\Entity\Version;
 use App\Event\PackageAbandonedEvent;
 use App\Event\PackageUnabandonedEvent;
+use App\FilterList\FilterLists;
 use App\Form\Model\MaintainerRequest;
 use App\Form\Model\TransferPackageRequest;
 use App\Form\Type\AbandonedType;
@@ -74,6 +75,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\Requirement\EnumRequirement;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
@@ -681,7 +683,7 @@ class PackageController extends Controller
                 foreach ($versions as $version) {
                     if ($version->getNormalizedVersion() === $normalizedVersion) {
                         $data['hasVersionsFlaggedAsMalware'][$version->getId()] = true;
-                        $data['listsFlaggingVersionsAsMalware'][$packageVersionFlaggedAsMalware->getList()->value] = $packageVersionFlaggedAsMalware->getList();
+                        $data['listsFlaggingVersionsAsMalware'][$packageVersionFlaggedAsMalware->getSource()->value] = $packageVersionFlaggedAsMalware->getSource();
                     }
                 }
             }
@@ -1656,12 +1658,12 @@ class PackageController extends Controller
         return $this->render('package/security_advisory.html.twig', ['securityAdvisories' => $securityAdvisories, 'id' => $id]);
     }
 
-    #[Route(path: '/packages/{name}/filter-lists/', name: 'view_package_filter_lists', requirements: ['name' => Package::PACKAGE_NAME_OR_EXT_REGEX])]
-    public function filterListsAction(Request $request, string $name): Response
+    #[Route(path: '/packages/{name}/filter-lists/{list}/', name: 'view_package_filter_lists', requirements: ['name' => Package::PACKAGE_NAME_OR_EXT_REGEX, 'list' => new EnumRequirement(FilterLists::class)])]
+    public function filterListsAction(Request $request, string $name, FilterLists $list): Response
     {
         /** @var FilterListEntryRepository $repo */
         $repo = $this->getEM()->getRepository(FilterListEntry::class);
-        $entries = $repo->getPackageEntries($name);
+        $entries = $repo->getPackageEntries($name, $list);
 
         $data = [];
         $data['name'] = $name;
@@ -1693,6 +1695,7 @@ class PackageController extends Controller
 
         $data['entries'] = $entries;
         $data['count'] = \count($entries);
+        $data['list'] = $list;
 
         return $this->render('package/filter_list_entries.html.twig', $data);
     }

--- a/src/Entity/FilterListEntry.php
+++ b/src/Entity/FilterListEntry.php
@@ -13,6 +13,7 @@
 namespace App\Entity;
 
 use App\FilterList\FilterLists;
+use App\FilterList\FilterSources;
 use App\FilterList\RemoteFilterListEntry;
 use App\Service\IdGenerator;
 use Doctrine\ORM\Mapping as ORM;
@@ -51,6 +52,9 @@ class FilterListEntry
     #[ORM\Column]
     private string $publicId;
 
+    #[ORM\Column]
+    private FilterSources $source;
+
     public function __construct(RemoteFilterListEntry $remote)
     {
         $this->assignPublicId();
@@ -59,6 +63,7 @@ class FilterListEntry
         $this->link = $remote->link;
         $this->list = $remote->list;
         $this->reason = $remote->reason;
+        $this->source = $remote->source;
 
         $this->createdAt = $this->updatedAt = new \DateTimeImmutable();
     }
@@ -91,6 +96,11 @@ class FilterListEntry
     public function getPublicId(): ?string
     {
         return $this->publicId;
+    }
+
+    public function getSource(): FilterSources
+    {
+        return $this->source;
     }
 
     private function assignPublicId(): void

--- a/src/Entity/FilterListEntry.php
+++ b/src/Entity/FilterListEntry.php
@@ -48,8 +48,8 @@ class FilterListEntry
     #[ORM\Column]
     private \DateTimeImmutable $updatedAt;
 
-    #[ORM\Column(nullable: true)]
-    private ?string $publicId;
+    #[ORM\Column]
+    private string $publicId;
 
     public function __construct(RemoteFilterListEntry $remote)
     {
@@ -93,7 +93,7 @@ class FilterListEntry
         return $this->publicId;
     }
 
-    public function assignPublicId(): void
+    private function assignPublicId(): void
     {
         $this->publicId = IdGenerator::generateFilterListEntry();
     }

--- a/src/Entity/FilterListEntryRepository.php
+++ b/src/Entity/FilterListEntryRepository.php
@@ -13,6 +13,7 @@
 namespace App\Entity;
 
 use App\FilterList\FilterLists;
+use App\FilterList\FilterSources;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\Persistence\ManagerRegistry;
@@ -31,11 +32,13 @@ class FilterListEntryRepository extends ServiceEntityRepository
     /**
      * @return list<FilterListEntry>
      */
-    public function getEntriesInList(FilterLists $list): array
+    public function getEntriesInList(FilterLists $list, FilterSources $source): array
     {
         return $this->createQueryBuilder('fl')
             ->where('fl.list = :list')
+            ->andWhere('fl.source = :source')
             ->setParameter('list', $list)
+            ->setParameter('source', $source)
             ->getQuery()
             ->getResult();
     }
@@ -47,9 +50,9 @@ class FilterListEntryRepository extends ServiceEntityRepository
     {
         return $this->createQueryBuilder('fl')
             ->where('fl.packageName = :packageName')
-            ->andWhere('fl.list IN (:lists)')
+            ->andWhere('fl.list = :malware')
             ->setParameter('packageName', $package->getName())
-            ->setParameter('lists', FilterLists::malwareListsValues(), ArrayParameterType::STRING)
+            ->setParameter('malware', FilterLists::MALWARE)
             ->getQuery()
             ->getResult();
     }
@@ -57,11 +60,13 @@ class FilterListEntryRepository extends ServiceEntityRepository
     /**
      * @return list<FilterListEntry>
      */
-    public function getPackageEntries(string $packageName): array
+    public function getPackageEntries(string $packageName, FilterLists $list): array
     {
         return $this->createQueryBuilder('fl')
             ->where('fl.packageName = :packageName')
+            ->andWhere('fl.list = :list')
             ->setParameter('packageName', $packageName)
+            ->setParameter('list', $list)
             ->getQuery()
             ->getResult();
     }
@@ -69,7 +74,7 @@ class FilterListEntryRepository extends ServiceEntityRepository
     /**
      * @param array<string> $packageNames
      *
-     * @return array<string, non-empty-list<array{version: string, list: string, reason: string|null, publicId: string|null}>>
+     * @return array<string, non-empty-list<array{version: string, list: string, reason: string|null, publicId: string|null, source: string}>>
      */
     public function getAllPackageEntriesMap(array $packageNames): array
     {
@@ -86,6 +91,7 @@ class FilterListEntryRepository extends ServiceEntityRepository
                 'list' => $entry->getList()->value,
                 'reason' => $entry->getReason(),
                 'publicId' => $entry->getPublicId(),
+                'source' => $entry->getSource()->value,
             ];
         }
 

--- a/src/FilterList/Dump/DumpableFilterList.php
+++ b/src/FilterList/Dump/DumpableFilterList.php
@@ -12,6 +12,8 @@
 
 namespace App\FilterList\Dump;
 
+use App\FilterList\FilterSources;
+
 final readonly class DumpableFilterList
 {
     public function __construct(
@@ -19,6 +21,7 @@ final readonly class DumpableFilterList
         public string $url,
         public ?string $reason,
         public ?string $id,
+        public string $source,
     ) {
     }
 }

--- a/src/FilterList/Dump/FilterListDumperProvider.php
+++ b/src/FilterList/Dump/FilterListDumperProvider.php
@@ -41,9 +41,10 @@ final readonly class FilterListDumperProvider
             foreach ($entries as $entry) {
                 $groupedEntries[$packageName][$entry['list']][] = new DumpableFilterList(
                     $entry['version'],
-                    $this->urlGenerator->generate('view_package_filter_lists', ['name' => $packageName], UrlGeneratorInterface::ABSOLUTE_URL),
+                    $this->urlGenerator->generate('view_package_filter_lists', ['name' => $packageName, 'list' => $entry['list']], UrlGeneratorInterface::ABSOLUTE_URL),
                     $entry['reason'],
                     $entry['publicId'],
+                    $entry['source'],
                 );
             }
         }

--- a/src/FilterList/FilterListResolver.php
+++ b/src/FilterList/FilterListResolver.php
@@ -20,18 +20,12 @@ class FilterListResolver
      * @param array<FilterListEntry>       $existingEntries
      * @param array<RemoteFilterListEntry> $remoteEntries
      *
-     * @return array{list<FilterListEntry>, list<FilterListEntry>, bool}
+     * @return array{list<FilterListEntry>, list<FilterListEntry>}
      */
     public function resolve(array $existingEntries, array $remoteEntries): array
     {
-        $modifiedExisting = false;
         $existingMap = [];
         foreach ($existingEntries as $existing) {
-            if (!$existing->getPublicId()) {
-                $existing->assignPublicId();
-                $modifiedExisting = true;
-            }
-
             $existingMap[$existing->getPackageName()][$existing->getVersion()] = $existing;
         }
 
@@ -58,7 +52,6 @@ class FilterListResolver
         return [
             $new,
             $unmatched,
-            $modifiedExisting,
         ];
     }
 }

--- a/src/FilterList/FilterLists.php
+++ b/src/FilterList/FilterLists.php
@@ -14,50 +14,5 @@ namespace App\FilterList;
 
 enum FilterLists: string
 {
-    case AIKIDO_MALWARE = 'aikido-malware';
-
-    public function logo(): string
-    {
-        return match ($this) {
-            self::AIKIDO_MALWARE => 'img/aikido-dark.svg',
-        };
-    }
-
-    public function displayName(): string
-    {
-        return match ($this) {
-            self::AIKIDO_MALWARE => 'Aikido',
-        };
-    }
-
-    public function url(): string
-    {
-        return match ($this) {
-            self::AIKIDO_MALWARE => 'https://aikido.dev/',
-        };
-    }
-
-    /**
-     * @return list<FilterLists>
-     */
-    public static function defaultLists(): array
-    {
-        return [self::AIKIDO_MALWARE];
-    }
-
-    /**
-     * @return list<FilterLists>
-     */
-    public static function malwareLists(): array
-    {
-        return [self::AIKIDO_MALWARE];
-    }
-
-    /**
-     * @return list<string>
-     */
-    public static function malwareListsValues(): array
-    {
-        return array_map(fn (FilterLists $list) => $list->value, self::malwareLists());
-    }
+    case MALWARE = 'malware';
 }

--- a/src/FilterList/FilterSources.php
+++ b/src/FilterList/FilterSources.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Packagist.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *     Nils Adermann <naderman@naderman.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\FilterList;
+
+enum FilterSources: string
+{
+    case AIKIDO = 'aikido';
+
+    public function logo(): string
+    {
+        return match ($this) {
+            self::AIKIDO => 'img/aikido-dark.svg',
+        };
+    }
+
+    public function displayName(): string
+    {
+        return match ($this) {
+            self::AIKIDO => 'Aikido',
+        };
+    }
+
+    public function url(): string
+    {
+        return match ($this) {
+            self::AIKIDO => 'https://aikido.dev/',
+        };
+    }
+}

--- a/src/FilterList/List/AikidoMalwareFilterList.php
+++ b/src/FilterList/List/AikidoMalwareFilterList.php
@@ -13,6 +13,7 @@
 namespace App\FilterList\List;
 
 use App\FilterList\FilterLists;
+use App\FilterList\FilterSources;
 use App\FilterList\RemoteFilterListEntry;
 use Psr\Log\LoggerInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -55,9 +56,10 @@ class AikidoMalwareFilterList implements FilterListInterface
             $entries[] = new RemoteFilterListEntry(
                 $packageName,
                 $entry['version'],
-                FilterLists::AIKIDO_MALWARE,
+                FilterLists::MALWARE,
                 \sprintf('https://app.aikido.dev/reports/malware/software-supply-chain-attacks?search=%s&ecosystem=packagist', urlencode($packageName)),
                 'malware',
+                FilterSources::AIKIDO,
             );
         }
 

--- a/src/FilterList/RemoteFilterListEntry.php
+++ b/src/FilterList/RemoteFilterListEntry.php
@@ -20,6 +20,7 @@ final readonly class RemoteFilterListEntry
         public FilterLists $list,
         public ?string $link,
         public string $reason,
+        public FilterSources $source,
     ) {
     }
 }

--- a/src/Package/V2Dumper.php
+++ b/src/Package/V2Dumper.php
@@ -98,7 +98,6 @@ class V2Dumper
         $rootFileContents['filter'] = [
             'metadata' => true,
             'lists' => array_map(fn (FilterLists $list) => $list->value, FilterLists::cases()),
-            'default-lists' => array_map(fn (FilterLists $list) => $list->value, FilterLists::defaultLists()),
         ];
 
         if ($verbose) {

--- a/src/Service/FilterListWorker.php
+++ b/src/Service/FilterListWorker.php
@@ -18,6 +18,7 @@ use App\Entity\Package;
 use App\FilterList\FilterListEntryUpdateListener;
 use App\FilterList\FilterListResolver;
 use App\FilterList\FilterLists;
+use App\FilterList\FilterSources;
 use App\FilterList\List\FilterListInterface;
 use App\Model\DownloadManager;
 use Doctrine\Persistence\ManagerRegistry;
@@ -58,23 +59,27 @@ final readonly class FilterListWorker
     public function process(Job $job, SignalHandler $signal): array
     {
         $list = FilterLists::from($job->getPayload()['list']);
+        $source = FilterSources::from($job->getPayload()['source']);
 
         $lockAcquired = $this->locker->lockFilterList(self::FILTER_LIST_WORKER_RUN);
         if (!$lockAcquired) {
             return ['status' => Job::STATUS_RESCHEDULE, 'after' => new \DateTimeImmutable('+2 minutes'), 'message' => 'Could not acquire lock'];
         }
 
-        $source = $this->filterLists[$list->value];
-        $remoteEntries = $source->getListEntries();
+        $filterList = $this->filterLists[$source->value . '-' . $list->value];
+        $remoteEntries = $filterList->getListEntries();
         if (null === $remoteEntries) {
-            $this->logger->info('Filter list update failed, skipping', ['list' => $list]);
+            $this->logger->info('Filter list update failed, skipping', [
+                'list' => $list,
+                'source' => $source,
+            ]);
             $this->locker->unlockFilterList(self::FILTER_LIST_WORKER_RUN);
 
             return ['status' => Job::STATUS_ERRORED, 'message' => 'Filter list update failed, skipped'];
         }
 
         /** @var FilterListEntry[] $existingEntries */
-        $existingEntries = $this->doctrine->getRepository(FilterListEntry::class)->getEntriesInList($list);
+        $existingEntries = $this->doctrine->getRepository(FilterListEntry::class)->getEntriesInList($list, $source);
         [$new, $removed] = $this->malwareFeedResolver->resolve($existingEntries, $remoteEntries);
 
         foreach ($new as $entry) {

--- a/src/Service/FilterListWorker.php
+++ b/src/Service/FilterListWorker.php
@@ -75,7 +75,7 @@ final readonly class FilterListWorker
 
         /** @var FilterListEntry[] $existingEntries */
         $existingEntries = $this->doctrine->getRepository(FilterListEntry::class)->getEntriesInList($list);
-        [$new, $removed, $modifiedExisting] = $this->malwareFeedResolver->resolve($existingEntries, $remoteEntries);
+        [$new, $removed] = $this->malwareFeedResolver->resolve($existingEntries, $remoteEntries);
 
         foreach ($new as $entry) {
             $this->doctrine->getManager()->persist($entry);
@@ -85,7 +85,7 @@ final readonly class FilterListWorker
             $this->doctrine->getManager()->remove($entry);
         }
 
-        if ($new !== [] || $removed !== [] || $modifiedExisting) {
+        if ($new !== [] || $removed !== []) {
             $this->doctrine->getManager()->flush();
         }
 

--- a/src/Service/Scheduler.php
+++ b/src/Service/Scheduler.php
@@ -15,6 +15,7 @@ namespace App\Service;
 use App\Entity\Job;
 use App\Entity\Package;
 use App\FilterList\FilterLists;
+use App\FilterList\FilterSources;
 use Doctrine\Persistence\ManagerRegistry;
 use Predis\Client as RedisClient;
 
@@ -80,9 +81,9 @@ class Scheduler
     /**
      * @return Job<FilterListJob>
      */
-    public function scheduleFilterList(FilterLists $list, int $packageId, ?\DateTimeImmutable $executeAfter = null): Job
+    public function scheduleFilterList(FilterLists $list, FilterSources $source, int $packageId, ?\DateTimeImmutable $executeAfter = null): Job
     {
-        return $this->createJob('filter:update', ['list' => $list->value], $packageId, $executeAfter);
+        return $this->createJob('filter:update', ['list' => $list->value, 'source' => $source->value], $packageId, $executeAfter);
     }
 
     private function getPendingUpdateJob(int $packageId, bool $updateEqualRefs = false, bool $deleteBefore = false): ?string

--- a/templates/audit_log/display/filter_list_entry_added.html.twig
+++ b/templates/audit_log/display/filter_list_entry_added.html.twig
@@ -1,4 +1,4 @@
 {% import 'audit_log/macros.html.twig' as auditLog %}
 
 <strong>{{ auditLog.packageLink(display.packageName) }}</strong><br>
-Versions {{ display.version}} were flagged by {{ display.list.displayName }}. Reason: {{ display.reason }}.
+Versions {{ display.version}} were flagged as {{ display.list.value }} by {{ display.source.displayName }}. Reason: {{ display.reason }}.

--- a/templates/audit_log/display/filter_list_entry_deleted.html.twig
+++ b/templates/audit_log/display/filter_list_entry_deleted.html.twig
@@ -1,4 +1,4 @@
 {% import 'audit_log/macros.html.twig' as auditLog %}
 
 <strong>{{ auditLog.packageLink(display.packageName) }}</strong><br>
-Versions {{ display.version}} were unflagged by {{ display.list}}.
+Versions {{ display.version }} were unflagged by {{ display.source.displayName }} as {{ display.list.value }}.

--- a/templates/package/_filter_list_entries_list.html.twig
+++ b/templates/package/_filter_list_entries_list.html.twig
@@ -13,13 +13,13 @@
                                         Reason: {{ entry.reason }}
 
                                         {% if entry.link %}
-                                            <a href="{{ entry.link }}">View details on {{ entry.list.displayName }}</a>
+                                            <a href="{{ entry.link }}">View details on {{ entry.source.displayName }}</a>
                                         {% endif %}
                                     </p>
 
                                 </div>
                                 <div class="col-sm-5 col-lg-4">
-                                    <p>Reported by: <a href="{{entry.list.url }}"><img alt="{{ entry.list.displayName }}" class="filter-list-log" src="{{ asset(entry.list.logo) }}" /></a></p>
+                                    <p>Reported by: <a href="{{entry.source.url }}"><img alt="{{ entry.source.displayName }}" class="filter-list-log" src="{{ asset(entry.source.logo) }}" /></a></p>
                                 </div>
                             </div>
                         </div>

--- a/templates/package/filter_list_entries.html.twig
+++ b/templates/package/filter_list_entries.html.twig
@@ -4,7 +4,7 @@
 
 {% block head_additions %}<meta name="robots" content="noindex, nofollow">{% endblock %}
 
-{% block title %}{{ 'packages.filter_lists'|trans }} - {{ name }} - {{ parent() }}{% endblock %}
+{% block title %}{{ ('packages.filter_lists.' ~ list.value)|trans }} - {{ name }} - {{ parent() }}{% endblock %}
 
 {% block content %}
     <div class="row">
@@ -12,6 +12,7 @@
             <div class="package-header">
                 <h2 class="title">
                     <a href="{{ path("view_package", {name: name}) }}">{{ name }}</a>
+                    {{ ('packages.filter_lists.' ~ list.value)|trans }}
                     {% if version is defined %}
                         for {{ version }}
                     {% endif %}

--- a/templates/package/version_list.html.twig
+++ b/templates/package/version_list.html.twig
@@ -17,7 +17,7 @@
                 {% endif %}
 
                 {% if hasVersionsFlaggedAsMalware[version.id]|default(false) %}
-                    <a rel="nofollow noindex" class="action-alert malware-alert" href="{{ path('view_package_filter_lists', {name: package.name, version: version.id, category: 'malware'}) }}">
+                    <a rel="nofollow noindex" class="action-alert malware-alert" href="{{ path('view_package_filter_lists', {name: package.name, version: version.id, list: 'malware'}) }}">
                         <i class="glyphicon glyphicon-fire" title="Version was flagged as malware"></i>
                     </a>
                 {% endif %}

--- a/templates/package/view_package.html.twig
+++ b/templates/package/view_package.html.twig
@@ -49,7 +49,7 @@
                     <p class="requireme"><i class="glyphicon glyphicon-save"></i> <input type="text" readonly="readonly" value="{{ package.installCommand(version) }}" /></p>
 
                     {% if hasVersionsFlaggedAsMalware %}
-                    <div class="alert alert-danger"><i class="glyphicon glyphicon-fire"></i> Versions of this package have been <a href="{{ path('view_package_filter_lists', {name: package.name, category: 'malware'}) }}">flagged as malware by {{ listsFlaggingVersionsAsMalware|map(l => l.displayName)|join(', ', ' and ') }}</a>!</div>
+                    <div class="alert alert-danger"><i class="glyphicon glyphicon-fire"></i> Versions of this package have been <a href="{{ path('view_package_filter_lists', {name: package.name, list: 'malware'}) }}">flagged as malware by {{ listsFlaggingVersionsAsMalware|map(l => l.displayName)|join(', ', ' and ') }}</a>!</div>
                     {% endif %}
 
                     {% if not package.isAutoUpdated() and is_granted('update', package) %}

--- a/tests/Audit/Display/AuditLogDisplayFactoryTest.php
+++ b/tests/Audit/Display/AuditLogDisplayFactoryTest.php
@@ -32,6 +32,7 @@ use App\Audit\Display\VersionReferenceChangedDisplay;
 use App\Entity\AuditRecord;
 use App\Entity\User;
 use App\FilterList\FilterLists;
+use App\FilterList\FilterSources;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
@@ -602,7 +603,7 @@ class AuditLogDisplayFactoryTest extends TestCase
         $auditRecord = $this->createAuditRecord(
             AuditRecordType::FilterListEntryAdded,
             [
-                'entry' => ['package_name' => 'acme/package', 'version' => '<1.0', 'list' => FilterLists::AIKIDO_MALWARE->value, 'reason' => 'malware'],
+                'entry' => ['package_name' => 'acme/package', 'version' => '<1.0', 'list' => FilterLists::MALWARE->value, 'reason' => 'malware', 'source' => FilterSources::AIKIDO->value],
             ]
         );
 
@@ -612,9 +613,10 @@ class AuditLogDisplayFactoryTest extends TestCase
         self::assertSame('acme/package', $display->packageName);
         self::assertSame('<1.0', $display->version);
         self::assertSame('malware', $display->reason);
-        self::assertSame(FilterLists::AIKIDO_MALWARE, $display->list);
+        self::assertSame(FilterLists::MALWARE, $display->list);
         self::assertNull($display->actor->id);
         self::assertSame('unknown', $display->actor->username);
+        self::assertSame(FilterSources::AIKIDO, $display->source);
         self::assertSame(AuditRecordType::FilterListEntryAdded, $display->getType());
         self::assertSame('audit_log/display/filter_list_entry_added.html.twig', $display->getTemplateName());
     }
@@ -624,7 +626,7 @@ class AuditLogDisplayFactoryTest extends TestCase
         $auditRecord = $this->createAuditRecord(
             AuditRecordType::FilterListEntryDeleted,
             [
-                'entry' => ['package_name' => 'acme/package', 'version' => '<1.0', 'list' => FilterLists::AIKIDO_MALWARE->value, 'reason' => 'malware'],
+                'entry' => ['package_name' => 'acme/package', 'version' => '<1.0', 'list' => FilterLists::MALWARE->value, 'reason' => 'malware', 'source' => FilterSources::AIKIDO->value],
             ]
         );
 
@@ -634,9 +636,10 @@ class AuditLogDisplayFactoryTest extends TestCase
         self::assertSame('acme/package', $display->packageName);
         self::assertSame('<1.0', $display->version);
         self::assertSame('malware', $display->reason);
-        self::assertSame(FilterLists::AIKIDO_MALWARE, $display->list);
+        self::assertSame(FilterLists::MALWARE, $display->list);
         self::assertNull($display->actor->id);
         self::assertSame('unknown', $display->actor->username);
+        self::assertSame(FilterSources::AIKIDO, $display->source);
         self::assertSame(AuditRecordType::FilterListEntryDeleted, $display->getType());
         self::assertSame('audit_log/display/filter_list_entry_deleted.html.twig', $display->getTemplateName());
     }

--- a/tests/FilterList/Dump/FilterListDumperProviderTest.php
+++ b/tests/FilterList/Dump/FilterListDumperProviderTest.php
@@ -16,6 +16,7 @@ use App\Entity\FilterListEntry;
 use App\Entity\FilterListEntryRepository;
 use App\FilterList\Dump\DumpableFilterList;
 use App\FilterList\Dump\FilterListDumperProvider;
+use App\FilterList\FilterSources;
 use Doctrine\ORM\EntityManager;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -59,16 +60,16 @@ class FilterListDumperProviderTest extends TestCase
             ->with(['acme/package'])
             ->willReturn([
                 'acme/package' => [
-                    ['version' => '1.0.0', 'reason' => 'malware', 'list' => 'test', 'publicId' => 'PKFE-test1'],
-                    ['version' => '2.0.0', 'reason' => 'malware', 'list' => 'test', 'publicId' => 'PKFE-test2'],
+                    ['version' => '1.0.0', 'reason' => 'malware', 'list' => 'test', 'publicId' => 'PKFE-test1', 'source' => 'aikido'],
+                    ['version' => '2.0.0', 'reason' => 'malware', 'list' => 'test', 'publicId' => 'PKFE-test2', 'source' => 'aikido'],
                 ],
             ]);
 
         $this->assertEquals([
             'acme/package' => [
                 'test' => [
-                    new DumpableFilterList('1.0.0', '', 'malware', 'PKFE-test1'),
-                    new DumpableFilterList('2.0.0', '', 'malware', 'PKFE-test2'),
+                    new DumpableFilterList('1.0.0', '', 'malware', 'PKFE-test1', 'aikido'),
+                    new DumpableFilterList('2.0.0', '', 'malware', 'PKFE-test2', 'aikido'),
                 ],
             ],
         ], $this->filterListDumperProvider->getEntriesForDump(['acme/package']));

--- a/tests/FilterList/FilterListResolverTest.php
+++ b/tests/FilterList/FilterListResolverTest.php
@@ -15,6 +15,7 @@ namespace App\Tests\FilterList;
 use App\Entity\FilterListEntry;
 use App\FilterList\FilterListResolver;
 use App\FilterList\FilterLists;
+use App\FilterList\FilterSources;
 use App\FilterList\RemoteFilterListEntry;
 use Doctrine\Persistence\Reflection\TypedNoDefaultReflectionProperty;
 use PHPUnit\Framework\TestCase;
@@ -119,9 +120,10 @@ class FilterListResolverTest extends TestCase
         return new RemoteFilterListEntry(
             $packageName,
             $version,
-            FilterLists::AIKIDO_MALWARE,
+            FilterLists::MALWARE,
             'https://example.com/'.$packageName,
             'malware',
+            FilterSources::AIKIDO,
         );
     }
 

--- a/tests/FilterList/FilterListResolverTest.php
+++ b/tests/FilterList/FilterListResolverTest.php
@@ -43,19 +43,7 @@ class FilterListResolverTest extends TestCase
         $remote = $this->createRemoteFilterListEntry('vendor/package', '1.0.0');
         $result = $this->resolver->resolve([$existing], [$remote, $remote]);
 
-        $this->assertSame([[], [], false], $result);
-    }
-
-    public function testExistingWithoutIdAssignsNewPublicId(): void
-    {
-        $existing = new FilterListEntry($this->createRemoteFilterListEntry('vendor/package', '1.0.0'));
-        $this->unsetPublicId($existing);
-        $this->assertNull($existing->getPublicId());
-        $remote = $this->createRemoteFilterListEntry('vendor/package', '1.0.0');
-        $result = $this->resolver->resolve([$existing], [$remote, $remote]);
-
-        $this->assertSame([[], [], true], $result);
-        $this->assertNotNull($existing->getPublicId());
+        $this->assertSame([[], []], $result);
     }
 
     public function testResolveRemoveOldEntry(): void
@@ -98,7 +86,7 @@ class FilterListResolverTest extends TestCase
     {
         $result = $this->resolver->resolve([], []);
 
-        $this->assertSame([[], [], false], $result);
+        $this->assertSame([[], []], $result);
     }
 
     public function testResolveMultipleVersionsSamePackage(): void

--- a/tests/FilterList/List/AikidoMalwareFilterListTest.php
+++ b/tests/FilterList/List/AikidoMalwareFilterListTest.php
@@ -38,7 +38,7 @@ class AikidoMalwareFilterListTest extends TestCase
         $this->assertInstanceOf(RemoteFilterListEntry::class, $result[0]);
         $this->assertSame('vendor/malware', $result[0]->packageName);
         $this->assertSame('1.0.0', $result[0]->version);
-        $this->assertSame(FilterLists::AIKIDO_MALWARE, $result[0]->list);
+        $this->assertSame(FilterLists::MALWARE, $result[0]->list);
     }
 
     public function testGetListEntriesFiltersNonMalwareEntries(): void

--- a/tests/FilterListWorkerTest.php
+++ b/tests/FilterListWorkerTest.php
@@ -20,6 +20,7 @@ use App\Entity\PackageRepository;
 use App\FilterList\FilterListEntryUpdateListener;
 use App\FilterList\FilterListResolver;
 use App\FilterList\FilterLists;
+use App\FilterList\FilterSources;
 use App\FilterList\List\FilterListInterface;
 use App\FilterList\RemoteFilterListEntry;
 use App\Model\DownloadManager;
@@ -55,7 +56,7 @@ class FilterListWorkerTest extends TestCase
         $this->downloadManager = $this->createStub(DownloadManager::class);
         $this->urlGenerator = $this->createStub(UrlGeneratorInterface::class);
         $doctrine = $this->createStub(ManagerRegistry::class);
-        $this->worker = new FilterListWorker($this->locker, new NullLogger(), $doctrine, [FilterLists::AIKIDO_MALWARE->value => $this->filterList], new FilterListResolver(), new FilterListEntryUpdateListener($doctrine), $this->mailer, $this->downloadManager, 'test@example.com', $this->urlGenerator, 'packagist.org');
+        $this->worker = new FilterListWorker($this->locker, new NullLogger(), $doctrine, [FilterSources::AIKIDO->value . '-' . FilterLists::MALWARE->value => $this->filterList], new FilterListResolver(), new FilterListEntryUpdateListener($doctrine), $this->mailer, $this->downloadManager, 'test@example.com', $this->urlGenerator, 'packagist.org');
 
         $this->em = $this->createMock(EntityManager::class);
 
@@ -96,7 +97,7 @@ class FilterListWorkerTest extends TestCase
         $this->filterListEntryRepository
             ->expects($this->once())
             ->method('getEntriesInList')
-            ->with(FilterLists::AIKIDO_MALWARE)
+            ->with(FilterLists::MALWARE)
             ->willReturn([$existingEntry, $existingEntryToBeDeleted]);
 
         $this->em
@@ -133,7 +134,7 @@ class FilterListWorkerTest extends TestCase
         $this->filterListEntryRepository
             ->expects($this->once())
             ->method('getEntriesInList')
-            ->with(FilterLists::AIKIDO_MALWARE)
+            ->with(FilterLists::MALWARE)
             ->willReturn([]);
 
         $this->expectNoPersistAndRemove();
@@ -191,15 +192,16 @@ class FilterListWorkerTest extends TestCase
         return new RemoteFilterListEntry(
             $packageName,
             $version,
-            FilterLists::AIKIDO_MALWARE,
+            FilterLists::MALWARE,
             'https://example.com/'.$packageName,
             'malware',
+            FilterSources::AIKIDO,
         );
     }
 
     private function createJob(): Job
     {
-        return new Job('job', 'filter:update', ['list' => FilterLists::AIKIDO_MALWARE->value]);
+        return new Job('job', 'filter:update', ['list' => FilterLists::MALWARE->value, 'source' => FilterSources::AIKIDO->value]);
     }
 
     private function expectLock(): void

--- a/tests/Package/V2DumperTest.php
+++ b/tests/Package/V2DumperTest.php
@@ -19,6 +19,7 @@ use App\Entity\SecurityAdvisory;
 use App\Entity\Version;
 use App\FilterList\Dump\FilterListDumperProvider;
 use App\FilterList\FilterLists;
+use App\FilterList\FilterSources;
 use App\FilterList\RemoteFilterListEntry;
 use App\Model\ProviderManager;
 use App\Package\V2Dumper;
@@ -150,9 +151,10 @@ class V2DumperTest extends IntegrationTestCase
         $remote = new RemoteFilterListEntry(
             'acme/package',
             '1.0.0',
-            FilterLists::AIKIDO_MALWARE,
+            FilterLists::MALWARE,
             null,
             'malware',
+            FilterSources::AIKIDO,
         );
         $filterEntry = new FilterListEntry($remote);
         $this->store($filterEntry);
@@ -164,11 +166,12 @@ class V2DumperTest extends IntegrationTestCase
 
         $data = json_decode((string) file_get_contents($releaseFile), true);
         $this->assertArrayHasKey('filter', $data);
-        $this->assertArrayHasKey('aikido-malware', $data['filter']);
-        $filterList = $data['filter']['aikido-malware'];
+        $this->assertArrayHasKey('malware', $data['filter']);
+        $filterList = $data['filter']['malware'];
         $this->assertNotEmpty($filterList);
         $this->assertSame('1.0.0', $filterList[0]['constraint']);
         $this->assertSame('malware', $filterList[0]['reason']);
+        $this->assertSame(FilterSources::AIKIDO->value, $filterList[0]['source']);
     }
 
     public function testSpamFrozenPackageIsSkipped(): void

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -68,8 +68,8 @@ packages:
     from: "Packages from %vendor%"
     security_advisory_title: Security Advisories
     security_advisories: Security Advisories
-    filter_lists_title: Filters
-    filter_lists: Filters
+    filter_lists:
+        malware: Malware Reports
 
 browse:
     packages: Packages


### PR DESCRIPTION
Changes here will further simplify the Composer malware filter feature

* Have one unified malware list where entries have a source, similar to advisories
* Make public ID not nullable
* Drop default-lists from to the packages.json


```sql
ALTER TABLE filter_list_entry CHANGE publicId publicId VARCHAR(255) NOT NULL;

ALTER TABLE filter_list_entry ADD source VARCHAR(255) DEFAULT NULL;
UPDATE filter_list_entry SET source = 'aikido', list = 'malware';
ALTER TABLE filter_list_entry CHANGE source source VARCHAR(255) NOT NULL;

UPDATE audit_log SET attributes = JSON_SET(attributes, '$.entry.source', 'aikido', '$.entry.list', 'malware') WHERE type IN ('filter_list_entry_added','filter_list_entry_deleted');
```