### PR TITLE
FilterLists: update list configuration in packages.json to return an object instead of a list of lists

### DIFF
--- a/src/FilterList/FilterLists.php
+++ b/src/FilterList/FilterLists.php
@@ -15,4 +15,17 @@ namespace App\FilterList;
 enum FilterLists: string
 {
     case MALWARE = 'malware';
+
+    /**
+     * @return array<string, bool>
+     */
+    public static function packagesJsonListConfig(): array
+    {
+        $lists = [];
+        foreach (self::cases() as $list) {
+            $lists[$list->value] = true;
+        }
+
+        return $lists;
+    }
 }

--- a/src/Package/V2Dumper.php
+++ b/src/Package/V2Dumper.php
@@ -97,7 +97,7 @@ class V2Dumper
         $rootFileContents['providers'] = [];
         $rootFileContents['filter'] = [
             'metadata' => true,
-            'lists' => array_map(fn (FilterLists $list) => $list->value, FilterLists::cases()),
+            'lists' => FilterLists::packagesJsonListConfig(),
         ];
 
         if ($verbose) {

--- a/tests/Package/V2DumperTest.php
+++ b/tests/Package/V2DumperTest.php
@@ -83,6 +83,17 @@ class V2DumperTest extends IntegrationTestCase
         new Filesystem()->remove($this->buildDir);
     }
 
+    public function testDumpRoot(): void
+    {
+        $this->dumper->dumpRoot();
+
+        $packagesJson = $this->webDir.'/packages.json';
+        $this->assertFileExists($packagesJson);
+
+        $data = json_decode((string) file_get_contents($packagesJson), true);
+        $this->assertTrue($data['filter']['metadata']);
+    }
+
     public function testDumpPackageMetadata(): void
     {
         $package = self::createPackage('acme/package', 'https://example.com/acme/package');


### PR DESCRIPTION
This will now return the json below making it possible to expand on the config in the future if necessary
```
{
    "filter": {
        "metadata": true,
        "lists": {
            "malware": true
        }
    }
}
```

See https://github.com/composer/composer/pull/12838