### PR TITLE
Sanitize ANSI escape/control characters when importing package data

### DIFF
--- a/src/Package/Updater.php
+++ b/src/Package/Updater.php
@@ -39,6 +39,7 @@ use App\Service\VersionCache;
 use App\Util\HttpDownloaderOptionsFactory;
 use cebe\markdown\GithubMarkdown;
 use Composer\Config;
+use Composer\IO\ConsoleIO;
 use Composer\IO\IOInterface;
 use Composer\Package\AliasPackage;
 use Composer\Package\CompletePackageInterface;
@@ -672,7 +673,7 @@ class Updater
         $versionId = null;
         $postUpdateEvents = [];
 
-        $normVersion = $data->getVersion();
+        $normVersion = ConsoleIO::sanitize($data->getVersion(), false);
         $newSourceRef = $data->getSourceReference();
         $newDistRef = $data->getDistReference();
         $newEffectiveRef = self::computeEffectiveReference($newSourceRef, $newDistRef);
@@ -741,10 +742,14 @@ class Updater
         $originalMetadata = $versionId !== null ? $version->toV2Array([]) : null;
 
         $version->setName($package->getName());
-        $version->setVersion($data->getPrettyVersion());
+        $version->setVersion(ConsoleIO::sanitize($data->getPrettyVersion(), false));
         $version->setNormalizedVersion($normVersion);
         $version->setDevelopment($data->isDev());
-        $version->setPhpExt($data->getPhpExt());
+        $phpExt = $data->getPhpExt();
+        if (null !== $phpExt) {
+            array_walk_recursive($phpExt, $this->sanitizeStringLeaf(...));
+        }
+        $version->setPhpExt($phpExt);
 
         $em->persist($version);
 
@@ -761,13 +766,13 @@ class Updater
                 $package->setAbandoned(true);
                 $postUpdateEvents[] = new PackageAbandonedEvent($package, $this->detectAbandonmentReason($driver, $rootIdentifier));
                 if ($data->getReplacementPackage()) {
-                    $package->setReplacementPackage($data->getReplacementPackage());
+                    $package->setReplacementPackage($this->sanitize($data->getReplacementPackage()));
                 }
             }
         }
 
         $version->setHomepage($this->filterUrl($data->getHomepage()));
-        $version->setLicense($data->getLicense() ?: []);
+        $version->setLicense(array_map($this->sanitize(...), $data->getLicense() ?: []));
 
         $version->setPackage($package);
         $version->setUpdatedAt(new \DateTimeImmutable());
@@ -777,8 +782,8 @@ class Updater
         $version->setReleasedAt($data->getReleaseDate() === null ? null : \DateTimeImmutable::createFromInterface($data->getReleaseDate()));
 
         if ($data->getSourceType() && !in_array($data->getSourceType(), ['perforce', 'fossil'], true)) { // null or '' here explicitly means no source and will be nulled, do not change this behavior
-            $source['type'] = $data->getSourceType();
-            $source['url'] = $data->getSourceUrl();
+            $source['type'] = $this->sanitize($data->getSourceType());
+            $source['url'] = $this->sanitize($data->getSourceUrl());
             // force public URLs even if the package somehow got downgraded to a GitDriver
             if (\is_string($source['url']) && Preg::isMatch('{^git@github.com:(?P<repo>.*?)\.git$}', $source['url'], $match)) {
                 $source['url'] = 'https://github.com/'.$match['repo'];
@@ -790,8 +795,8 @@ class Updater
         }
 
         if ($data->getDistType()) {
-            $dist['type'] = $data->getDistType();
-            $dist['url'] = $data->getDistUrl();
+            $dist['type'] = $this->sanitize($data->getDistType());
+            $dist['url'] = $this->sanitize($data->getDistUrl());
             $dist['reference'] = $data->getDistReference();
             $dist['shasum'] = $data->getDistSha1Checksum();
             $version->setDist($dist);
@@ -807,17 +812,25 @@ class Updater
             }
         }
 
