### PR TITLE
Add tooltips to version list

### DIFF
--- a/css/app.scss
+++ b/css/app.scss
@@ -1405,7 +1405,7 @@ input:focus:invalid:focus, textarea:focus:invalid:focus, select:focus:invalid:fo
   color: #b87800;
 }
 
-.package .versions .version.version-soft-deleted .version-number {
+.package .versions .version.version-soft-deleted .version-number a {
   color: #999;
   text-decoration: line-through;
   text-decoration-color: rgba(153, 153, 153, 0.5);

--- a/css/app.scss
+++ b/css/app.scss
@@ -1313,15 +1313,6 @@ input:focus:invalid:focus, textarea:focus:invalid:focus, select:focus:invalid:fo
   color: #2d2d32;
   margin-right: 4px;
 }
-.package .package-aside a.advisory-alert {
-    margin-left: -40px;
-}
-.package .package-aside a.malware-alert {
-    margin-left: -40px;
-}
-.package .package-aside a.retag-blocked-alert {
-    margin-left: -40px;
-}
 .package .package-aside a.action-alert:hover, .package .package-aside a.action-alert:active {
     text-decoration: none;
 }
@@ -1369,12 +1360,16 @@ input:focus:invalid:focus, textarea:focus:invalid:focus, select:focus:invalid:fo
   line-height: 25px;
 }
 .package .versions .version {
-  padding: 2px 0 2px 5px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 26px;
+  padding: 2px 5px 2px 5px;
 }
 .package .versions .version-number {
-  display: block;
-  float: left;
-  width: 91%;
+  flex: 1 1 auto;
+  min-width: 0;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
@@ -1383,21 +1378,14 @@ input:focus:invalid:focus, textarea:focus:invalid:focus, select:focus:invalid:fo
   cursor: pointer;
 }
 
-.package .versions .version {
-  position: relative;
-  display: block;
-  height: 26px;
-}
 .package .delete-version, .package .hide-version {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
 }
 .package .delete-version .submit, .package .hide-version .submit {
-  position: absolute;
-  top: 7px;
   cursor: pointer;
 }
-.package .delete-version .submit { right: 5px; }
-.package .hide-version .submit { right: 25px; color: #999; }
+.package .hide-version .submit { color: #999; }
 .package .delete-version .submit:hover, .package .package-aside a.action-alert:hover i {
   color: #cd3729;
 }
@@ -1411,9 +1399,6 @@ input:focus:invalid:focus, textarea:focus:invalid:focus, select:focus:invalid:fo
   text-decoration-color: rgba(153, 153, 153, 0.5);
 }
 .package .package-aside .deletion-alert {
-  position: absolute;
-  right: 28px;
-  top: 2px;
   cursor: help;
 }
 .package .package-aside .deletion-alert i {
@@ -1424,12 +1409,10 @@ input:focus:invalid:focus, textarea:focus:invalid:focus, select:focus:invalid:fo
   color: #b87800;
 }
 .package .recover-version {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
 }
 .package .recover-version .submit {
-  position: absolute;
-  right: 5px;
-  top: 6px;
   cursor: pointer;
   color: #999;
 }
@@ -1464,10 +1447,6 @@ input:focus:invalid:focus, textarea:focus:invalid:focus, select:focus:invalid:fo
     .package .versions .version {
       padding: 2px 15px 2px 15px;
     }
-    .package .delete-version .submit {
-      right: 15px;
-    }
-    .package .hide-version .submit { right: 35px; }
 }
 @media (max-width: 767px) {
   .package-aside .facts {

--- a/js/app.js
+++ b/js/app.js
@@ -77,6 +77,8 @@ import 'bootstrap';
             }
         } catch (e) {}
     }
