### PR TITLE
Add frozen-users admin queue and moderation activity feed

### DIFF
--- a/src/Audit/AuditRecordType.php
+++ b/src/Audit/AuditRecordType.php
@@ -83,6 +83,25 @@ enum AuditRecordType: string
         return array_values(array_filter(self::cases(), static fn (self $type): bool => $type->category() === 'organization'));
     }
 
+    /**
+     * The manually-performed moderation actions surfaced on the admin dashboard so admins can see at a
+     * glance what their peers have been up to. Curated (not every human action) to stay high-signal.
+     *
+     * @return list<self>
+     */
+    public static function moderationActionCases(): array
+    {
+        return [
+            self::UserFrozen,
+            self::UserUnfrozen,
+            self::UserDeleted,
+            self::PackageFrozen,
+            self::PackageUnfrozen,
+            self::VersionSoftDeleted,
+            self::VersionRecovered,
+        ];
+    }
+
     public function category(): string
     {
         return match ($this) {

--- a/src/Controller/Admin/FrozenUserController.php
+++ b/src/Controller/Admin/FrozenUserController.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Packagist.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *     Nils Adermann <naderman@naderman.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Controller\Admin;
+
+use App\Audit\AuditRecordType;
+use App\Controller\Controller;
+use App\Entity\AuditRecord;
+use App\Entity\User;
+use App\Entity\UserFreezeReason;
+use Pagerfanta\Doctrine\ORM\QueryAdapter;
+use Pagerfanta\Pagerfanta;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_DISABLE_USERS')]
+class FrozenUserController extends Controller
+{
+    /**
+     * Review queue for frozen accounts (Temporary holds in particular, which are meant to be
+     * revisited). Any reason can be filtered on; the freeze context per row is derived from the
+     * latest UserFrozen audit record.
+     */
+    #[Route(path: '/admin/frozen-users', name: 'admin_frozen_users', methods: ['GET'])]
+    public function index(Request $req): Response
+    {
+        $reason = UserFreezeReason::tryFrom($req->query->getString('reason'));
+
+        $qb = $this->getEM()->getRepository(User::class)->getFrozenUsersQueryBuilder($reason);
+
+        // Output walkers keep the count query valid despite the HIDDEN ordering subquery.
+        $users = new Pagerfanta(new QueryAdapter($qb, false, true));
+        $users->setNormalizeOutOfRangePages(true);
+        $users->setMaxPerPage(20);
+        $users->setCurrentPage(max(1, $req->query->getInt('page', 1)));
+
+        $userIds = array_values(array_map(static fn (User $user): int => $user->getId(), iterator_to_array($users)));
+
+        return $this->render('admin/frozen_users.html.twig', [
+            'users' => $users,
+            'freezeContext' => $this->latestFreezeAuditByUserId($userIds),
+            'reasons' => UserFreezeReason::cases(),
+            'selectedReason' => $reason,
+        ]);
+    }
+
+    /**
+     * @param list<int> $userIds
+     *
+     * @return array<int, AuditRecord> the most recent UserFrozen record per user id
+     */
+    private function latestFreezeAuditByUserId(array $userIds): array
+    {
+        if ($userIds === []) {
+            return [];
+        }
+
+        /** @var list<AuditRecord> $records */
+        $records = $this->getEM()->getRepository(AuditRecord::class)->createQueryBuilder('a')
+            ->where('a.type = :type')
+            ->andWhere('a.userId IN (:ids)')
+            ->setParameter('type', AuditRecordType::UserFrozen->value)
+            ->setParameter('ids', $userIds)
+            ->orderBy('a.datetime', 'DESC')
+            ->getQuery()->getResult();
+
+        $latestByUserId = [];
+        foreach ($records as $record) {
+            if ($record->userId !== null && !isset($latestByUserId[$record->userId])) {
+                $latestByUserId[$record->userId] = $record;
+            }
+        }
+
+        return $latestByUserId;
+    }
+}

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -12,6 +12,9 @@
 
 namespace App\Controller;
 
+use App\Audit\AuditRecordType;
+use App\Audit\Display\AuditLogDisplayFactory;
+use App\Entity\AuditRecordRepository;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -19,20 +22,29 @@ class AdminController extends Controller
 {
     /**
      * Roles that grant access to the /admin/ section. Any one of them is sufficient, so the
-     * fine-grained admins (filter-list, disable-packages, orgs, auditor) can reach the section too.
-     * ROLE_ADMIN is covered transitively but listed for clarity. Also used by
+     * fine-grained admins (filter-list, disable-packages, disable-users, orgs, auditor) can reach the
+     * section too. ROLE_ADMIN is covered transitively but listed for clarity. Also used by
      * App\Menu\MenuBuilder to decide whether to show the Admin menu entries.
      *
      * @var list<string>
      */
-    public const ADMIN_ROLES = ['ROLE_ADMIN', 'ROLE_FILTER_LIST_ADMIN', 'ROLE_DISABLE_PACKAGES', 'ROLE_ADMIN_ORGS', 'ROLE_AUDITOR'];
+    public const ADMIN_ROLES = ['ROLE_ADMIN', 'ROLE_FILTER_LIST_ADMIN', 'ROLE_DISABLE_PACKAGES', 'ROLE_DISABLE_USERS', 'ROLE_ADMIN_ORGS', 'ROLE_AUDITOR'];
 
     #[Route(path: '/admin/', name: 'admin_index', methods: ['GET'])]
-    public function index(): Response
+    public function index(AuditRecordRepository $auditRecordRepository, AuditLogDisplayFactory $displayFactory): Response
     {
         $this->denyAccessUnlessAdmin();
 
-        return $this->render('admin/index.html.twig');
+        $recentModeration = $auditRecordRepository->createQueryBuilder('a')
+            ->where('a.type IN (:types)')
+            ->setParameter('types', array_map(static fn (AuditRecordType $type): string => $type->value, AuditRecordType::moderationActionCases()))
+            ->orderBy('a.id', 'DESC')
+            ->setMaxResults(20)
+            ->getQuery()->getResult();
+
+        return $this->render('admin/index.html.twig', [
+            'recentModerationActivity' => $displayFactory->build($recentModeration),
+        ]);
     }
 
     private function denyAccessUnlessAdmin(): void

--- a/src/Entity/UserRepository.php
+++ b/src/Entity/UserRepository.php
@@ -12,6 +12,7 @@
 
 namespace App\Entity;
 
+use App\Audit\AuditRecordType;
 use Composer\Pcre\Preg;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\QueryBuilder;
@@ -27,6 +28,28 @@ class UserRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, User::class);
+    }
+
+    /**
+     * Currently-frozen accounts for the admin review queue, optionally filtered by reason and ordered
+     * most-recently-frozen first. The freeze time is derived from the latest UserFrozen audit record
+     * (the audit log stays canonical for who/when/notes — there is no frozenAt column on User).
+     */
+    public function getFrozenUsersQueryBuilder(?UserFreezeReason $reason = null): QueryBuilder
+    {
+        $qb = $this->createQueryBuilder('u')
+            ->addSelect('(SELECT MAX(a.datetime) FROM App\Entity\AuditRecord a WHERE a.userId = u.id AND a.type = :frozenType) AS HIDDEN frozenAt')
+            ->where('u.frozen IS NOT NULL')
+            ->setParameter('frozenType', AuditRecordType::UserFrozen->value)
+            ->orderBy('frozenAt', 'DESC')
+            ->addOrderBy('u.id', 'DESC');
+
+        if ($reason !== null) {
+            $qb->andWhere('u.frozen = :reason')
+                ->setParameter('reason', $reason);
+        }
+
+        return $qb;
     }
 
     public function findOneByUsernameOrEmail(string $usernameOrEmail): ?User

--- a/src/Menu/MenuBuilder.php
+++ b/src/Menu/MenuBuilder.php
@@ -82,6 +82,13 @@ class MenuBuilder
                 'extras' => ['safe_label' => true, 'translation_domain' => false],
             ]);
         }