-        $version->setTargetDir($data->getTargetDir());
-        $version->setAutoload($data->getAutoload());
-        $version->setExtra($data->getExtra());
-        $version->setBinaries($data->getBinaries());
-        $version->setIncludePaths($data->getIncludePaths());
+        $version->setTargetDir($this->sanitize($data->getTargetDir()));
+        $autoload = $data->getAutoload();
+        array_walk_recursive($autoload, $this->sanitizeStringLeaf(...));
+        $version->setAutoload($autoload);
+        $extra = $data->getExtra();
+        array_walk_recursive($extra, $this->sanitizeStringLeaf(...));
+        $version->setExtra($extra);
+        $version->setBinaries(array_map($this->sanitize(...), $data->getBinaries()));
+        $version->setIncludePaths(array_map($this->sanitize(...), $data->getIncludePaths()));
         $version->setSupport($this->filterSupportUrls($data->getSupport()));
         $version->setFunding($this->filterFundingUrls($data->getFunding()));
 
         if ($data->getKeywords()) {
             $keywords = [];
             foreach ($data->getKeywords() as $keyword) {
+                $keyword = $this->sanitize($keyword);
+                if ('' === $keyword) {
+                    continue;
+                }
                 $keywords[mb_strtolower($keyword, 'UTF-8')] = $keyword;
             }
 
@@ -853,7 +866,7 @@ class Updater
 
                 foreach (['email', 'name', 'homepage', 'role'] as $field) {
                     if (isset($authorData[$field])) {
-                        $author[$field] = trim($authorData[$field]);
+                        $author[$field] = trim($this->sanitize($authorData[$field]));
                         if ('homepage' === $field) {
                             $author[$field] = (string) $this->filterUrl($author[$field]);
                         }
@@ -888,7 +901,7 @@ class Updater
                     }, $constraint);
                 }
 
