### PR TITLE
FilterLists: only import entries with a valid version constraint

### DIFF
--- a/src/FilterList/FilterListResolver.php
+++ b/src/FilterList/FilterListResolver.php
@@ -13,9 +13,16 @@
 namespace App\FilterList;
 
 use App\Entity\FilterListEntry;
+use Composer\Semver\VersionParser;
+use Psr\Log\LoggerInterface;
 
 class FilterListResolver
 {
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
     /**
      * @param array<FilterListEntry>       $existingEntries
      * @param array<RemoteFilterListEntry> $remoteEntries
@@ -29,9 +36,20 @@ class FilterListResolver
             $existingMap[$existing->getPackageName()][$existing->getVersion()] = $existing;
         }
 
+        $versionParser = new VersionParser();
         $new = [];
         $found = [];
         foreach ($remoteEntries as $remote) {
+            try {
+                $versionParser->parseConstraints($remote->version);
+            } catch (\UnexpectedValueException $e) {
+                $this->logger->warning('Skipping filter list entry with invalid version constraint', [
+                    'entry' => $remote,
+                    'exception' => $e,
+                ]);
+                continue;
+            }
+
             if (isset($existingMap[$remote->packageName][$remote->version])) {
                 $found[$remote->packageName][$remote->version] = true;
                 continue;

--- a/tests/FilterList/FilterListResolverTest.php
+++ b/tests/FilterList/FilterListResolverTest.php
@@ -19,6 +19,7 @@ use App\FilterList\FilterSources;
 use App\FilterList\RemoteFilterListEntry;
 use Doctrine\Persistence\Reflection\TypedNoDefaultReflectionProperty;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 
 class FilterListResolverTest extends TestCase
 {
@@ -26,7 +27,7 @@ class FilterListResolverTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->resolver = new FilterListResolver();
+        $this->resolver = new FilterListResolver(new NullLogger());
     }
 
     public function testResolveAddNewEntry(): void
@@ -113,6 +114,17 @@ class FilterListResolverTest extends TestCase
 
         $this->assertSame([], $result[0]);
         $this->assertSame([$existing2], $result[1]);
+    }
+
+    public function testResolveSkipsRemoteEntriesWithInvalidVersionConstraint(): void
+    {
+        $valid = $this->createRemoteFilterListEntry('vendor/good', '1.0.0');
+        $invalid = $this->createRemoteFilterListEntry('vendor/bad', 'not-a-valid-constraint!@#');
+
+        $result = $this->resolver->resolve([], [$valid, $invalid]);
+
+        $this->assertEntry($valid, $result[0]);
+        $this->assertSame([], $result[1]);
     }
 
     private function createRemoteFilterListEntry(string $packageName, string $version): RemoteFilterListEntry

--- a/tests/FilterListWorkerTest.php
+++ b/tests/FilterListWorkerTest.php
@@ -59,7 +59,7 @@ class FilterListWorkerTest extends TestCase
         $this->urlGenerator = $this->createStub(UrlGeneratorInterface::class);
         $doctrine = $this->createStub(ManagerRegistry::class);
         $this->summaryDumper = $this->createMock(FilterListSummaryDumper::class);
-        $this->worker = new FilterListWorker($this->locker, new NullLogger(), $doctrine, [FilterSources::AIKIDO->value . '-' . FilterLists::MALWARE->value => $this->filterList], new FilterListResolver(), new FilterListEntryUpdateListener($doctrine), $this->mailer, $this->downloadManager, 'test@example.com', $this->urlGenerator, 'packagist.org', $this->summaryDumper);
+        $this->worker = new FilterListWorker($this->locker, new NullLogger(), $doctrine, [FilterSources::AIKIDO->value . '-' . FilterLists::MALWARE->value => $this->filterList], new FilterListResolver(new NullLogger()), new FilterListEntryUpdateListener($doctrine), $this->mailer, $this->downloadManager, 'test@example.com', $this->urlGenerator, 'packagist.org', $this->summaryDumper);
 
         $this->em = $this->createMock(EntityManager::class);
 


### PR DESCRIPTION
Just adding validation that we don't start to import invalid versions/constraints