### PR TITLE
Escape GitHub API error text shown on the profile page

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -62,7 +62,7 @@ parameters:
         SecurityAdvisoryJob: 'array{source: string}'
         FilterListJob: 'array{list: string, source: string}'
 
-        JobResult: 'array{status: \App\Entity\Job::STATUS_*, message: string, vendor?: string, details?: string, exceptionMsg?: string, exceptionClass?: class-string<\Throwable>, results?: array{hooks_setup: int, hooks_failed: array<int, array{package: string, reason: mixed}>, hooks_ok_unchanged: int}}'
+        JobResult: 'array{status: \App\Entity\Job::STATUS_*, message: string, vendor?: string, details?: string, exceptionMsg?: string, exceptionClass?: class-string<\Throwable>, results?: array{hooks_setup: int, hooks_failed: array<int, array{package: string, reason: string, reasonIsHtml: bool}>, hooks_ok_unchanged: int}}'
         ErroredResult: 'array{status: \App\Entity\Job::STATUS_ERRORED, message: string, exception: \Throwable}'
         GenericCompletedResult: 'array{status: \App\Entity\Job::STATUS_COMPLETED, message: string}'
         RescheduleResult: 'array{status: \App\Entity\Job::STATUS_RESCHEDULE, after: \DateTimeImmutable, message: string, vendor?: string}'
@@ -72,7 +72,7 @@ parameters:
         PackageDeletedResult: 'array{status: \App\Entity\Job::STATUS_PACKAGE_DELETED, message: string, vendor: string, exception: \Throwable, details: string}'
         AdvisoriesCompletedResult: 'array{status: \App\Entity\Job::STATUS_COMPLETED, message: string, details: string}'
         AdvisoriesErroredResult: 'array{status: \App\Entity\Job::STATUS_ERRORED, message: string}'
-        GitHubMigrationResult: 'array{status: \App\Entity\Job::STATUS_COMPLETED, message: string, results: array{hooks_setup: int, hooks_failed: array<int, array{package: string, reason: mixed}>, hooks_ok_unchanged: int}}'
+        GitHubMigrationResult: 'array{status: \App\Entity\Job::STATUS_COMPLETED, message: string, results: array{hooks_setup: int, hooks_failed: array<int, array{package: string, reason: string, reasonIsHtml: bool}>, hooks_ok_unchanged: int}}'
         GitHubMigrationFailedResult: 'array{status: \App\Entity\Job::STATUS_FAILED, message: string}'
         FilterListCompletedResult: 'array{status: \App\Entity\Job::STATUS_COMPLETED, message: string}'
         FilterListErroredResult: 'array{status: \App\Entity\Job::STATUS_ERRORED, message: string}'

--- a/src/Service/GitHubUserMigrationWorker.php
+++ b/src/Service/GitHubUserMigrationWorker.php
@@ -69,8 +69,8 @@ class GitHubUserMigrationWorker
             $results = ['hooks_setup' => 0, 'hooks_failed' => [], 'hooks_ok_unchanged' => 0];
             foreach ($packageRepository->getGitHubPackagesByMaintainer($id) as $package) {
                 $result = $this->setupWebHook($user->getGithubToken(), $package);
-                if (\is_string($result)) {
-                    $results['hooks_failed'][] = ['package' => $package->getName(), 'reason' => $result];
+                if (\is_array($result)) {
+                    $results['hooks_failed'][] = ['package' => $package->getName(), 'reason' => $result['message'], 'reasonIsHtml' => $result['html']];
                 } elseif ($result === true) {
                     $results['hooks_setup']++;
                 } elseif ($result === false) {
@@ -93,7 +93,10 @@ class GitHubUserMigrationWorker
         ];
     }
 
-    public function setupWebHook(string $token, Package $package): bool|string|null
+    /**
+     * @return bool|array{message: string, html: bool}|null
+     */
+    public function setupWebHook(string $token, Package $package): bool|array|null
     {
         if (!Preg::isMatch('#^(?:(?:https?|git)://([^/]+)/|git@([^:]+):)(?P<owner>[^/]+)/(?P<repo>.+?)(?:\.git|/)?$#', $package->getRepository(), $match)) {
             return null;
@@ -179,10 +182,10 @@ class GitHubUserMigrationWorker
                 }
             }
         } catch (HttpExceptionInterface $e) {
-            if ($msg = $this->isAcceptableException($e)) {
-                $this->logger->debug($msg);
+            if ($failure = $this->isAcceptableException($e)) {
+                $this->logger->debug($failure['message']);
 
-                return $msg;
+                return $failure;
             }
 
             $this->logger->error('Rejected GitHub hook request', ['response' => (string) $e->getResponse()->getContent(false)]);
@@ -213,8 +216,8 @@ class GitHubUserMigrationWorker
                 }
             }
         } catch (HttpExceptionInterface $e) {
-            if ($msg = $this->isAcceptableException($e)) {
-                $this->logger->debug($msg);
+            if ($failure = $this->isAcceptableException($e)) {
+                $this->logger->debug($failure['message']);
 
                 return false;
             }
@@ -306,25 +309,28 @@ class GitHubUserMigrationWorker
         ];
     }
 
-    private function isAcceptableException(HttpExceptionInterface $e): string|false
+    /**
+     * @return array{message: string, html: bool}|false
+     */
+    private function isAcceptableException(HttpExceptionInterface $e): array|false
     {
         $message = $e->getResponse()->toArray(false)['message'];
 
         // repo not found probably means the user does not have admin access to it on github
         if ($e->getCode() === 404) {
-            return 'GitHub user has no admin access to the repository, or Packagist was not granted access to the organization (<a href="https://github.com/settings/connections/applications/a059f127e1c09c04aa5a">check here</a>)';
+            return ['message' => 'GitHub user has no admin access to the repository, or Packagist was not granted access to the organization (<a href="https://github.com/settings/connections/applications/a059f127e1c09c04aa5a">check here</a>)', 'html' => true];
         }
 
         if ($e->getCode() === 403 && str_contains($message, 'Repository was archived so is read-only')) {
-            return 'The repository is archived and read-only';
+            return ['message' => 'The repository is archived and read-only', 'html' => false];
         }
 
         if ($e->getCode() === 403) {
-            return $message;
+            return ['message' => (string) $message, 'html' => false];
         }
 
         if ($e->getCode() === 401 && str_contains($message, 'Bad credentials')) {
-            return 'Invalid credentials to access this repository';
+            return ['message' => 'Invalid credentials to access this repository', 'html' => false];
         }
 
         return false;

--- a/templates/user/my_profile.html.twig
+++ b/templates/user/my_profile.html.twig
@@ -47,7 +47,7 @@
                 {% if githubSync.result.results.hooks_failed|length > 0 %}
                     <h4>Hooks setup failures</h4>
                     {% for fail in githubSync.result.results.hooks_failed %}
-                        <p><a href="{{ path('view_package', {name: fail.package}) }}">{{ fail.package }}</a> {{ fail.reason|raw }}</p>
+                        <p><a href="{{ path('view_package', {name: fail.package}) }}">{{ fail.package }}</a> {% if fail.reasonIsHtml|default(false) %}{{ fail.reason|raw }}{% else %}{{ fail.reason }}{% endif %}</p>
                     {% endfor %}
                 {% endif %}
             {% endif %}


### PR DESCRIPTION
`isAcceptableException` returns the upstream GitHub error message for a 403, and `my_profile.html.twig` renders the failure reason with `|raw` because the 404 branch returns trusted markup. This escapes the upstream-controlled text so it can't inject markup into the page.
