### PR TITLE
Fix handling of withdrawn advisories

### DIFF
--- a/src/SecurityAdvisory/GitHubSecurityAdvisoriesSource.php
+++ b/src/SecurityAdvisory/GitHubSecurityAdvisoriesSource.php
@@ -55,6 +55,8 @@ class GitHubSecurityAdvisoriesSource implements SecurityAdvisorySourceInterface
         $advisoryMap = [];
         /** @var array<string, array<string, true>> $foundPackageCves */
         $foundPackageCves = [];
+        /** @var array<string, array<string, true>> $withdrawnAdvisories */
+        $withdrawnAdvisories = [];
         $hasNextPage = true;
         $after = '';
 
@@ -100,10 +102,6 @@ class GitHubSecurityAdvisoriesSource implements SecurityAdvisorySourceInterface
                 $remoteId = null;
                 $cve = null;
 
-                if (isset($node['advisory']['withdrawnAt'])) {
-                    continue;
-                }
-
                 foreach ($node['advisory']['identifiers'] as $identifier) {
                     if ('GHSA' === $identifier['type']) {
                         $remoteId = $identifier['value'];
@@ -122,6 +120,14 @@ class GitHubSecurityAdvisoriesSource implements SecurityAdvisorySourceInterface
                 }
 
                 $packageName = strtolower($node['package']['name']);
+
+                // Record advisories withdrawn at the source so existing DB entries can be removed.
+                // These are kept out of $advisoryMap and $foundPackageCves so a live advisory for
+                // the same CVE is not suppressed by a withdrawn one.
+                if (isset($node['advisory']['withdrawnAt'])) {
+                    $withdrawnAdvisories[$packageName][$remoteId] = true;
+                    continue;
+                }
 
                 // GitHub adds spaces everywhere e.g. > 1.0, adjust to be able to match other advisories
                 $versionRange = Preg::replace('#\s#', '', $node['vulnerableVersionRange']);
@@ -177,7 +183,20 @@ class GitHubSecurityAdvisoriesSource implements SecurityAdvisorySourceInterface
             }
         }
 
-        return new RemoteSecurityAdvisoryCollection($advisories);
+        // A remote id that is both withdrawn and live in the same run (e.g. withdrawn on one node
+        // but present on another) must be treated as live, so do not flag it for removal.
+        foreach ($withdrawnAdvisories as $packageName => $remoteIds) {
+            foreach (array_keys($remoteIds) as $remoteId) {
+                if (isset($advisoryMap[$packageName][$remoteId])) {
+                    unset($withdrawnAdvisories[$packageName][$remoteId]);
+                }
+            }
+            if (\count($withdrawnAdvisories[$packageName]) === 0) {
+                unset($withdrawnAdvisories[$packageName]);
+            }
+        }
+
+        return new RemoteSecurityAdvisoryCollection($advisories, $withdrawnAdvisories);
     }
 
     private function getQuery(string $after = ''): string

--- a/src/SecurityAdvisory/RemoteSecurityAdvisoryCollection.php
+++ b/src/SecurityAdvisory/RemoteSecurityAdvisoryCollection.php
@@ -19,9 +19,12 @@ class RemoteSecurityAdvisoryCollection
 
     /**
      * @param list<RemoteSecurityAdvisory> $advisories
+     * @param array<string, array<string, true>> $withdrawnAdvisories packageName => (remoteId => true) for advisories withdrawn at the source
      */
