### PR TITLE
FilterList: adjust packages.json response to use {enabled: true} instead of true for active lists

### DIFF
--- a/src/FilterList/FilterLists.php
+++ b/src/FilterList/FilterLists.php
@@ -17,13 +17,13 @@ enum FilterLists: string
     case MALWARE = 'malware';
 
     /**
-     * @return array<string, bool>
+     * @return array<string, array{enabled: bool}>
      */
     public static function packagesJsonListConfig(): array
     {
         $lists = [];
         foreach (self::cases() as $list) {
-            $lists[$list->value] = true;
+            $lists[$list->value] = ['enabled' => true];
         }
 
         return $lists;

--- a/tests/Package/V2DumperTest.php
+++ b/tests/Package/V2DumperTest.php
@@ -92,6 +92,7 @@ class V2DumperTest extends IntegrationTestCase
 
         $data = json_decode((string) file_get_contents($packagesJson), true);
         $this->assertTrue($data['filter']['metadata']);
+        $this->assertSame(['enabled' => true], $data['filter']['lists']['malware']);
     }
 
     public function testDumpPackageMetadata(): void


### PR DESCRIPTION
As per https://github.com/composer/composer/pull/12838#discussion_r3228764601