### PR TITLE
fix: breaking `scss` design removed from

### DIFF
--- a/css/app.scss
+++ b/css/app.scss
@@ -779,7 +779,6 @@ input:focus:invalid:focus, textarea:focus:invalid:focus, select:focus:invalid:fo
     line-height: 20px;
     padding: 6px 0;
     margin: 0 -4px 6px 0;
-    padding-bottom: 7px;
     border-right: 0;
     background: none;
     color: #c6cacd;


### PR DESCRIPTION
## Changes
Previously user authentication related forms were broken due to a previous design changes. Removed the `scss` design rule to fix the form to it's previous state.

## Related
* Closes #1557 