-    public function __construct(array $advisories)
-    {
+    public function __construct(
+        array $advisories,
+        private readonly array $withdrawnAdvisories = [],
+    ) {
         foreach ($advisories as $advisory) {
             $this->groupedSecurityAdvisories[$advisory->packageName][] = $advisory;
         }
@@ -41,5 +44,21 @@ class RemoteSecurityAdvisoryCollection
     public function getPackageNames(): array
     {
         return array_keys($this->groupedSecurityAdvisories);
+    }
+
+    /**
+     * Whether the advisory with the given remote id was withdrawn at the source for the given package.
+     */
+    public function isWithdrawn(string $packageName, string $remoteId): bool
+    {
+        return isset($this->withdrawnAdvisories[$packageName][$remoteId]);
+    }
+
+    /**
+     * @return list<string> package names that have at least one advisory withdrawn at the source
+     */
+    public function getWithdrawnPackageNames(): array
+    {
+        return array_keys($this->withdrawnAdvisories);
     }
 }

--- a/src/SecurityAdvisory/SecurityAdvisoryResolver.php
+++ b/src/SecurityAdvisory/SecurityAdvisoryResolver.php
@@ -17,6 +17,52 @@ use App\Entity\SecurityAdvisory;
 class SecurityAdvisoryResolver
 {
     /**
+     * Remove the source from existing advisories that were withdrawn at the remote source.
+     *
+     * The caller is expected to delete the returned advisories (and flush) before running
+     * {@see self::resolve()}, so the freed (packageName, cve) unique key can be reused in the
+     * same run without a constraint violation.
+     *
+     * @param SecurityAdvisory[] $existingAdvisories
+     *
+     * @return array{SecurityAdvisory[], SecurityAdvisory[]} [$remaining, $toRemove]
+     */
+    public function removeWithdrawn(array $existingAdvisories, RemoteSecurityAdvisoryCollection $remoteAdvisories, string $sourceName): array
+    {
+        $remaining = [];
+        $toRemove = [];
+        foreach ($existingAdvisories as $advisory) {
+            $sourceRemoteId = $advisory->getSourceRemoteId($sourceName);
+            if (null !== $sourceRemoteId && $remoteAdvisories->isWithdrawn($advisory->getPackageName(), $sourceRemoteId)) {
+                // The withdrawn source is the only one: remove the whole advisory. The source row is
+                // left attached so the caller can delete the full entity graph in one go.
+                if (!$this->hasOtherSource($advisory, $sourceName)) {
+                    $toRemove[] = $advisory;
+                    continue;
+                }
+
+                // Other sources remain, so only drop the withdrawn source and keep the advisory.
+                $advisory->removeSource($sourceName);
+            }
+
+            $remaining[] = $advisory;
+        }
+
+        return [$remaining, $toRemove];
+    }
+
+    private function hasOtherSource(SecurityAdvisory $advisory, string $sourceName): bool
+    {
+        foreach ($advisory->getSources() as $source) {
+            if ($source->getSource() !== $sourceName) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @param SecurityAdvisory[] $existingAdvisories
      *
      * @return array{SecurityAdvisory[], SecurityAdvisory[]}

--- a/src/Service/SecurityAdvisoryWorker.php
+++ b/src/Service/SecurityAdvisoryWorker.php
@@ -66,8 +66,31 @@ class SecurityAdvisoryWorker
             return ['status' => Job::STATUS_ERRORED, 'message' => 'Security advisory update failed, skipped'];
         }
 
+        // Include packages that only have withdrawn advisories this run so their stale DB entries
+        // are still loaded (getPackageAdvisoriesWithSources returns nothing for an empty list).
+        $packageNames = array_values(array_unique([...$remoteAdvisories->getPackageNames(), ...$remoteAdvisories->getWithdrawnPackageNames()]));
+
         /** @var SecurityAdvisory[] $existingAdvisories */
-        $existingAdvisories = $this->doctrine->getRepository(SecurityAdvisory::class)->getPackageAdvisoriesWithSources($remoteAdvisories->getPackageNames(), $sourceName);
+        $existingAdvisories = $this->doctrine->getRepository(SecurityAdvisory::class)->getPackageAdvisoriesWithSources($packageNames, $sourceName);
+
+        // Remove advisories withdrawn at the source first and flush them on their own, before
+        // resolve() mutates any remaining advisory. Doctrine commits inserts/updates before deletes
+        // within a single flush, so deleting here frees any (packageName, cve) unique key that a
+        // replacement advisory may reuse in the same run, avoiding a constraint violation.
+        [$existingAdvisories, $withdrawn] = $this->securityAdvisoryResolver->removeWithdrawn($existingAdvisories, $remoteAdvisories, $sourceName);
+        if (\count($withdrawn) > 0) {
+            $manager = $this->doctrine->getManager();
+            foreach ($withdrawn as $advisory) {
+                // Remove the loaded source rows explicitly: the association only cascades persist, so
+                // otherwise they would dangle in the UnitOfWork and trip the later flush once their
+                // advisory is gone.
+                foreach ($advisory->getSources() as $source) {
+                    $manager->remove($source);
+                }
+                $manager->remove($advisory);
+            }
+            $manager->flush();
+        }
 
         [$new, $removed] = $this->securityAdvisoryResolver->resolve($existingAdvisories, $remoteAdvisories, $sourceName);
 

--- a/tests/SecurityAdvisory/GitHubSecurityAdvisoriesSourceTest.php
+++ b/tests/SecurityAdvisory/GitHubSecurityAdvisoriesSourceTest.php
@@ -178,6 +178,111 @@ class GitHubSecurityAdvisoriesSourceTest extends TestCase
         $this->assertSame(Severity::MEDIUM, $advisories[0]->severity);
     }
 
+    public function testWithdrawnAdvisoryIsExcludedButRecorded(): void
+    {
+        $responseFactory = fn (string $method, string $url, array $options) => new MockResponse(json_encode([
+            'data' => [
+                'securityVulnerabilities' => [
+                    'nodes' => [
+                        $this->graphQlPackageNode('GHSA-live-aaaa-aaaa', 'vendor/package', '= 4.10.0', 'CVE-2021-35210', 'Live advisory', '2021-07-01T17:00:04Z'),
+                        $this->graphQlPackageNode('GHSA-gone-bbbb-bbbb', 'vendor/package', '= 4.10.0', 'CVE-2020-25768', 'Withdrawn advisory', '2020-09-24T16:23:54Z', '2021-01-01T00:00:00Z'),
+                    ],
+                    'pageInfo' => ['hasNextPage' => false, 'endCursor' => 'cursor'],
+                ],
+            ],
+        ]), ['http_code' => 200, 'response_headers' => ['Content-Type' => 'application/json; charset=utf-8']]);
+
+        $source = new GitHubSecurityAdvisoriesSource(new MockHttpClient($responseFactory), new NullLogger(), $this->providerManager, [], $this->doctrine);
+        $advisoryCollection = $source->getAdvisories(new BufferIO());
+
+        $this->assertNotNull($advisoryCollection);
+
+        $advisories = $advisoryCollection->getAdvisoriesForPackageName('vendor/package');
+        $this->assertCount(1, $advisories);
+        $this->assertSame('GHSA-live-aaaa-aaaa', $advisories[0]->id);
+
+        $this->assertTrue($advisoryCollection->isWithdrawn('vendor/package', 'GHSA-gone-bbbb-bbbb'));
+        $this->assertFalse($advisoryCollection->isWithdrawn('vendor/package', 'GHSA-live-aaaa-aaaa'));
+    }
+
+    public function testWithdrawnAdvisoryDoesNotSuppressLiveAdvisoryForSameCve(): void
+    {
+        // The withdrawn node is listed before the live node for the same CVE.
+        $responseFactory = fn (string $method, string $url, array $options) => new MockResponse(json_encode([
+            'data' => [
+                'securityVulnerabilities' => [
+                    'nodes' => [
+                        $this->graphQlPackageNode('GHSA-gone-bbbb-bbbb', 'vendor/package', '= 4.10.0', 'CVE-2020-25768', 'Withdrawn advisory', '2020-09-24T16:23:54Z', '2021-01-01T00:00:00Z'),
+                        $this->graphQlPackageNode('GHSA-live-cccc-cccc', 'vendor/package', '= 4.10.0', 'CVE-2020-25768', 'Live advisory', '2021-07-01T17:00:04Z'),
+                    ],
+                    'pageInfo' => ['hasNextPage' => false, 'endCursor' => 'cursor'],
+                ],
+            ],
+        ]), ['http_code' => 200, 'response_headers' => ['Content-Type' => 'application/json; charset=utf-8']]);
+
+        $source = new GitHubSecurityAdvisoriesSource(new MockHttpClient($responseFactory), new NullLogger(), $this->providerManager, [], $this->doctrine);
+        $advisoryCollection = $source->getAdvisories(new BufferIO());
+
+        $this->assertNotNull($advisoryCollection);
+
+        $advisories = $advisoryCollection->getAdvisoriesForPackageName('vendor/package');
+        $this->assertCount(1, $advisories);
+        $this->assertSame('GHSA-live-cccc-cccc', $advisories[0]->id);
+        $this->assertSame('CVE-2020-25768', $advisories[0]->cve);
+
+        $this->assertTrue($advisoryCollection->isWithdrawn('vendor/package', 'GHSA-gone-bbbb-bbbb'));
+    }
+
+    public function testSameRemoteIdWithdrawnAndLiveIsTreatedAsLive(): void
+    {
+        // Same package + GHSA id appears both withdrawn and live; live wins, no removal flagged.
+        $responseFactory = fn (string $method, string $url, array $options) => new MockResponse(json_encode([
+            'data' => [
+                'securityVulnerabilities' => [
+                    'nodes' => [
+                        $this->graphQlPackageNode('GHSA-dup-dddd-dddd', 'vendor/package', '< 4.9.0', 'CVE-2021-35210', 'Advisory', '2021-07-01T17:00:04Z', '2021-01-01T00:00:00Z'),
+                        $this->graphQlPackageNode('GHSA-dup-dddd-dddd', 'vendor/package', '= 4.10.0', 'CVE-2021-35210', 'Advisory', '2021-07-01T17:00:04Z'),
+                    ],
+                    'pageInfo' => ['hasNextPage' => false, 'endCursor' => 'cursor'],
+                ],
+            ],
+        ]), ['http_code' => 200, 'response_headers' => ['Content-Type' => 'application/json; charset=utf-8']]);
+
+        $source = new GitHubSecurityAdvisoriesSource(new MockHttpClient($responseFactory), new NullLogger(), $this->providerManager, [], $this->doctrine);
+        $advisoryCollection = $source->getAdvisories(new BufferIO());
+
+        $this->assertNotNull($advisoryCollection);
+
+        $advisories = $advisoryCollection->getAdvisoriesForPackageName('vendor/package');
+        $this->assertCount(1, $advisories);
+        $this->assertSame('GHSA-dup-dddd-dddd', $advisories[0]->id);
+
+        $this->assertFalse($advisoryCollection->isWithdrawn('vendor/package', 'GHSA-dup-dddd-dddd'));
+    }
+
+    public function testWithdrawnAdvisoryWithoutGhsaIdIsIgnored(): void
+    {
+        $node = $this->graphQlPackageNode('GHSA-ignored', 'vendor/package', '= 4.10.0', 'CVE-2020-25768', 'Withdrawn advisory', '2020-09-24T16:23:54Z', '2021-01-01T00:00:00Z');
+        // Drop the GHSA identifier, leaving only the CVE one.
+        $node['advisory']['identifiers'] = [['type' => 'CVE', 'value' => 'CVE-2020-25768']];
+
+        $responseFactory = fn (string $method, string $url, array $options) => new MockResponse(json_encode([
+            'data' => [
+                'securityVulnerabilities' => [
+                    'nodes' => [$node],
+                    'pageInfo' => ['hasNextPage' => false, 'endCursor' => 'cursor'],
+                ],
+            ],
+        ]), ['http_code' => 200, 'response_headers' => ['Content-Type' => 'application/json; charset=utf-8']]);
+
+        $source = new GitHubSecurityAdvisoriesSource(new MockHttpClient($responseFactory), new NullLogger(), $this->providerManager, [], $this->doctrine);
+        $advisoryCollection = $source->getAdvisories(new BufferIO());
+
+        $this->assertNotNull($advisoryCollection);
+        $this->assertSame([], $advisoryCollection->getAdvisoriesForPackageName('vendor/package'));
+        $this->assertSame([], $advisoryCollection->getPackageNames());
+    }
+
     private function getPackage(): Package
     {
         $package = new Package();
@@ -241,14 +346,14 @@ class GitHubSecurityAdvisoriesSourceTest extends TestCase
         ];
     }
 
-    private function graphQlPackageNode(string $advisoryId, string $packageName, string $range, string $cve, string $summary, string $publishedAt): array
+    private function graphQlPackageNode(string $advisoryId, string $packageName, string $range, string $cve, string $summary, string $publishedAt, ?string $withdrawnAt = null): array
     {
         return [
             'advisory' => [
                 'summary' => $summary,
                 'permalink' => 'https://github.com/advisories/'.$advisoryId,
                 'publishedAt' => $publishedAt,
-                'withdrawnAt' => null,
+                'withdrawnAt' => $withdrawnAt,
                 'severity' => 'MODERATE',
                 'identifiers' => [
                     ['type' => 'GHSA', 'value' => $advisoryId],

--- a/tests/SecurityAdvisory/SecurityAdvisoryResolverTest.php
+++ b/tests/SecurityAdvisory/SecurityAdvisoryResolverTest.php
@@ -118,6 +118,63 @@ class SecurityAdvisoryResolverTest extends TestCase
         $this->assertSame([], $removed);
     }
 
+    public function testRemoveWithdrawnDeletesSingleSourceAdvisory(): void
+    {
+        $advisory = new SecurityAdvisory($this->createRemoteAdvisory('test'), 'test');
+        $remoteId = $advisory->getSourceRemoteId('test');
+        $this->assertNotNull($remoteId);
+        $collection = new RemoteSecurityAdvisoryCollection([], ['acme/package' => [$remoteId => true]]);
+
+        [$remaining, $toRemove] = $this->resolver->removeWithdrawn([$advisory], $collection, 'test');
+
+        $this->assertSame([], $remaining);
+        $this->assertSame([$advisory], $toRemove);
+        // The source is left attached so the caller can delete the whole entity graph at once.
+        $this->assertTrue($advisory->hasSources());
+    }
+
+    public function testRemoveWithdrawnKeepsAdvisoryWithRemainingSource(): void
+    {
+        $advisory = new SecurityAdvisory($this->createRemoteAdvisory('test'), 'test');
+        $advisory->addSource('other-id', 'other', null);
+        $remoteId = $advisory->getSourceRemoteId('test');
+        $this->assertNotNull($remoteId);
+        $collection = new RemoteSecurityAdvisoryCollection([], ['acme/package' => [$remoteId => true]]);
+
+        [$remaining, $toRemove] = $this->resolver->removeWithdrawn([$advisory], $collection, 'test');
+
+        $this->assertSame([$advisory], $remaining);
+        $this->assertSame([], $toRemove);
+        $this->assertNull($advisory->getSourceRemoteId('test'));
+        $this->assertNotNull($advisory->getSourceRemoteId('other'));
+    }
+
+    public function testRemoveWithdrawnIgnoresUnknownRemoteId(): void
+    {
+        $advisory = new SecurityAdvisory($this->createRemoteAdvisory('test'), 'test');
+        $collection = new RemoteSecurityAdvisoryCollection([], ['acme/package' => ['unknown-id' => true]]);
+
+        [$remaining, $toRemove] = $this->resolver->removeWithdrawn([$advisory], $collection, 'test');
+
+        $this->assertSame([$advisory], $remaining);
+        $this->assertSame([], $toRemove);
+        $this->assertTrue($advisory->hasSources());
+    }
+
+    public function testRemoveWithdrawnIgnoresOtherSource(): void
+    {
+        $advisory = new SecurityAdvisory($this->createRemoteAdvisory('other'), 'other');
+        $remoteId = $advisory->getSourceRemoteId('other');
+        $this->assertNotNull($remoteId);
+        $collection = new RemoteSecurityAdvisoryCollection([], ['acme/package' => [$remoteId => true]]);
+
+        [$remaining, $toRemove] = $this->resolver->removeWithdrawn([$advisory], $collection, 'test');
+
+        $this->assertSame([$advisory], $remaining);
+        $this->assertSame([], $toRemove);
+        $this->assertTrue($advisory->hasSources());
+    }
+
     private function createRemoteAdvisory(string $source, string $packageName = 'acme/package', ?string $cve = null): RemoteSecurityAdvisory
     {
         return new RemoteSecurityAdvisory(

--- a/tests/SecurityAdvisoryWorkerIntegrationTest.php
+++ b/tests/SecurityAdvisoryWorkerIntegrationTest.php
@@ -1,0 +1,124 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Packagist.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *     Nils Adermann <naderman@naderman.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests;
+
+use App\Entity\Job;
+use App\Entity\SecurityAdvisory;
+use App\EventListener\SecurityAdvisoryUpdateListener;
+use App\SecurityAdvisory\GitHubSecurityAdvisoriesSource;
+use App\SecurityAdvisory\RemoteSecurityAdvisory;
+use App\SecurityAdvisory\RemoteSecurityAdvisoryCollection;
+use App\SecurityAdvisory\SecurityAdvisoryResolver;
+use App\SecurityAdvisory\SecurityAdvisorySourceInterface;
+use App\Service\Locker;
+use App\Service\SecurityAdvisoryWorker;
+use Composer\IO\ConsoleIO;
+use Doctrine\Persistence\ManagerRegistry;
+use Predis\Client;
+use Psr\Log\NullLogger;
+use Seld\Signal\SignalHandler;
+
+class SecurityAdvisoryWorkerIntegrationTest extends IntegrationTestCase
+{
+    /**
+     * Exercises the real unique constraint on (packageName, cve): a withdrawn advisory holds a CVE
+     * that the source reassigns to another advisory in the same run. The worker must delete the
+     * withdrawn advisory (and flush) before resolve() updates the survivor, otherwise Doctrine
+     * commits the UPDATE before the DELETE and the package_name_cve_idx constraint is violated.
+     */
+    public function testWithdrawnAdvisoryRemovalFreesCveForReassignment(): void
+    {
+        $withdrawn = new SecurityAdvisory($this->remoteAdvisory('GHSA-old-0000-0000', 'acme/package', 'CVE-2024-10001'), GitHubSecurityAdvisoriesSource::SOURCE_NAME);
+        $survivor = new SecurityAdvisory($this->remoteAdvisory('GHSA-new-1111-1111', 'acme/package', 'CVE-2024-20002'), GitHubSecurityAdvisoriesSource::SOURCE_NAME);
+        $this->store($withdrawn, $survivor);
+
+        // GHSA-old is withdrawn at the source; the survivor (GHSA-new) now carries the freed CVE.
+        $collection = new RemoteSecurityAdvisoryCollection(
+            [$this->remoteAdvisory('GHSA-new-1111-1111', 'acme/package', 'CVE-2024-10001')],
+            ['acme/package' => ['GHSA-old-0000-0000' => true]],
+        );
+
+        $this->runWorkerWithSource($collection);
+
+        $this->getEM()->clear();
+        $advisories = $this->getEM()->getRepository(SecurityAdvisory::class)->findByPackageName('acme/package');
+
+        $this->assertCount(1, $advisories);
+        $this->assertSame('GHSA-new-1111-1111', $advisories[0]->getRemoteId());
+        $this->assertSame('CVE-2024-10001', $advisories[0]->getCve());
+    }
+
+    public function testPureOrphanWithdrawnAdvisoryIsRemoved(): void
+    {
+        $withdrawn = new SecurityAdvisory($this->remoteAdvisory('GHSA-orphan-0000', 'acme/orphan', 'CVE-2024-30003'), GitHubSecurityAdvisoriesSource::SOURCE_NAME);
+        $this->store($withdrawn);
+
+        // The source reports the advisory only as withdrawn, with no live advisory for the package.
+        $collection = new RemoteSecurityAdvisoryCollection([], ['acme/orphan' => ['GHSA-orphan-0000' => true]]);
+
+        $this->runWorkerWithSource($collection);
+
+        $this->getEM()->clear();
+        $advisories = $this->getEM()->getRepository(SecurityAdvisory::class)->findByPackageName('acme/orphan');
+
+        $this->assertSame([], $advisories);
+    }
+
+    private function runWorkerWithSource(RemoteSecurityAdvisoryCollection $collection): void
+    {
+        $doctrine = static::getContainer()->get(ManagerRegistry::class);
+        \assert($doctrine instanceof ManagerRegistry);
+
+        $source = new class($collection) implements SecurityAdvisorySourceInterface {
+            public function __construct(private readonly RemoteSecurityAdvisoryCollection $collection)
+            {
+            }
+
+            public function getAdvisories(ConsoleIO $io): ?RemoteSecurityAdvisoryCollection
+            {
+                return $this->collection;
+            }
+        };
+
+        $worker = new SecurityAdvisoryWorker(
+            new Locker($doctrine),
+            new NullLogger(),
+            $doctrine,
+            [GitHubSecurityAdvisoriesSource::SOURCE_NAME => $source],
+            new SecurityAdvisoryResolver(),
+            new SecurityAdvisoryUpdateListener($doctrine, $this->createStub(Client::class)),
+        );
+
+        $job = new Job('advisory-job', 'security:advisory', ['source' => GitHubSecurityAdvisoriesSource::SOURCE_NAME]);
+        $result = $worker->process($job, SignalHandler::create());
+
+        $this->assertSame(Job::STATUS_COMPLETED, $result['status']);
+    }
+
+    private function remoteAdvisory(string $remoteId, string $packageName, string $cve): RemoteSecurityAdvisory
+    {
+        return new RemoteSecurityAdvisory(
+            $remoteId,
+            'Advisory '.$cve,
+            $packageName,
+            '^1.0',
+            'https://example.org/'.$remoteId,
+            $cve,
+            new \DateTimeImmutable('2024-01-01 00:00:00'),
+            null,
+            [],
+            GitHubSecurityAdvisoriesSource::SOURCE_NAME,
+            null,
+        );
+    }
+}

--- a/tests/SecurityAdvisoryWorkerTest.php
+++ b/tests/SecurityAdvisoryWorkerTest.php
@@ -108,6 +108,50 @@ class SecurityAdvisoryWorkerTest extends TestCase
         $this->worker->process($job, SignalHandler::create());
     }
 
+    public function testProcessRemovesWithdrawnAdvisoryBeforeResolve(): void
+    {
+        $newRemote = $this->createRemoteAdvisory('package/new', 'new-id');
+        $withdrawnExisting = new SecurityAdvisory($this->createRemoteAdvisory('package/withdrawn', 'withdrawn-id'), 'test');
+
+        $collection = new RemoteSecurityAdvisoryCollection([$newRemote], ['package/withdrawn' => ['withdrawn-id' => true]]);
+
+        $this->source
+            ->expects($this->once())
+            ->method('getAdvisories')
+            ->willReturn($collection);
+
+        $this->securityAdvisoryRepository
+            ->expects($this->once())
+            ->method('getPackageAdvisoriesWithSources')
+            ->willReturn([$withdrawnExisting->getPackagistAdvisoryId() => $withdrawnExisting]);
+
+        $calls = [];
+        $this->em
+            ->method('remove')
+            ->willReturnCallback(function (object $entity) use (&$calls): void {
+                $calls[] = $entity instanceof SecurityAdvisory ? 'remove:advisory' : 'remove:source';
+            });
+        $this->em
+            ->method('persist')
+            ->willReturnCallback(function () use (&$calls): void {
+                $calls[] = 'persist';
+            });
+        $this->em
+            ->expects($this->exactly(2))
+            ->method('flush')
+            ->willReturnCallback(function () use (&$calls): void {
+                $calls[] = 'flush';
+            });
+
+        $job = new Job('job', 'security:advisory', ['source' => 'test']);
+        $job->setPackageId(42);
+        $this->worker->process($job, SignalHandler::create());
+
+        // The withdrawn advisory (and its source row) is removed and flushed on its own before the
+        // new advisory is persisted, freeing any (packageName, cve) unique key for reuse.
+        $this->assertSame(['remove:source', 'remove:advisory', 'flush', 'persist', 'flush'], $calls);
+    }
+
     public function testProcessNoAdvisories(): void
     {
         $this->source


### PR DESCRIPTION
If one was already stored but then an update tries to withdraw it + add another one for the same CVE, doctrines flush() fails as it tries to insert the new one first