### PR TITLE
Harden internal metadata write path check and signature

### DIFF
--- a/src/Controller/InternalController.php
+++ b/src/Controller/InternalController.php
@@ -41,13 +41,13 @@ class InternalController extends Controller
         $filemtime = $req->request->getInt('filemtime');
         $sig = (string) $req->headers->get('Internal-Signature');
 
-        $expectedSig = hash_hmac('sha256', $path.$contents.$filemtime, $this->internalSecret);
+        $expectedSig = hash_hmac('sha256', \strlen($path).':'.$path.':'.\strlen($contents).':'.$contents.':'.$filemtime, $this->internalSecret);
         if (!hash_equals($expectedSig, $sig)) {
             $this->logger->error('Invalid signature', ['contents' => $contents, 'path' => $path, 'filemtime' => $filemtime, 'sig' => $sig]);
             throw $this->createAccessDeniedException();
         }
 
-        if (!Preg::isMatch('{^(packages\.json|p2/.*\.json)$}', $path)) {
+        if (str_contains($path, '..') || !Preg::isMatch('{^(packages\.json|p2/[^/]+/[^/]+\.json)$}', $path)) {
             $this->logger->error('Invalid path received for metadata write: '.$path);
             throw $this->createAccessDeniedException();
         }

--- a/src/Service/ReplicaClient.php
+++ b/src/Service/ReplicaClient.php
@@ -30,7 +30,7 @@ class ReplicaClient
 
     public function uploadMetadata(string $path, string $contents, int $filemtime): void
     {
-        $sig = hash_hmac('sha256', $path.$contents.$filemtime, $this->internalSecret);
+        $sig = hash_hmac('sha256', \strlen($path).':'.$path.':'.\strlen($contents).':'.$contents.':'.$filemtime, $this->internalSecret);
 
         $resps = [];
         foreach ($this->replicaIps as $ip) {

--- a/tests/Controller/InternalControllerTest.php
+++ b/tests/Controller/InternalControllerTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Packagist.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *     Nils Adermann <naderman@naderman.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Controller;
+
+use App\Tests\IntegrationTestCase;
+
+class InternalControllerTest extends IntegrationTestCase
+{
+    private function sign(string $path, string $contents, int $filemtime): string
+    {
+        $secret = (string) static::getContainer()->getParameter('kernel.secret');
+
+        return hash_hmac('sha256', \strlen($path).':'.$path.':'.\strlen($contents).':'.$contents.':'.$filemtime, $secret);
+    }
+
+    private function post(string $path, string $contents, int $filemtime, string $sig): void
+    {
+        $this->client->request(
+            'POST',
+            '/internal/update-metadata',
+            ['path' => $path, 'contents' => $contents, 'filemtime' => $filemtime],
+            [],
+            ['HTTP_Internal-Signature' => $sig]
+        );
+    }
+
+    public function testAcceptsValidSignedMetadataWrite(): void
+    {
+        $path = 'p2/test/internal-write-'.bin2hex(random_bytes(6)).'.json';
+        $contents = '{"packages":{}}';
+        $filemtime = 1700000000;
+        $target = static::getContainer()->getParameter('kernel.cache_dir').'/composer-packages-build/'.$path.'.gz';
+
+        $this->post($path, $contents, $filemtime, $this->sign($path, $contents, $filemtime));
+
+        self::assertSame(202, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
+        self::assertFileExists($target);
+        @unlink($target);
+    }
+
+    public function testRejectsPathTraversalEvenWithValidSignature(): void
+    {
+        $path = 'p2/../../../../tmp/packagist-traversal-test.json';
+        $contents = '{"packages":{}}';
+        $filemtime = 1700000000;
+
+        $this->post($path, $contents, $filemtime, $this->sign($path, $contents, $filemtime));
+
+        // access-denied redirects to login rather than writing the file
+        self::assertSame(302, $this->client->getResponse()->getStatusCode());
+        self::assertFileDoesNotExist(sys_get_temp_dir().'/packagist-traversal-test.json.gz');
+    }
+
+    public function testRejectsInvalidSignature(): void
+    {
+        $this->post('p2/test/pkg.json', '{"packages":{}}', 1700000000, 'deadbeef');
+
+        self::assertSame(302, $this->client->getResponse()->getStatusCode());
+    }
+}


### PR DESCRIPTION
Two fixes to the internal metadata write endpoint, both only reachable with the internal secret. The path was matched with `p2/.*\.json` where `.` also matches `/`, so `..` segments passed and could resolve outside the metadata dir; now restricted to `p2/vendor/package.json` segments with a `..` reject. The HMAC signed path, contents and filemtime with no delimiter, so different boundaries produced the same message; now length-prefixed on both sender and receiver. Signature format changes, so primary and replicas must deploy together (writes are idempotent, `replicaIps` empty by default).
