### PR TITLE
GitHub Actions: use zizmor to harden existing workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     schedule:
       interval: "weekly"
     labels: []
+    cooldown:
+      default-days: 7

--- a/.github/workflows/conductor.yaml
+++ b/.github/workflows/conductor.yaml
@@ -1,22 +1,29 @@
 # See the Conductor setup guide at https://packagist.com/docs/conductor/getting-started
 
+name: Private Packagist Conductor
+
 on:
   repository_dispatch:
     types:
       - dependency_update
 
-name: Private Packagist Conductor
+concurrency:
+    group: ${{ github.workflow }}
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   conductor:
     name: Private Packagist Conductor
     runs-on: ubuntu-24.04-arm
 
+    permissions:
+        contents: write # Allow Conductor to push commits with composer.json/.lock changes
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: true
 
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,9 +4,16 @@ on:
   - push
   - pull_request
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 env:
   APP_ENV: test
   DATABASE_URL: "mysql://root:root@127.0.0.1:3306/packagist?serverVersion=8.0"
+
+permissions:
+    contents: read
 
 jobs:
   tests:
@@ -16,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,13 @@ on:
   - push
   - pull_request
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
 jobs:
   tests:
     name: "Lint"
@@ -12,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -4,9 +4,16 @@ on:
   - push
   - pull_request
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 env:
   APP_ENV: dev
   DATABASE_URL: "mysql://root:root@127.0.0.1:3306/packagist?serverVersion=8.0"
+
+permissions:
+    contents: read
 
 jobs:
   tests:
@@ -16,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,35 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - '.github/**.yml'
+    pull_request:
+        paths:
+            - '.github/**.yml'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    zizmor:
+        name: Run zizmor 🌈
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - name: Run zizmor 🌈
+              uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+              with:
+                  advanced-security: false
+                  annotations: true
+                  persona: 'pedantic'


### PR DESCRIPTION
This introduces [zizmor](https://github.com/zizmorcore/zizmor) a static analyzer for GitHub Actions to harden existing GitHub Action workflows and adds a new workflow to analyze any future changes to those workflows.

I didn't introduce any new concurrency limitations. Happy to add that if wanted but don't think this is necessary.