### PR TITLE
Validate URL schemes on package metadata link fields

### DIFF
--- a/src/Package/Updater.php
+++ b/src/Package/Updater.php
@@ -737,7 +737,7 @@ class Updater
             }
         }
 
-        $version->setHomepage($data->getHomepage());
+        $version->setHomepage($this->filterUrl($data->getHomepage()));
         $version->setLicense($data->getLicense() ?: []);
 
         $version->setPackage($package);
@@ -783,8 +783,8 @@ class Updater
         $version->setExtra($data->getExtra());
         $version->setBinaries($data->getBinaries());
         $version->setIncludePaths($data->getIncludePaths());
-        $version->setSupport($data->getSupport());
-        $version->setFunding($data->getFunding());
+        $version->setSupport($this->filterSupportUrls($data->getSupport()));
+        $version->setFunding($this->filterFundingUrls($data->getFunding()));
 
         if ($data->getKeywords()) {
             $keywords = [];
@@ -825,6 +825,9 @@ class Updater
                 foreach (['email', 'name', 'homepage', 'role'] as $field) {
                     if (isset($authorData[$field])) {
                         $author[$field] = trim($authorData[$field]);
+                        if ('homepage' === $field) {
+                            $author[$field] = (string) $this->filterUrl($author[$field]);
+                        }
                         if ('' === $author[$field]) {
                             unset($author[$field]);
                         }
@@ -1162,6 +1165,61 @@ class Updater
         $str = Preg::replace("{\x1B(?:\[.)?}u", '', $str);
 
         return Preg::replace("{[\x01-\x1A]}u", '', $str);
+    }
+
+    /**
+     * Package metadata link fields are rendered into href attributes, so only web
+     * schemes are allowed, mirroring the readme link sanitizer (allowLinkSchemes).
+     */
+    private function filterUrl(?string $url): ?string
+    {
+        if (null === $url || '' === $url) {
+            return $url;
+        }
+
+        $scheme = strtolower((string) parse_url($url, \PHP_URL_SCHEME));
+
+        return \in_array($scheme, ['http', 'https'], true) ? $url : null;
+    }
+
+    /**
+     * @param array{issues?: string, forum?: string, wiki?: string, source?: string, email?: string, irc?: string, docs?: string, rss?: string, chat?: string, security?: string}|null $support
+     *
+     * @return array<string, string>|null
+     */
+    private function filterSupportUrls(?array $support): ?array
+    {
+        if (null === $support) {
+            return null;
+        }
+
+        foreach (['issues', 'forum', 'wiki', 'source', 'docs', 'rss', 'chat', 'security'] as $key) {
+            if (isset($support[$key]) && null === $this->filterUrl($support[$key])) {
+                unset($support[$key]);
+            }
+        }
+
+        return $support;
+    }
+
+    /**
+     * @param array<array{type?: string, url?: string}>|null $funding
+     *
+     * @return array<array{type?: string, url?: string}>|null
+     */
+    private function filterFundingUrls(?array $funding): ?array
+    {
+        if (null === $funding) {
+            return null;
+        }
+
+        foreach ($funding as $i => $entry) {
+            if (isset($entry['url']) && null === $this->filterUrl($entry['url'])) {
+                unset($funding[$i]['url']);
+            }
+        }
+
+        return $funding;
     }
 
     private function detectAbandonmentReason(VcsDriverInterface $driver, string $rootIdentifier): AbandonmentReason

--- a/src/Package/Updater.php
+++ b/src/Package/Updater.php
@@ -1201,9 +1201,11 @@ class Updater
             }
         }
 
