### PR TITLE
Clarify sponsor logo placement across both sites

### DIFF
--- a/templates/web/sponsor.html.twig
+++ b/templates/web/sponsor.html.twig
@@ -58,7 +58,7 @@
                     <h4>Bronze</h4>
                     <div class="sponsor-tier-price">&euro;2,500<span>/mo</span></div>
                     <ul>
-                        <li>Logo on sponsors page</li>
+                        <li>Logo on getcomposer.org and packagist.org sponsors pages</li>
                         <li>Social media welcome post (Mastodon, Bluesky, LinkedIn, X)</li>
                         <li>Included in annual sponsor thank-you blog post</li>
                         <li>Logo on Composer GitHub README</li>
@@ -71,7 +71,7 @@
                     <h4>Silver</h4>
                     <div class="sponsor-tier-price">&euro;5,000<span>/mo</span></div>
                     <ul>
-                        <li>Logo on sponsors page</li>
+                        <li>Logo on getcomposer.org and packagist.org sponsors pages</li>
                         <li>Social media welcome post (Mastodon, Bluesky, LinkedIn, X)</li>
                         <li>Included in annual sponsor thank-you blog post</li>
                         <li>Logo on Composer GitHub README</li>
@@ -86,7 +86,7 @@
                     <h4>Gold</h4>
                     <div class="sponsor-tier-price">&euro;8,000<span>/mo</span></div>
                     <ul>
-                        <li>Logo on sponsors page</li>
+                        <li>Logo on getcomposer.org and packagist.org sponsors pages</li>
                         <li>Social media welcome post (Mastodon, Bluesky, LinkedIn, X)</li>
                         <li>Included in annual sponsor thank-you blog post</li>
                         <li>Logo on Composer GitHub README</li>


### PR DESCRIPTION
Updates the sponsor tier benefits (Bronze, Silver, Gold) on the sponsors page to clarify that the sponsor logo appears on both getcomposer.org and packagist.org sponsors pages, rather than just "sponsors page".

🤖 Generated with [Claude Code](https://claude.com/claude-code)