### PR TITLE
Pin GitHub webhook signature algorithm to sha256

### DIFF
--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -512,10 +512,10 @@ class ApiController extends Controller
             $sig = $request->headers->get('X-Hub-Signature-256');
             $user = $this->getEM()->getRepository(User::class)->findOneBy(['usernameCanonical' => $username]);
             if ($sig && $user && $user->isEnabled()) {
-                [$algo, $sig] = explode('=', $sig);
-                $expected = hash_hmac($algo, $request->getContent(), $user->getApiToken());
+                $sig = Preg::isMatch('{^sha256=(?P<hex>[0-9a-f]{64})$}i', $sig, $sigMatch) ? strtolower($sigMatch['hex']) : '';
+                $expected = hash_hmac('sha256', $request->getContent(), $user->getApiToken());
                 $source = 'manual_github_hook';
-                if (hash_equals($expected, $sig) || hash_equals(hash_hmac($algo, $request->getContent(), $user->getSafeApiToken()), $sig)) {
+                if (hash_equals($expected, $sig) || hash_equals(hash_hmac('sha256', $request->getContent(), $user->getSafeApiToken()), $sig)) {
                     $packages = $this->findGitHubPackagesByRepository($match['path'], (string) $remoteId, $source, $user);
                     $autoUpdated = Package::AUTO_GITHUB_HOOK;
                     $receiveType = 'github_user_secret';
@@ -541,8 +541,8 @@ class ApiController extends Controller
         if (!$user && $match['host'] === 'github.com' && $request->getContent()) {
             $sig = $request->headers->get('X-Hub-Signature-256');
             if ($sig) {
-                [$algo, $sig] = explode('=', $sig);
-                $expected = hash_hmac($algo, $request->getContent(), $githubWebhookSecret);
+                $sig = Preg::isMatch('{^sha256=(?P<hex>[0-9a-f]{64})$}i', $sig, $sigMatch) ? strtolower($sigMatch['hex']) : '';
+                $expected = hash_hmac('sha256', $request->getContent(), $githubWebhookSecret);
                 $source = 'github_official_hook';
 
                 if (hash_equals($expected, $sig)) {

--- a/tests/Controller/ApiControllerTest.php
+++ b/tests/Controller/ApiControllerTest.php
@@ -68,6 +68,20 @@ class ApiControllerTest extends IntegrationTestCase
         ];
     }
 
+    public function testGithubHookRejectsMalformedSignature(): void
+    {
+        $payload = json_encode(['repository' => ['url' => 'https://github.com/composer/composer']]);
+        $this->client->request(
+            'POST',
+            '/api/github',
+            [],
+            [],
+            ['HTTP_X-Hub-Signature-256' => 'not-an-algo=deadbeef', 'CONTENT_TYPE' => 'application/json'],
+            $payload
+        );
+        $this->assertEquals(403, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
+    }
+
     public function testUnsafeApiRejectsSafeApiToken(): void
     {
         $user = self::createUser();


### PR DESCRIPTION
The `/api/github` handler split the `X-Hub-Signature-256` header on `=` and passed the left side to `hash_hmac` as the algorithm name, so a header like `bogus=...` raised an uncaught `ValueError` and returned 500 instead of rejecting the signature. This pins the algorithm to the sha256 scheme GitHub sends to that header and requires a well-formed hex digest, so malformed headers fall through to the existing 403. Adds a regression test.