-        // chat may point at an IRC channel, so allow the irc/ircs schemes there too
-        if (isset($support['chat']) && null === $this->filterUrl($support['chat'], ['http', 'https', 'irc', 'ircs'])) {
-            unset($support['chat']);
+        // chat and irc may point at an IRC channel, so allow the irc/ircs schemes there too
+        foreach (['chat', 'irc'] as $key) {
+            if (isset($support[$key]) && null === $this->filterUrl($support[$key], ['http', 'https', 'irc', 'ircs'])) {
+                unset($support[$key]);
+            }
         }
 
         return $support;

--- a/src/Package/Updater.php
+++ b/src/Package/Updater.php
@@ -1170,8 +1170,10 @@ class Updater
     /**
      * Package metadata link fields are rendered into href attributes, so only web
      * schemes are allowed, mirroring the readme link sanitizer (allowLinkSchemes).
+     *
+     * @param list<string> $allowedSchemes
      */
-    private function filterUrl(?string $url): ?string
+    private function filterUrl(?string $url, array $allowedSchemes = ['http', 'https']): ?string
     {
         if (null === $url || '' === $url) {
             return $url;
@@ -1179,7 +1181,7 @@ class Updater
 
         $scheme = strtolower((string) parse_url($url, \PHP_URL_SCHEME));
 
-        return \in_array($scheme, ['http', 'https'], true) ? $url : null;
+        return \in_array($scheme, $allowedSchemes, true) ? $url : null;
     }
 
     /**
@@ -1193,10 +1195,15 @@ class Updater
             return null;
         }
 
-        foreach (['issues', 'forum', 'wiki', 'source', 'docs', 'rss', 'chat', 'security'] as $key) {
+        foreach (['issues', 'forum', 'wiki', 'source', 'docs', 'rss', 'security'] as $key) {
             if (isset($support[$key]) && null === $this->filterUrl($support[$key])) {
                 unset($support[$key]);
             }
+        }
+
+        // chat may point at an IRC channel, so allow the irc/ircs schemes there too
+        if (isset($support['chat']) && null === $this->filterUrl($support['chat'], ['http', 'https', 'irc', 'ircs'])) {
+            unset($support['chat']);
         }
 
         return $support;

--- a/tests/Package/UpdaterTest.php
+++ b/tests/Package/UpdaterTest.php
@@ -121,6 +121,7 @@ class UpdaterTest extends IntegrationTestCase
             'source' => 'https://github.com/test/pkg',
             'email' => 'security@example.com',
             'chat' => 'irc://irc.libera.chat/composer',
+            'irc' => 'javascript:alert(4)',
         ]);
         $upstream->setFunding([
             ['type' => 'custom', 'url' => 'javascript:alert(2)'],
@@ -145,6 +146,7 @@ class UpdaterTest extends IntegrationTestCase
         self::assertSame('https://github.com/test/pkg', $support['source']);
         self::assertSame('security@example.com', $support['email']);
         self::assertSame('irc://irc.libera.chat/composer', $support['chat']);
+        self::assertArrayNotHasKey('irc', $support);
 
         $funding = $version->getFunding();
         self::assertArrayNotHasKey('url', $funding[0]);

--- a/tests/Package/UpdaterTest.php
+++ b/tests/Package/UpdaterTest.php
@@ -120,6 +120,7 @@ class UpdaterTest extends IntegrationTestCase
             'issues' => 'javascript:alert(1)',
             'source' => 'https://github.com/test/pkg',
             'email' => 'security@example.com',
+            'chat' => 'irc://irc.libera.chat/composer',
         ]);
         $upstream->setFunding([
             ['type' => 'custom', 'url' => 'javascript:alert(2)'],
@@ -143,6 +144,7 @@ class UpdaterTest extends IntegrationTestCase
         self::assertArrayNotHasKey('issues', $support);
         self::assertSame('https://github.com/test/pkg', $support['source']);
         self::assertSame('security@example.com', $support['email']);
+        self::assertSame('irc://irc.libera.chat/composer', $support['chat']);
 
         $funding = $version->getFunding();
         self::assertArrayNotHasKey('url', $funding[0]);

--- a/tests/Package/UpdaterTest.php
+++ b/tests/Package/UpdaterTest.php
@@ -109,6 +109,50 @@ class UpdaterTest extends IntegrationTestCase
         $this->assertStringContainsString('This is the readme', $readme->contents);
     }
 
+    public function testFiltersDangerousUrlSchemesFromMetadata(): void
+    {
+        $upstream = new CompletePackage('test/pkg', '1.0.0.0', '1.0.0');
+        $upstream->setSourceType('git');
+        $upstream->setSourceUrl('https://example.com/test/pkg');
+        $upstream->setSourceReference('abcdef1234567890');
+        $upstream->setHomepage('javascript:alert(document.domain)');
+        $upstream->setSupport([
+            'issues' => 'javascript:alert(1)',
+            'source' => 'https://github.com/test/pkg',
+            'email' => 'security@example.com',
+        ]);
+        $upstream->setFunding([
+            ['type' => 'custom', 'url' => 'javascript:alert(2)'],
+            ['type' => 'github', 'url' => 'https://github.com/sponsors/test'],
+        ]);
+        $upstream->setAuthors([
+            ['name' => 'Bob', 'homepage' => 'javascript:alert(3)'],
+        ]);
+
+        $this->repositoryMock = $this->createStub(VcsRepository::class);
+        $this->repositoryMock->method('getPackages')->willReturn([$upstream]);
+        $this->repositoryMock->method('getDriver')->willReturn($this->stableDriver());
+
+        $this->updater->update($this->ioMock, $this->config, $this->package, $this->repositoryMock);
+
+        $version = $this->getEM()->getRepository(Version::class)->findOneBy(['name' => 'test/pkg', 'normalizedVersion' => '1.0.0.0']);
+        self::assertNotNull($version);
+        self::assertNull($version->getHomepage());
+
+        $support = $version->getSupport();
+        self::assertArrayNotHasKey('issues', $support);
+        self::assertSame('https://github.com/test/pkg', $support['source']);
+        self::assertSame('security@example.com', $support['email']);
+
+        $funding = $version->getFunding();
+        self::assertArrayNotHasKey('url', $funding[0]);
+        self::assertSame('https://github.com/sponsors/test', $funding[1]['url']);
+
+        $authors = $version->getAuthors();
+        self::assertArrayNotHasKey('homepage', $authors[0]);
+        self::assertSame('Bob', $authors[0]['name']);
+    }
+
     public function testConvertsMarkdownForReadme(): void
     {
         $readme = <<<EOR


### PR DESCRIPTION
A package's homepage, the support source/issues/chat/forum/wiki/docs/security links, funding URLs and author homepages come from its composer.json and are rendered into href attributes, but were stored without a scheme check while the readme link sanitizer already restricts schemes via `allowLinkSchemes`. This drops any of those fields whose scheme is not http or https at store time, so the stored metadata and the dumped v2 JSON only carry web links.