+
+    $('[data-toggle="tooltip"]').tooltip();
 })(jQuery);
 
 if (

--- a/templates/package/version_list.html.twig
+++ b/templates/package/version_list.html.twig
@@ -4,43 +4,51 @@
             {% set expanded = version.id == expandedId|default(false) %}
             {% set softDeleted = version.softDeletedAt is not null %}
             {% set reason = version.deletionReason %}
+
+            {% if softDeleted %}
+                {% set deletionTitle = 'Deleted' %}
+                {% if reason == enum('App\\Audit\\VersionDeletionReason').DeletedByMaintainer %}
+                    {% set deletionTitle = 'Deleted by maintainer on ' ~ version.softDeletedAt|date('Y-m-d H:i:s') ~ ' UTC' %}
+                {% elseif reason == enum('App\\Audit\\VersionDeletionReason').DeletedByAdmin %}
+                    {% set deletionTitle = 'Removed by admin on ' ~ version.softDeletedAt|date('Y-m-d H:i:s') ~ ' UTC' ~ (version.deletionReasonText ? ': ' ~ version.deletionReasonText : '') %}
+                {% elseif reason == enum('App\\Audit\\VersionDeletionReason').AutoDeletedMissing %}
+                    {% set deletionTitle = 'No longer found in upstream repository' %}
+                {% elseif reason == enum('App\\Audit\\VersionDeletionReason').Hidden %}
+                    {% set deletionTitle = 'Hidden by admin on ' ~ version.softDeletedAt|date('Y-m-d H:i:s') ~ ' UTC' ~ (version.deletionReasonText ? ': ' ~ version.deletionReasonText : '') %}
+                {% endif %}
+            {% endif %}
+
             <li class="details-toggler version{% if loop.last %} last{% endif %}{% if expanded %} open{% endif %}{% if softDeleted %} version-soft-deleted{% endif %}" data-version-id="{{ version.version }}" data-load-more="{{ path('view_version', {versionId: version.id, _format: 'json'}) }}">
-                <a rel="nofollow noindex" href="#{{ version.version }}" class="version-number">
-                    {{- version.version -}}
-                    {% if version.hasVersionAlias() %}
-                        / {{ version.versionAlias }}
-                    {% endif -%}
-                </a>
+                <div class="version-number">
+                    <a rel="nofollow noindex" href="#{{ version.version }}" {% if softDeleted %}data-toggle="tooltip" data-placement="top" title="{{ deletionTitle }}" data-container="body"{% endif %}>
+                        {{- version.version -}}
+                        {% if version.hasVersionAlias() %}
+                            / {{ version.versionAlias }}
+                        {% endif -%}
+                    </a>
+                </div>
 
                 {% if hasVersionSecurityAdvisories[version.id]|default(false) %}
                     <a rel="nofollow noindex" class="action-alert advisory-alert" href="{{ path('view_package_advisories', {name: package.name, version: version.id}) }}">
-                        <i class="glyphicon glyphicon-alert " title="Version has security advisories"></i>
+                        <i class="glyphicon glyphicon-alert" data-toggle="tooltip" data-placement="top" title="Version has security advisories"></i>
                     </a>
                 {% endif %}
 
                 {% if hasVersionsFlaggedAsMalware[version.id]|default(false) %}
                     <a rel="nofollow noindex" class="action-alert malware-alert" href="{{ path('view_package_filter_lists', {name: package.name, version: version.id, list: 'malware'}) }}">
-                        <i class="glyphicon glyphicon-fire" title="Version was flagged as malware"></i>
+                        <i class="glyphicon glyphicon-fire" data-toggle="tooltip" data-placement="top" title="Version was flagged as malware"></i>
                     </a>
                 {% endif %}
 
                 {% if version.lastBlockedReference is not null and not softDeleted %}
-                    <a rel="nofollow noindex" class="action-alert retag-blocked-alert" href="{{ path('about_version_immutability') }}" title="Upstream re-tag blocked — Packagist may no longer match the VCS repo for this version">
+                    <a rel="nofollow noindex" class="action-alert retag-blocked-alert" href="{{ path('about_version_immutability') }}" data-toggle="tooltip" data-placement="top" title="Upstream re-tag blocked — Packagist may no longer match the VCS repo for this version">
                         <i class="glyphicon glyphicon-warning-sign"></i>
                     </a>
                 {% endif %}
 
                 {% if softDeleted %}
-                    {% set deletionTitle = 'Deleted' %}
                     {% set deletionIcon = 'glyphicon-trash' %}
-                    {% if reason == enum('App\\Audit\\VersionDeletionReason').DeletedByMaintainer %}
-                        {% set deletionTitle = 'Deleted by maintainer on ' ~ version.softDeletedAt|date('Y-m-d H:i:s') ~ ' UTC' %}
-                    {% elseif reason == enum('App\\Audit\\VersionDeletionReason').DeletedByAdmin %}
-                        {% set deletionTitle = 'Removed by admin on ' ~ version.softDeletedAt|date('Y-m-d H:i:s') ~ ' UTC' ~ (version.deletionReasonText ? ': ' ~ version.deletionReasonText : '') %}
-                    {% elseif reason == enum('App\\Audit\\VersionDeletionReason').AutoDeletedMissing %}
-                        {% set deletionTitle = 'No longer found in upstream repository' %}
-                    {% elseif reason == enum('App\\Audit\\VersionDeletionReason').Hidden %}
-                        {% set deletionTitle = 'Hidden by admin on ' ~ version.softDeletedAt|date('Y-m-d H:i:s') ~ ' UTC' ~ (version.deletionReasonText ? ': ' ~ version.deletionReasonText : '') %}
+                    {% if reason == enum('App\\Audit\\VersionDeletionReason').Hidden %}
                         {% set deletionIcon = 'glyphicon-eye-close' %}
                     {% endif %}
                     <span class="action-alert deletion-alert" title="{{ deletionTitle }}">

--- a/templates/package/version_list.html.twig
+++ b/templates/package/version_list.html.twig
@@ -30,18 +30,18 @@
 
                 {% if hasVersionSecurityAdvisories[version.id]|default(false) %}
                     <a rel="nofollow noindex" class="action-alert advisory-alert" href="{{ path('view_package_advisories', {name: package.name, version: version.id}) }}">
-                        <i class="glyphicon glyphicon-alert" data-toggle="tooltip" data-placement="top" title="Version has security advisories"></i>
+                        <i class="glyphicon glyphicon-alert" data-toggle="tooltip" data-placement="top" title="Version has security advisories" data-container="body"></i>
                     </a>
                 {% endif %}
 
                 {% if hasVersionsFlaggedAsMalware[version.id]|default(false) %}
                     <a rel="nofollow noindex" class="action-alert malware-alert" href="{{ path('view_package_filter_lists', {name: package.name, version: version.id, list: 'malware'}) }}">
-                        <i class="glyphicon glyphicon-fire" data-toggle="tooltip" data-placement="top" title="Version was flagged as malware"></i>
+                        <i class="glyphicon glyphicon-fire" data-toggle="tooltip" data-placement="top" title="Version was flagged as malware" data-container="body"></i>
                     </a>
                 {% endif %}
 
                 {% if version.lastBlockedReference is not null and not softDeleted %}
-                    <a rel="nofollow noindex" class="action-alert retag-blocked-alert" href="{{ path('about_version_immutability') }}" data-toggle="tooltip" data-placement="top" title="Upstream re-tag blocked — Packagist may no longer match the VCS repo for this version">
+                    <a rel="nofollow noindex" class="action-alert retag-blocked-alert" href="{{ path('about_version_immutability') }}" data-toggle="tooltip" data-placement="top" title="Upstream re-tag blocked — Packagist may no longer match the VCS repo for this version" data-container="body">
                         <i class="glyphicon glyphicon-warning-sign"></i>
                     </a>
                 {% endif %}
@@ -51,7 +51,7 @@
                     {% if reason == enum('App\\Audit\\VersionDeletionReason').Hidden %}
                         {% set deletionIcon = 'glyphicon-eye-close' %}
                     {% endif %}
-                    <span class="action-alert deletion-alert" title="{{ deletionTitle }}">
+                    <span class="action-alert deletion-alert" data-toggle="tooltip" data-placement="top" title="{{ deletionTitle }}" data-container="body">
                         <i class="glyphicon {{ deletionIcon }}"></i>
                     </span>
                 {% endif %}
@@ -60,7 +60,7 @@
                     {% if canHideVersion|default(false) %}
                         <form class="hide-version" action="{{ path("admin_hide_version", {"versionId": version.id}) }}" method="POST">
                             <input type="hidden" name="_token" value="{{ manageVersionsCsrfToken }}" />
-                            <i class="submit glyphicon glyphicon-eye-close" title="Hide version from public"></i>
+                            <i class="submit glyphicon glyphicon-eye-close" data-toggle="tooltip" data-placement="top" title="Hide version from public" data-container="body"></i>
                         </form>
                     {% endif %}
                     <form class="delete-version" action="{{ path("delete_version", {"versionId": version.id}) }}" method="DELETE"
@@ -70,7 +70,7 @@
                           {% endif %}
                           >
                         <input type="hidden" name="_token" value="{{ manageVersionsCsrfToken }}" />
-                        <i class="submit glyphicon glyphicon-remove" title="{% if version.isDevelopment() %}Hard-delete dev version permanently{% else %}Soft-delete stable version{% endif %}{% if canAdminDeleteVersion|default(false) %} (or remove with reason){% endif %}"></i>
+                        <i class="submit glyphicon glyphicon-remove" data-toggle="tooltip" data-placement="top" title="{% if version.isDevelopment() %}Hard-delete dev version permanently{% else %}Soft-delete stable version{% endif %}{% if canAdminDeleteVersion|default(false) %} (or remove with reason){% endif %}" data-container="body"></i>
                     </form>
                 {% endif %}
 
@@ -83,7 +83,7 @@
                 {% if canRecover %}
                     <form class="recover-version" action="{{ path("recover_version", {"versionId": version.id}) }}" method="POST">
                         <input type="hidden" name="_token" value="{{ manageVersionsCsrfToken }}" />
-                        <i class="submit glyphicon glyphicon-repeat" title="Recover version"></i>
+                        <i class="submit glyphicon glyphicon-repeat" data-toggle="tooltip" data-placement="top" title="Recover version" data-container="body"></i>
                     </form>
                 {% endif %}
             </li>


### PR DESCRIPTION
It's not clear why a version could be grayed out and crossed out now, so this PR adds a tooltip to display the reason. 

Since I was playing around with that file now anyway, I also added tooltips to the other buttons in there, and changed the styling for every version row to automatically align all icons to the right in the same way. (Claude Code did that, actually). Only suggestions, let me know if you want to drop/change anything.

<img width="423" height="220" alt="CleanShot 2026-06-11 at 11 56 55" src="https://github.com/user-attachments/assets/fdb354d0-352e-457c-9477-df7b27547746" />