+        if ($this->security->isGranted('ROLE_DISABLE_USERS')) {
+            $menu->addChild('Frozen users', [
+                'label' => '<span class="icon-lock"></span>Frozen users',
+                'route' => 'admin_frozen_users',
+                'extras' => ['safe_label' => true, 'translation_domain' => false],
+            ]);
+        }
         if ($this->security->isGranted('ROLE_ADMIN_ORGS')) {
             $menu->addChild('Organizations', [
                 'label' => '<span class="icon-users"></span>Organizations',

--- a/templates/admin/frozen_users.html.twig
+++ b/templates/admin/frozen_users.html.twig
@@ -1,0 +1,77 @@
+{% extends "admin/layout.html.twig" %}
+
+{% block title %}Frozen Users - {{ parent() }}{% endblock %}
+
+{% block admin_content %}
+    <div class="row">
+        <div class="col-xs-12 package">
+            <div class="package-header">
+                <h2 class="title">
+                    Frozen Users
+                    <small>({{ users.nbResults }})</small>
+                </h2>
+                <p>Currently-frozen accounts. Temporary holds are meant to be revisited &mdash; unfreeze or escalate them from each user's profile.</p>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <form class="form-inline" method="GET" action="{{ path('admin_frozen_users') }}">
+                <div class="form-group">
+                    <label for="reason-filter">Filter by reason:</label>
+                    <select name="reason" id="reason-filter" class="form-control" onchange="this.form.submit()">
+                        <option value="">All</option>
+                        {% for reason in reasons %}
+                            <option value="{{ reason.value }}"{{ selectedReason == reason ? ' selected' : '' }}>{{ ('user_freeze_reasons.' ~ reason.value)|trans }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <section class="row">
+        <section class="col-md-12">
+            {% if users|length %}
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>User</th>
+                            <th>Reason</th>
+                            <th>Frozen at</th>
+                            <th>Frozen by</th>
+                            <th>Public reason</th>
+                            {% if is_granted('ROLE_AUDITOR') %}
+                                <th>Internal note</th>
+                            {% endif %}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for user in users %}
+                            {% set ctx = freezeContext[user.id]|default(null) %}
+                            <tr>
+                                <td><a href="{{ path('user_profile', {name: user.username}) }}">{{ user.username }}</a></td>
+                                <td>{{ ('user_freeze_reasons.' ~ user.freezeReason.value)|trans }}</td>
+                                <td>{{ ctx ? ctx.datetime|date('Y-m-d H:i:s') ~ ' UTC' : '—' }}</td>
+                                <td>{{ ctx ? (ctx.attributes.actor.username ?? ctx.attributes.actor) : '—' }}</td>
+                                <td>{{ ctx and ctx.attributes.reasonText ? ctx.attributes.reasonText : '—' }}</td>
+                                {% if is_granted('ROLE_AUDITOR') %}
+                                    <td>{{ ctx and ctx.attributes.internalReason ? ctx.attributes.internalReason : '—' }}</td>
+                                {% endif %}
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+
+                {% if users.haveToPaginate() %}
+                    {{ pagerfanta(users, 'twitter_bootstrap', {'proximity': 2}) }}
+                {% endif %}
+            {% else %}
+                <div class="alert alert-info">
+                    <p>No frozen accounts{{ selectedReason ? ' for this reason' : '' }}.</p>
+                </div>
+            {% endif %}
+        </section>
+    </section>
+{% endblock %}

--- a/templates/admin/index.html.twig
+++ b/templates/admin/index.html.twig
@@ -1,47 +1,18 @@
-{% extends "layout.html.twig" %}
-
-{% set showSearchDesc = 'hide' %}
-
-{% block head_additions %}<meta name="robots" content="noindex, nofollow">{% endblock %}
+{% extends "admin/layout.html.twig" %}
 
 {% block title %}Administration - {{ parent() }}{% endblock %}
 
-{% block content %}
+{% block admin_content %}
     <div class="row">
         <div class="col-xs-12 package">
             <div class="package-header">
-                <h2 class="title">Administration</h2>
-                <p>Administrative tools for Packagist. Pick a section below.</p>
+                <h2 class="title">Recent moderation activity</h2>
             </div>
-        </div>
-    </div>
-
-    <div class="row">
-        <div class="col-md-6">
-            <div class="list-group">
-                {% if is_granted('ROLE_FILTER_LIST_ADMIN') %}
-                    <a href="{{ path('admin_filter_lists') }}" class="list-group-item">
-                        <h4 class="list-group-item-heading"><span class="icon-archive"></span> Filter lists</h4>
-                        <p class="list-group-item-text">Manage filter list entries received from external providers (e.g. malware reports).</p>
-                    </a>
-                {% endif %}
-                {% if is_granted('ROLE_DISABLE_PACKAGES') %}
-                    <a href="{{ path('view_spam') }}" class="list-group-item">
-                        <h4 class="list-group-item-heading"><span class="icon-traffic-cone"></span> Suspect packages</h4>
-                        <p class="list-group-item-text">Review packages flagged as potential spam and mark them as safe.</p>
-                    </a>
-                {% endif %}
-                {% if is_granted('ROLE_ADMIN_ORGS') %}
-                    <a href="{{ path('admin_organization_list') }}" class="list-group-item">
-                        <h4 class="list-group-item-heading"><span class="icon-users"></span> Organizations</h4>
-                        <p class="list-group-item-text">Manage and moderate organizations.</p>
-                    </a>
-                {% endif %}
-                <a href="{{ path('view_transparency_log') }}" class="list-group-item">
-                    <h4 class="list-group-item-heading"><span class="icon-back-in-time"></span> Transparency log</h4>
-                    <p class="list-group-item-text">Browse the audit trail of administrative and account actions.</p>
-                </a>
-            </div>
+            {% include 'audit_log/_transparency_log_table.html.twig' with {
+                displays: recentModerationActivity,
+                linkSurroundingLogs: true,
+                emptyMessage: 'No recent moderation activity.'
+            } only %}
         </div>
     </div>
 {% endblock %}

--- a/tests/Controller/AdminControllerTest.php
+++ b/tests/Controller/AdminControllerTest.php
@@ -12,10 +12,30 @@
 
 namespace App\Tests\Controller;
 
+use App\Entity\AuditRecord;
+use App\Entity\UserFreezeReason;
 use App\Tests\IntegrationTestCase;
 
 class AdminControllerTest extends IntegrationTestCase
 {
+    public function testIndexShowsRecentModerationActivity(): void
+    {
+        $admin = self::createUser('admin', 'admin@example.com', roles: ['ROLE_ADMIN']);
+        $victim = self::createUser('victim', 'victim@example.org');
+        $this->store($admin, $victim);
+
+        self::getEM()->getRepository(AuditRecord::class)->insert(
+            AuditRecord::userFrozen($victim, $admin, UserFreezeReason::Temporary, 'pending review')
+        );
+
+        $this->client->loginUser($admin);
+        $crawler = $this->client->request('GET', '/admin/');
+
+        static::assertResponseIsSuccessful();
+        static::assertStringContainsString('Recent moderation activity', $crawler->html());
+        static::assertStringContainsString('victim', $crawler->filter('.audit-log-table')->text());
+    }
+
     public function testIndexDeniedForRegularUser(): void
     {
         $user = self::createUser('plain', 'plain@example.com', roles: ['ROLE_USER']);

--- a/tests/Controller/FrozenUserControllerTest.php
+++ b/tests/Controller/FrozenUserControllerTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Packagist.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *     Nils Adermann <naderman@naderman.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Controller;
+
+use App\Entity\UserFreezeReason;
+use App\Tests\IntegrationTestCase;
+
+class FrozenUserControllerTest extends IntegrationTestCase
+{
+    public function testDeniedWithoutDisableUsersRole(): void
+    {
+        // ROLE_DISABLE_PACKAGES can reach /admin/ but must not see the frozen-users page.
+        $mod = self::createUser('pkgmod', 'pkgmod@example.org', roles: ['ROLE_DISABLE_PACKAGES']);
+        $this->store($mod);
+
+        $this->client->loginUser($mod);
+        $this->client->request('GET', '/admin/frozen-users');
+
+        self::assertSame(403, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testListsFrozenUsersAndFiltersByReason(): void
+    {
+        $mod = self::createUser('mod', 'mod@example.org', roles: ['ROLE_DISABLE_USERS']);
+        $spammer = self::createUser('spammer', 'spammer@example.org');
+        $spammer->freeze(UserFreezeReason::Spam);
+        $temp = self::createUser('temphold', 'temp@example.org');
+        $temp->freeze(UserFreezeReason::Temporary);
+        $this->store($mod, $spammer, $temp);
+
+        $this->client->loginUser($mod);
+
+        $html = $this->client->request('GET', '/admin/frozen-users')->html();
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('spammer', $html);
+        self::assertStringContainsString('temphold', $html);
+
+        $filtered = $this->client->request('GET', '/admin/frozen-users?reason=temporary')->html();
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('temphold', $filtered);
+        self::assertStringNotContainsString('spammer', $filtered);
+    }
+}

--- a/tests/Entity/UserRepositoryTest.php
+++ b/tests/Entity/UserRepositoryTest.php
@@ -12,6 +12,8 @@
 
 namespace App\Tests\Entity;
 
+use App\Entity\User;
+use App\Entity\UserFreezeReason;
 use App\Entity\UserRepository;
 use App\Tests\IntegrationTestCase;
 
@@ -24,6 +26,26 @@ class UserRepositoryTest extends IntegrationTestCase
         parent::setUp();
 
         $this->userRepository = self::getEM()->getRepository(\App\Entity\User::class);
+    }
+
+    public function testGetFrozenUsersQueryBuilderExcludesUnfrozenAndFiltersByReason(): void
+    {
+        $spammer = self::createUser('spammer', 'spammer@example.org');
+        $spammer->freeze(UserFreezeReason::Spam);
+        $temp = self::createUser('temphold', 'temp@example.org');
+        $temp->freeze(UserFreezeReason::Temporary);
+        $active = self::createUser('active', 'active@example.org');
+        $this->store($spammer, $temp, $active);
+
+        $usernames = static fn (array $users): array => array_map(static fn (User $u): string => $u->getUsername(), $users);
+
+        $all = $usernames($this->userRepository->getFrozenUsersQueryBuilder()->getQuery()->getResult());
+        self::assertContains('spammer', $all);
+        self::assertContains('temphold', $all);
+        self::assertNotContains('active', $all, 'unfrozen accounts must not appear');
+
+        $temporaryOnly = $usernames($this->userRepository->getFrozenUsersQueryBuilder(UserFreezeReason::Temporary)->getQuery()->getResult());
+        self::assertSame(['temphold'], $temporaryOnly);
     }
 
     public function testFindUsersByUsernameWithMultipleValidUsernames(): void


### PR DESCRIPTION
- Frozen users page (/admin/frozen-users, ROLE_DISABLE_USERS): all currently-frozen accounts with a reason filter, ordered most-recently-frozen first; per-row who/when/notes derived from the latest UserFrozen audit record. Adds ROLE_DISABLE_USERS to ADMIN_ROLES plus a menu entry and dashboard card.

- Admin dashboard: last 20 manual moderation actions (AuditRecordType::moderationActionCases()), rendered via the existing transparency-log table and AuditLogDisplayFactory.

- UserRepository::getFrozenUsersQueryBuilder() orders by a HIDDEN correlated subquery on the latest UserFrozen audit (no frozenAt column; audit log stays canonical for who/when/notes).