-                $links[$link->getTarget()] = $constraint;
+                $links[$this->sanitize($link->getTarget())] = $this->sanitize($constraint);
             }
 
             foreach ($version->{$opts['getter']}() as $link) {
@@ -915,6 +928,12 @@ class Updater
 
         // handle suggests
         if ($suggests = $data->getSuggests()) {
+            $sanitizedSuggests = [];
+            foreach ($suggests as $suggestName => $suggestReason) {
+                $sanitizedSuggests[$this->sanitize($suggestName)] = $this->sanitize($suggestReason);
+            }
+            $suggests = $sanitizedSuggests;
+
             foreach ($version->getSuggest() as $link) {
                 // clear links that have changed/disappeared (for updates)
                 if (!isset($suggests[$link->getPackageName()]) || $suggests[$link->getPackageName()] !== $link->getPackageVersion()) {
@@ -1190,10 +1209,20 @@ class Updater
             return null;
         }
 
-        // remove escape chars
-        $str = Preg::replace("{\x1B(?:\[.)?}u", '', $str);
+        return ConsoleIO::sanitize($str, false);
+    }
 
-        return Preg::replace("{[\x01-\x1A]}u", '', $str);
+    /**
+     * array_walk_recursive callback to strip control/escape chars from every string leaf of a
+     * nested structure (e.g. composer "extra"/"autoload"/php-ext config) without altering the
+     * array shape — non-string values and keys are left untouched, so the caller's declared type
+     * is preserved.
+     */
+    private function sanitizeStringLeaf(mixed &$value): void
+    {
+        if (\is_string($value)) {
+            $value = ConsoleIO::sanitize($value, false);
+        }
     }
 
     /**
@@ -1205,6 +1234,11 @@ class Updater
     private function filterUrl(?string $url, array $allowedSchemes = ['http', 'https']): ?string
     {
         if (null === $url || '' === $url) {
+            return $url;
+        }
+
+        $url = $this->sanitize($url);
+        if ('' === $url) {
             return $url;
         }
 
@@ -1223,6 +1257,9 @@ class Updater
         if (null === $support) {
             return null;
         }
+
+        // strip control/escape chars from every value, including non-URL ones like email
+        $support = array_map($this->sanitize(...), $support);
 
         foreach (['issues', 'forum', 'wiki', 'source', 'docs', 'rss', 'security'] as $key) {
             if (isset($support[$key]) && null === $this->filterUrl($support[$key])) {
@@ -1252,8 +1289,16 @@ class Updater
         }
 
         foreach ($funding as $i => $entry) {
-            if (isset($entry['url']) && null === $this->filterUrl($entry['url'])) {
-                unset($funding[$i]['url']);
+            if (isset($entry['type'])) {
+                $funding[$i]['type'] = $this->sanitize($entry['type']);
+            }
+            if (isset($entry['url'])) {
+                $url = $this->filterUrl($entry['url']);
+                if (null === $url) {
+                    unset($funding[$i]['url']);
+                } else {
+                    $funding[$i]['url'] = $url;
+                }
             }
         }
 

--- a/tests/Package/UpdaterTest.php
+++ b/tests/Package/UpdaterTest.php
@@ -30,10 +30,12 @@ use Composer\Config;
 use Composer\IO\IOInterface;
 use Composer\IO\NullIO;
 use Composer\Package\CompletePackage;
+use Composer\Package\Link;
 use Composer\Repository\RepositoryInterface;
 use Composer\Repository\Vcs\GitDriver;
 use Composer\Repository\Vcs\VcsDriverInterface;
 use Composer\Repository\VcsRepository;
+use Composer\Semver\Constraint\MatchAllConstraint;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
@@ -155,6 +157,115 @@ class UpdaterTest extends IntegrationTestCase
         $authors = $version->getAuthors();
         self::assertArrayNotHasKey('homepage', $authors[0]);
         self::assertSame('Bob', $authors[0]['name']);
+    }
+
+    public function testStripsControlCharactersFromMetadata(): void
+    {
+        $esc = "\x1B[31m"; // ANSI CSI color sequence
+        $ctrl = "\x07\x01"; // BEL + SOH control chars
+
+        $upstream = new CompletePackage('test/pkg', '1.0.0.0', '1.0.0');
+        // default branch so the package-level description/type/replacement paths are exercised too
+        $upstream->setIsDefaultBranch(true);
+        $upstream->setDescription('Clean desc'.$esc.$ctrl);
+        $upstream->setType('library'.$esc);
+        $upstream->setKeywords(['key'.$esc.'word', 'two'.$ctrl]);
+        $upstream->setLicense(['MIT'.$esc]);
+        $upstream->setHomepage('https://example.com/home'.$esc);
+        $upstream->setAuthors([
+            ['name' => 'Bob'.$esc, 'email' => 'bob'.$ctrl.'@example.com', 'role' => 'Dev'.$esc],
+        ]);
+        $upstream->setSupport([
+            'issues' => 'https://example.com/issues'.$esc,
+            'email' => 'sec'.$ctrl.'@example.com',
+        ]);
+        $upstream->setFunding([
+            ['type' => 'custom'.$esc, 'url' => 'https://example.com/fund'.$esc],
+        ]);
+        $upstream->setTargetDir('sub/dir'.$esc);
+        $upstream->setBinaries(['bin/foo'.$esc]);
+        $upstream->setIncludePaths(['lib/'.$ctrl]);
+        // nested config: only string leaf values are sanitized, keys/non-strings are left intact
+        $upstream->setExtra(['branch-alias' => ['dev-main' => '1.x-dev'.$esc], 'nested' => 'val'.$ctrl, 'num' => 5]);
+        $upstream->setAutoload(['psr-4' => ['App\\' => 'src/'.$esc]]);
+        $upstream->setPhpExt(['priority' => 80, 'configure-options' => [['name' => 'with-foo'.$esc, 'description' => 'Enable'.$ctrl]]]);
+        $upstream->setSuggests(['some/pkg'.$ctrl => 'because'.$esc]);
+        $upstream->setSourceType('git');
+        $upstream->setSourceUrl('https://example.com/test/pkg'.$esc);
+        $upstream->setSourceReference('aabbccddeeff00112233445566778899aabbccdd');
+        $upstream->setDistType('zip'.$ctrl);
+        $upstream->setDistUrl('https://example.com/dist.zip'.$esc);
+        $upstream->setDistReference('00112233445566778899aabbccddeeff00112233');
+        $require = new Link('test/pkg', 'some/dep'.$ctrl, new MatchAllConstraint(), Link::TYPE_REQUIRE, '^1.0'.$esc);
+        $upstream->setRequires(['some/dep' => $require]);
+        $upstream->setAbandoned('replacement/pkg'.$esc);
+
+        $this->repositoryMock = $this->createStub(VcsRepository::class);
+        $this->repositoryMock->method('getPackages')->willReturn([$upstream]);
+        $this->repositoryMock->method('getDriver')->willReturn($this->stableDriver());
+
+        $this->updater->update($this->ioMock, $this->config, $this->package, $this->repositoryMock);
+
+        $version = $this->getEM()->getRepository(Version::class)->findOneBy(['name' => 'test/pkg', 'normalizedVersion' => '1.0.0.0']);
+        self::assertNotNull($version);
+
+        self::assertSame('Clean desc', $version->getDescription());
+        self::assertSame('library', $version->getType());
+        self::assertSame(['MIT'], $version->getLicense());
+        self::assertSame('https://example.com/home', $version->getHomepage());
+
+        $tagNames = array_map(static fn ($t) => $t->getName(), $version->getTags()->toArray());
+        sort($tagNames);
+        self::assertSame(['keyword', 'two'], $tagNames);
+
+        $authors = $version->getAuthors();
+        self::assertSame('Bob', $authors[0]['name']);
+        self::assertSame('bob@example.com', $authors[0]['email']);
+        self::assertSame('Dev', $authors[0]['role']);
+
+        $support = $version->getSupport();
+        self::assertSame('https://example.com/issues', $support['issues']);
+        self::assertSame('sec@example.com', $support['email']);
+
+        $funding = $version->getFunding();
+        self::assertSame('custom', $funding[0]['type']);
+        self::assertSame('https://example.com/fund', $funding[0]['url']);
+
+        self::assertSame('sub/dir', $version->getTargetDir());
+        self::assertSame(['bin/foo'], $version->getBinaries());
+        self::assertSame(['lib/'], $version->getIncludePaths());
+
+        // assertEquals (not assertSame): extra key order is not preserved through storage and is not meaningful
+        self::assertEquals(['branch-alias' => ['dev-main' => '1.x-dev'], 'nested' => 'val', 'num' => 5], $version->getExtra());
+        self::assertSame(['psr-4' => ['App\\' => 'src/']], $version->getAutoload());
+        self::assertSame(['priority' => 80, 'configure-options' => [['name' => 'with-foo', 'description' => 'Enable']]], $version->getPhpExt());
+
+        $source = $version->getSource();
+        self::assertSame('https://example.com/test/pkg', $source['url']);
+        self::assertSame('git', $source['type']);
+        // reference is intentionally left untouched (out of sanitization scope)
+        self::assertSame('aabbccddeeff00112233445566778899aabbccdd', $source['reference']);
+
+        $dist = $version->getDist();
+        self::assertSame('https://example.com/dist.zip', $dist['url']);
+        self::assertSame('zip', $dist['type']);
+        self::assertSame('00112233445566778899aabbccddeeff00112233', $dist['reference']);
+
+        $requires = $version->getRequire();
+        self::assertCount(1, $requires);
+        $reqLink = $requires->first();
+        self::assertSame('some/dep', $reqLink->getPackageName());
+        self::assertSame('^1.0', $reqLink->getPackageVersion());
+
+        $suggests = $version->getSuggest();
+        self::assertCount(1, $suggests);
+        $sugLink = $suggests->first();
+        self::assertSame('some/pkg', $sugLink->getPackageName());
+        self::assertSame('because', $sugLink->getPackageVersion());
+
+        $this->getEM()->refresh($this->package);
+        self::assertTrue($this->package->isAbandoned());
+        self::assertSame('replacement/pkg', $this->package->getReplacementPackage());
     }
 
     public function testConvertsMarkdownForReadme(): void


### PR DESCRIPTION
Covers similar inputs to https://github.com/composer/composer/security/advisories/GHSA-59pp-r3rg-353g at the source directly, just to protect other clients. Best effort basis here, as this isn't extremely relevant for Packagist itself.