### PR TITLE
Fix overlapping X-axis labels in package stats charts

### DIFF
--- a/js/charts.js
+++ b/js/charts.js
@@ -102,11 +102,15 @@ import '../css/charts.css';
                 return a;
             }
 
-            chart.xAxis.tickFormat(formatDate);
+            chart.xAxis
+                .showMaxMin(false)
+                .tickFormat(formatDate);
             chart.yAxis.tickFormat(formatDigit);
 
             if (withDatePicker) {
-                chart.x2Axis.tickFormat(formatDate);
+                chart.x2Axis
+                    .showMaxMin(false)
+                    .tickFormat(formatDate);
                 chart.y2Axis.tickFormat(formatDigit);
             }
 


### PR DESCRIPTION
Closes #1787.

## Summary

This prevents the X-axis labels in package stats charts from overlapping near the right edge.

NVD3 renders regular X-axis tick labels and separate max/min labels. On Packagist package stats pages, the extra right-edge max label can overlap with the neighboring tick label, especially in `lineWithFocusChart`.

This change disables those extra max/min labels for:
- `xAxis`
- `x2Axis`

Regular tick labels remain unchanged.

## Before

![Before](https://raw.githubusercontent.com/savinmikhail/packagist/issue-assets/.github/issue-assets/repro-before.png)

## After

![After](https://raw.githubusercontent.com/savinmikhail/packagist/issue-assets/.github/issue-assets/repro-after.png)

## Alternatives considered

1. Keep `showMaxMin(true)` and reduce the number of ticks.
   This is less predictable because NVD3 still decides which labels to keep, and it does not reliably eliminate the right-edge overlap for all date ranges and widths.

2. Rotate or stagger X-axis labels.
   This preserves more labels, but it is a much more visible UI change and makes both the main chart and the focus chart harder to scan.

3. Increase chart margins or adjust CSS for the last label.
   This is more fragile because the overlap comes from two different label layers being rendered at the same edge, not only from missing space.

4. Hide only one specific edge label with DOM/CSS hacks.
   This would be tightly coupled to NVD3's generated markup and would be more brittle than using the library option directly.

## Why this approach

Disabling `showMaxMin` is the smallest and most predictable fix:
- it targets the overlapping label layer directly;
- it keeps the chart data, tooltip behavior, and focus interaction unchanged;
- it avoids layout-specific hacks.

## Validation

I reproduced the issue locally with real stats JSON from:
- `https://packagist.org/packages/savinmikhail/add_named_arguments_rector/stats/all.json`
- `https://packagist.org/packages/savinmikhail/add_named_arguments_rector/stats/v0.1.26.json`

Then I rendered `charts.js` before and after the change and confirmed the overlap disappears.
