### PR TITLE
Organization: add organization internal audit log page

### DIFF
--- a/migrations/2026_07_audit_log_organization_index.sql
+++ b/migrations/2026_07_audit_log_organization_index.sql
@@ -1,0 +1,5 @@
+-- Index audit_log.organizationId so the per-organization audit log page
+-- (organization_audit_log) can filter records for a single organization
+-- without scanning the whole table.
+
+ALTER TABLE audit_log ADD INDEX organization_idx (organizationId);

--- a/src/Audit/AuditRecordType.php
+++ b/src/Audit/AuditRecordType.php
@@ -73,6 +73,14 @@ enum AuditRecordType: string
     case OrganizationMemberRemoved = 'organization_member_removed';
     case OrganizationMemberLeft = 'organization_member_left';
 
+    /**
+     * @return list<self>
+     */
+    public static function organizationCases(): array
+    {
+        return array_values(array_filter(self::cases(), static fn (self $type): bool => $type->category() === 'organization'));
+    }
+
     public function category(): string
     {
         return match ($this) {

--- a/src/Controller/OrganizationController.php
+++ b/src/Controller/OrganizationController.php
@@ -12,6 +12,9 @@
 
 namespace App\Controller;
 
+use App\Audit\AuditRecordType;
+use App\Audit\Display\AuditLogDisplayFactory;
+use App\Entity\AuditRecordRepository;
 use App\Entity\Organization;
 use App\Entity\OrganizationRepository;
 use App\Entity\OrganizationTeam;
@@ -34,7 +37,15 @@ use App\Organization\Domain\Exception\OrganizationException;
 use App\Organization\Domain\Slug;
 use App\Organization\OrganizationManager;
 use App\Organization\OrganizationMembershipManager;
+use App\QueryFilter\AuditLog\ActorFilter;
+use App\QueryFilter\AuditLog\AuditRecordTypeFilter;
+use App\QueryFilter\AuditLog\DateTimeFromFilter;
+use App\QueryFilter\AuditLog\DateTimeToFilter;
+use App\QueryFilter\QueryFilterInterface;
 use App\Security\Voter\OrganizationActions;
+use Pagerfanta\Doctrine\ORM\QueryAdapter;
+use Pagerfanta\Pagerfanta;
+use Symfony\Bridge\Doctrine\Types\UlidType;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -107,6 +118,53 @@ class OrganizationController extends Controller
         return $this->render('organization/settings.html.twig', [
             'organization' => $organization,
             'form' => $form->createView(),
+        ]);
+    }
+
+    #[IsGranted(OrganizationActions::ViewAuditLog->value, 'organization')]
+    #[Route(path: '/organizations/{organization}/audit-log', name: 'organization_audit_log', methods: ['GET'], requirements: ['organization' => Slug::PATTERN])]
+    public function auditLog(Request $request, Organization $organization, AuditRecordRepository $auditRecordRepository, AuditLogDisplayFactory $displayFactory): Response
+    {
+        $isAuditAdmin = $this->isGranted('ROLE_AUDITOR');
+
+        $dateTimeFromFilter = DateTimeFromFilter::fromQuery($request->query);
+        $dateTimeToFilter = DateTimeToFilter::fromQuery($request->query);
+
+        /** @var QueryFilterInterface[] $filters */
+        $filters = [
+            AuditRecordTypeFilter::fromQuery($request->query),
+            ActorFilter::fromQuery($request->query, 'actor', $isAuditAdmin),
+            $dateTimeFromFilter,
+            $dateTimeToFilter,
+        ];
+
+        $qb = $auditRecordRepository->createQueryBuilder('a')
+            ->where('a.organizationId = :organizationId')
+            ->setParameter('organizationId', $organization->id, UlidType::NAME)
+            ->orderBy('a.id', 'DESC');
+
+        foreach ($filters as $filter) {
+            $filter->filter($qb);
+        }
+
+        $auditLogs = new Pagerfanta(new QueryAdapter($qb, false, false));
+        $auditLogs->setNormalizeOutOfRangePages(true);
+        $auditLogs->setMaxPerPage(20);
+        $auditLogs->setCurrentPage(max(1, $request->query->getInt('page', 1)));
+
+        $selectedFilters = [];
+        foreach ($filters as $filter) {
+            $selectedFilters[$filter->getKey()] = $filter->getSelectedValue();
+        }
+
+        return $this->render('organization/audit_log.html.twig', [
+            'organization' => $organization,
+            'auditLogDisplays' => $displayFactory->build($auditLogs),
+            'auditLogPaginator' => $auditLogs,
+            'types' => AuditRecordType::organizationCases(),
+            'selectedFilters' => $selectedFilters,
+            'dateTimeFromFilter' => $dateTimeFromFilter,
+            'dateTimeToFilter' => $dateTimeToFilter,
         ]);
     }
 

--- a/src/Entity/AuditRecord.php
+++ b/src/Entity/AuditRecord.php
@@ -33,6 +33,7 @@ use Symfony\Component\Uid\Ulid;
 #[ORM\Index(name: 'type_idx', columns: ['type'])]
 #[ORM\Index(name: 'datetime_idx', columns: ['datetime'])]
 #[ORM\Index(name: 'vendor_idx', columns: ['vendor'])]
+#[ORM\Index(name: 'organization_idx', columns: ['organizationId'])]
 class AuditRecord
 {
     #[ORM\Id]

--- a/src/Menu/MenuBuilder.php
+++ b/src/Menu/MenuBuilder.php
@@ -116,7 +116,7 @@ class MenuBuilder
         }
 
         $menu->addChild($this->translator->trans('menu.organization_overview'), [
-            'label' => '<span class="icon-dashboard"></span>'.$this->translator->trans('menu.organization_overview'),
+            'label' => '<span class="icon-chart"></span>'.$this->translator->trans('menu.organization_overview'),
             'route' => 'organization_show',
             'routeParameters' => ['organization' => $slug],
             'extras' => ['safe_label' => true, 'translation_domain' => false],
@@ -155,6 +155,13 @@ class MenuBuilder
         $menu->addChild($this->translator->trans('menu.organization_settings'), [
             'label' => '<span class="icon-tools"></span>'.$this->translator->trans('menu.organization_settings'),
             'route' => 'organization_settings',
+            'routeParameters' => ['organization' => $slug],
+            'extras' => ['safe_label' => true, 'translation_domain' => false],
+        ]);
+
+        $menu->addChild($this->translator->trans('menu.organization_audit_log'), [
+            'label' => '<span class="icon-back-in-time"></span>'.$this->translator->trans('menu.organization_audit_log'),
+            'route' => 'organization_audit_log',
             'routeParameters' => ['organization' => $slug],
             'extras' => ['safe_label' => true, 'translation_domain' => false],
         ]);

--- a/src/Security/Voter/OrganizationActions.php
+++ b/src/Security/Voter/OrganizationActions.php
@@ -18,6 +18,7 @@ namespace App\Security\Voter;
 enum OrganizationActions: string
 {
     case Edit = 'edit';
+    case ViewAuditLog = 'view-audit-log';
     // Groundwork for org deletion (not yet implemented).
     case SoftDelete = 'soft-delete';
     case Restore = 'restore';

--- a/src/Security/Voter/OrganizationVoter.php
+++ b/src/Security/Voter/OrganizationVoter.php
@@ -82,6 +82,7 @@ class OrganizationVoter extends Voter
             OrganizationActions::ViewTeams,
             OrganizationActions::Leave => $this->memberDenialReason($organization, $user),
             OrganizationActions::Edit,
+            OrganizationActions::ViewAuditLog,
             OrganizationActions::SoftDelete,
             OrganizationActions::CreateTeam,
             OrganizationActions::RenameTeam,

--- a/templates/organization/audit_log.html.twig
+++ b/templates/organization/audit_log.html.twig
@@ -1,0 +1,116 @@
+{% extends 'organization/layout.html.twig' %}
+
+{% block org_content %}
+    <div class="audit-log-filters">
+        <form method="get" action="{{ path('organization_audit_log', { organization: organization.slug }) }}" name="filters">
+            <div class="row">
+                <div class="col-md-4 col-sm-6">
+                    <div class="form-group">
+                        <label for="type-filter">Type</label>
+                        <select name="type[]" id="type-filter" class="form-control audit-log-type-select" multiple style="height: 120px;">
+                            {% for type in types %}
+                                <option value="{{ type.value }}" {% if type.value in selectedFilters.type %}selected="selected"{% endif %}>
+                                    {{ ('audit_log.type.' ~ type.value)|trans }}
+                                </option>
+                            {% endfor %}
+                        </select>
+                        <small class="help-block">Hold Ctrl/Cmd to select multiple</small>
+                    </div>
+                </div>
+                <div class="col-md-8 col-sm-6">
+                    <div class="row">
+                        <div class="col-md-12">
+                            <div class="form-group">
+                                <label for="actor-filter">Actor</label>
+                                <input type="text" name="actor" id="actor-filter" class="form-control" value="{{ selectedFilters.actor }}" placeholder="Filter by username">
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6 col-sm-12">
+                            <div class="form-group">
+                                <label for="datetime-from-filter">Date & Time From</label>
+                                <input type="datetime-local" name="datetime_from" id="datetime-from-filter" class="form-control" value="{{ selectedFilters.datetime_from }}" step="1">
+                                <small class="help-block">Filter logs from this time onwards (UTC)</small>
+                            </div>
+                        </div>
+                        <div class="col-md-6 col-sm-12">
+                            <div class="form-group">
+                                <label for="datetime-to-filter">Date & Time To</label>
+                                <input type="datetime-local" name="datetime_to" id="datetime-to-filter" class="form-control" value="{{ selectedFilters.datetime_to }}" step="1">
+                                <small class="help-block">Filter logs up to this time (UTC)</small>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-12">
+                    <div class="audit-log-filter-actions">
+                        <button type="submit" class="btn btn-primary">
+                            <span class="glyphicon glyphicon-filter"></span> Apply Filters
+                        </button>
+                        <a href="{{ url('organization_audit_log', { organization: organization.slug }) }}" class="btn btn-default">
+                            <span class="glyphicon glyphicon-remove-circle"></span> Clear All Filters
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
+
+    {% if dateTimeFromFilter.dateTime or dateTimeToFilter.dateTime %}
+        <div class="alert alert-info audit-log-time-range">
+            <strong>Time range:</strong>
+            {% if dateTimeFromFilter.dateTime %}
+                <span>From: {{ dateTimeFromFilter.dateTime|date('Y-m-d H:i:s') }} UTC</span>
+            {% endif %}
+            {% if dateTimeToFilter.dateTime %}
+                <span>{% if dateTimeFromFilter.dateTime %} | {% endif %}To: {{ dateTimeToFilter.dateTime|date('Y-m-d H:i:s') }} UTC</span>
+            {% endif %}
+        </div>
+    {% endif %}
+
+    {% if auditLogDisplays|length %}
+        <table class="table audit-log-table">
+            <thead>
+            <tr>
+                <th class="audit-log-datetime">Date & Time</th>
+                <th class="audit-log-type">Type</th>
+                <th class="audit-log-details">Details</th>
+                {% if is_granted('ROLE_AUDITOR') %}
+                  <th class="audit-log-ip">IP</th>
+                {% endif  %}
+            </tr>
+            </thead>
+            <tbody>
+                {% for display in auditLogDisplays %}
+                    <tr>
+                        <td class="audit-log-datetime">
+                            {% set fromDate = display.dateTime|date_modify('-2 minutes')|date('Y-m-d\\TH:i:s') %}
+                            {% set toDate = display.dateTime|date_modify('+2 minutes')|date('Y-m-d\\TH:i:s') %}
+                            <a href="{{ path('organization_audit_log', { organization: organization.slug, 'datetime_from': fromDate, 'datetime_to': toDate }) }}" title="Show surrounding logs">
+                                <span class="glyphicon glyphicon-time"></span> {{ display.dateTime|date('Y-m-d H:i:s') }} UTC
+                            </a>
+                        </td>
+                        <td class="audit-log-type" data-test="audit-log-type">{{ display.typeTranslationKey|trans }}</td>
+                        <td class="audit-log-details">
+                            {% include display.templateName with {display} only %}
+                        </td>
+                        {% if is_granted('ROLE_AUDITOR') %}
+                            <td class="audit-log-ip">{{ display.ip }}</td>
+                        {% endif  %}
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+
+        {% if auditLogPaginator.haveToPaginate() %}
+            {{ pagerfanta(auditLogPaginator, 'twitter_bootstrap', {'proximity': 2}) }}
+        {% endif %}
+    {% else %}
+        <div class="alert alert-info">
+            <p>No audit logs found.</p>
+        </div>
+    {% endif %}
+{% endblock %}

--- a/tests/Controller/OrganizationControllerTest.php
+++ b/tests/Controller/OrganizationControllerTest.php
@@ -12,6 +12,8 @@
 
 namespace App\Tests\Controller;
 
+use App\Audit\AuditRecordType;
+use App\Entity\AuditRecord;
 use App\Entity\Organization;
 use App\Entity\OrganizationRepository;
 use App\Entity\OrganizationTeam;
@@ -816,6 +818,63 @@ class OrganizationControllerTest extends IntegrationTestCase
         $this->client->request('GET', '/organizations/acme/settings');
 
         self::assertResponseRedirects('/organizations/acme-inc/settings', 302);
+    }
+
+    public function testAuditLogShowsOnlyRecordsForThisOrganization(): void
+    {
+        $owner = self::createUser('owner', 'owner@example.org');
+        $owner->setTotpSecret('totp-secret');
+        $this->store($owner);
+        $organization = $this->persistOrganization('acme', 'ACME Corp', owner: $owner);
+        $otherOrganization = $this->persistOrganization('globex', 'Globex', owner: $owner);
+
+        $this->store(
+            AuditRecord::organizationCreated($organization->id, $organization->slug, $organization->displayName, $owner),
+            AuditRecord::organizationNameChanged($organization->id, $organization->slug, 'ACME Inc', 'ACME Corp', $owner),
+            // Belongs to a different organization and must not leak into this page.
+            AuditRecord::organizationCreated($otherOrganization->id, $otherOrganization->slug, $otherOrganization->displayName, $owner),
+        );
+
+        $this->client->loginUser($owner);
+        $crawler = $this->client->request('GET', '/organizations/acme/audit-log');
+        self::assertResponseIsSuccessful();
+
+        $types = $crawler->filter('[data-test=audit-log-type]')->each(fn ($element) => trim($element->text()));
+        self::assertCount(2, $types, 'Only the two records for this organization should be listed');
+    }
+
+    public function testAuditLogTypeFilterNarrowsResults(): void
+    {
+        $owner = self::createUser('owner', 'owner@example.org');
+        $owner->setTotpSecret('totp-secret');
+        $this->store($owner);
+        $organization = $this->persistOrganization('acme', 'ACME Corp', owner: $owner);
+
+        $this->store(
+            AuditRecord::organizationCreated($organization->id, $organization->slug, $organization->displayName, $owner),
+            AuditRecord::organizationNameChanged($organization->id, $organization->slug, 'ACME Inc', 'ACME Corp', $owner),
+        );
+
+        $this->client->loginUser($owner);
+        $crawler = $this->client->request('GET', '/organizations/acme/audit-log?type[]='.AuditRecordType::OrganizationNameChanged->value);
+        self::assertResponseIsSuccessful();
+
+        $types = $crawler->filter('[data-test=audit-log-type]')->each(fn ($element) => trim($element->text()));
+        self::assertCount(1, $types, 'The type filter should narrow the results to a single record');
+    }
+
+    public function testAuditLogForbiddenForNonOwner(): void
+    {
+        $owner = self::createUser('owner', 'owner@example.org');
+        $owner->setTotpSecret('totp-secret');
+        $stranger = self::createUser('stranger', 'stranger@example.org');
+        $this->store($owner, $stranger);
+        $this->persistOrganization('acme', 'ACME Corp', owner: $owner);
+
+        $this->client->loginUser($stranger);
+        $this->client->request('GET', '/organizations/acme/audit-log');
+
+        self::assertResponseStatusCodeSame(403);
     }
 
     /**

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -29,6 +29,7 @@ menu:
     organization_teams: Teams
     organization_members: Members
     organization_settings: Settings
+    organization_audit_log: Audit log
 
 signinbox:
      register: No account yet? Create one now!


### PR DESCRIPTION
Adds a per-organization audit log page so org managers can review the transparency-log records for their own organization, without the site-wide /transparency-log view. Records are scoped to the single organization and reuse the existing audit display/rendering layer.

- New `GET /organizations/{organization}/audit-log` route and `auditLog()` action on `OrganizationController`, gated by a new `OrganizationActions::ViewAuditLog` permission (wired into `OrganizationVoter` alongside the other management actions). The query filters on `audit_log.organizationId`, orders newest-first, and paginates at 20/page via Pagerfanta.
- Supports the same filters as the global log: type (multi-select), actor, and date/time from/to. The type dropdown is populated from a new `AuditRecordType::organizationCases()` helper (organization-category types only). Actor filtering is admin-aware (`ROLE_AUDITOR`), and the IP column is shown only to auditors.
- Adds an `organization_idx` index on `audit_log.organizationId` so per-organization filtering doesn't scan the whole table.
- Adds an "Audit log" item to the organization menu (and switches the organization overview icon from dashboard to chart). New menu.organization_audit_log translation.
- New `templates/organization/audit_log.html.twig` with the filter form, an active time-range banner, the results table, and an empty state.

<img width="1165" height="872" alt="Screenshot 2026-07-24 at 14 39 23" src="https://github.com/user-attachments/assets/e98ebd28-f294-4524-8e4f-4d6e75f182fd" />
