### PR TITLE
Allow admins to hide versions that are already soft-deleted by maintainer/updater without recovering them first

### DIFF
--- a/js/view.js
+++ b/js/view.js
@@ -239,6 +239,18 @@ const init = function ($) {
         return $(form).closest('.version').find('.version-number').text().trim();
     }
 
+    // Point a deletion tooltip at a new title, creating it when the row was not soft-deleted before.
+    // fixTitle re-reads the native title into data-original-title and blanks it, so the browser
+    // tooltip does not render on top of the Bootstrap one.
+    function setDeletionTooltip($el, title) {
+        $el.attr('title', title);
+        if ($el.data('bs.tooltip')) {
+            $el.tooltip('fixTitle');
+        } else {
+            $el.tooltip({placement: 'top', container: 'body'});
+        }
+    }
+
     function applyVersionDeleteResponse(form, data, deletedToast, softDeletedToast) {
         var row = $(form).closest('.version');
         if (data && data.softDeleted) {
@@ -248,13 +260,15 @@ const init = function ($) {
             // and refresh it rather than leaving the previous icon and title in place.
             var alert = row.find('.deletion-alert');
             if (!alert.length) {
-                alert = $('<span class="action-alert deletion-alert"><i class="glyphicon"></i></span>');
+                alert = $('<span class="action-alert deletion-alert" data-toggle="tooltip" data-placement="top" data-container="body"><i class="glyphicon"></i></span>');
                 alert.insertBefore(row.find('form').first());
             }
             alert.find('i').attr('class', 'glyphicon ' + (data.deletionIcon || 'glyphicon-trash'));
+            // The version number carries the same title, and has no tooltip at all until the row is
+            // soft-deleted, so it needs the same treatment as the badge.
             var title = data.deletionTitle || 'Deleted';
-            // server-rendered badges have an initialised BS3 tooltip, which reads data-original-title
-            alert.attr('title', title).attr('data-original-title', title);
+            setDeletionTooltip(alert, title);
+            setDeletionTooltip(row.find('.version-number a'), title);
             row.find('.delete-version, .hide-version').remove();
         } else {
             notifier.log(deletedToast, {timeout: 3000});

--- a/js/view.js
+++ b/js/view.js
@@ -239,18 +239,22 @@ const init = function ($) {
         return $(form).closest('.version').find('.version-number').text().trim();
     }
 
-    function applyVersionDeleteResponse(form, data, deletedToast) {
+    function applyVersionDeleteResponse(form, data, deletedToast, softDeletedToast) {
         var row = $(form).closest('.version');
         if (data && data.softDeleted) {
-            notifier.log('Version soft-deleted. Reload the page to access the recovery action.', {timeout: 4000});
+            notifier.log(softDeletedToast || 'Version soft-deleted. Reload the page to access the recovery action.', {timeout: 4000});
             row.addClass('version-soft-deleted');
-            if (!row.find('.deletion-alert').length) {
-                var icon = data.deletionIcon || 'glyphicon-trash';
-                var alert = $('<span class="action-alert deletion-alert"><i class="glyphicon"></i></span>');
-                alert.find('i').addClass(icon);
-                alert.attr('title', data.deletionTitle || 'Deleted');
+            // The row may already carry a badge (hiding an already soft-deleted version), so reuse
+            // and refresh it rather than leaving the previous icon and title in place.
+            var alert = row.find('.deletion-alert');
+            if (!alert.length) {
+                alert = $('<span class="action-alert deletion-alert"><i class="glyphicon"></i></span>');
                 alert.insertBefore(row.find('form').first());
             }
+            alert.find('i').attr('class', 'glyphicon ' + (data.deletionIcon || 'glyphicon-trash'));
+            var title = data.deletionTitle || 'Deleted';
+            // server-rendered badges have an initialised BS3 tooltip, which reads data-original-title
+            alert.attr('title', title).attr('data-original-title', title);
             row.find('.delete-version, .hide-version').remove();
         } else {
             notifier.log(deletedToast, {timeout: 3000});
@@ -330,7 +334,7 @@ const init = function ($) {
             if (publicReason) data.push({name: 'reason', value: publicReason});
             if (internalReason) data.push({name: 'internalReason', value: internalReason});
             dispatchVersionAction(form, function (resp) {
-                applyVersionDeleteResponse(form, resp, 'Version hidden');
+                applyVersionDeleteResponse(form, resp, 'Version hidden.', 'Version hidden.');
             }, {data: data});
         });
     });

--- a/src/Audit/VersionDeletionReason.php
+++ b/src/Audit/VersionDeletionReason.php
@@ -77,4 +77,17 @@ enum VersionDeletionReason: string
             self::DeletedByAdmin, self::Hidden => false,
         };
     }
+
+    /**
+     * Whether an admin can switch this soft-delete straight to Hidden. Admin-pulled rows already
+     * carry a deliberate admin decision, and Hidden rows are already hidden — both go through
+     * recover first.
+     */
+    public function isHideableByAdmin(): bool
+    {
+        return match ($this) {
+            self::AutoDeletedMissing, self::DeletedByMaintainer => true,
+            self::DeletedByAdmin, self::Hidden => false,
+        };
+    }
 }

--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -845,7 +845,6 @@ class PackageController extends Controller
         }
 
         $this->getEM()->flush();
-        $this->getEM()->clear();
 
         return new JsonResponse(['softDeleted' => $softDeleted, 'deletionTitle' => $deletionTitle]);
     }
@@ -871,7 +870,6 @@ class PackageController extends Controller
 
         $repo->softDelete($version, VersionDeletionReason::DeletedByAdmin, $reasonText, $internalReasonText, $user);
         $this->getEM()->flush();
-        $this->getEM()->clear();
 
         // deletionTitle becomes a public tooltip, so it only carries the public reason.
         $deletionTitle = 'Removed by admin on '.gmdate('Y-m-d H:i:s').' UTC'
@@ -910,10 +908,8 @@ class PackageController extends Controller
         $repo->softDelete($version, VersionDeletionReason::Hidden, $reasonText, $internalReasonText, $user);
         $this->getEM()->flush();
 
-        // Read before clear(), and from the entity so the date matches what a page reload renders —
-        // softDelete() keeps the original removal time when the version was already soft-deleted.
+        // Read off the entity so the ajax tooltip matches what a page reload renders.
         $deletionTitle = $version->getDeletionTitle();
-        $this->getEM()->clear();
 
         return new JsonResponse(['softDeleted' => true, 'deletionTitle' => $deletionTitle, 'deletionIcon' => 'glyphicon-eye-close']);
     }
@@ -944,7 +940,6 @@ class PackageController extends Controller
 
         $repo->recover($version, $user);
         $this->getEM()->flush();
-        $this->getEM()->clear();
 
         return new Response('', 204);
     }

--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -896,15 +896,24 @@ class PackageController extends Controller
             throw new AccessDeniedException('Invalid CSRF token');
         }
 
+        // Admins may hide a version that is already soft-deleted as gone-from-upstream or
+        // maintainer-pulled, without recovering it first. Admin-pulled rows already carry a
+        // deliberate admin decision and Hidden rows are already hidden, so those go through recover.
+        $currentReason = $version->getDeletionReason() ?? VersionDeletionReason::AutoDeletedMissing;
+        if ($version->isSoftDeleted() && !$currentReason->isHideableByAdmin()) {
+            throw new AccessDeniedException('This version must be recovered before it can be hidden.');
+        }
+
         $reasonText = trim($req->request->getString('reason')) ?: null;
         $internalReasonText = trim($req->request->getString('internalReason')) ?: null;
 
         $repo->softDelete($version, VersionDeletionReason::Hidden, $reasonText, $internalReasonText, $user);
         $this->getEM()->flush();
-        $this->getEM()->clear();
 
-        $deletionTitle = 'Hidden by admin on '.gmdate('Y-m-d H:i:s').' UTC'
-            .($reasonText !== null ? ': '.$reasonText : '');
+        // Read before clear(), and from the entity so the date matches what a page reload renders —
+        // softDelete() keeps the original removal time when the version was already soft-deleted.
+        $deletionTitle = $version->getDeletionTitle();
+        $this->getEM()->clear();
 
         return new JsonResponse(['softDeleted' => true, 'deletionTitle' => $deletionTitle, 'deletionIcon' => 'glyphicon-eye-close']);
     }

--- a/src/Entity/VersionRepository.php
+++ b/src/Entity/VersionRepository.php
@@ -97,18 +97,14 @@ class VersionRepository extends ServiceEntityRepository
      * Soft-delete a version with a reason. On a first soft-delete this schedules a fresh Updater run
      * so dependents/suggesters and the V2 dump get recomputed without the version (frozen packages
      * only get marked for dump). Changing the reason on an already soft-deleted version only
-     * rewrites the reason and audits it.
+     * restamps and audits it; the audit log keeps the detailed timeline.
      */
     public function softDelete(Version $version, VersionDeletionReason $reason, ?string $reasonText, ?string $internalReasonText, ?User $actor): void
     {
         $em = $this->getEntityManager();
         $wasSoftDeleted = $version->isSoftDeleted();
 
-        // A reason change on an already soft-deleted version keeps the original removal time — the
-        // version really has been gone since then; the audit record carries when the reason changed.
-        if (!$wasSoftDeleted) {
-            $version->setSoftDeletedAt(new \DateTimeImmutable());
-        }
+        $version->setSoftDeletedAt(new \DateTimeImmutable());
         $version->setDeletionReason($reason);
         $version->setDeletionReasonText($reasonText);
         $version->setInternalDeletionReasonText($internalReasonText);

--- a/src/Entity/VersionRepository.php
+++ b/src/Entity/VersionRepository.php
@@ -94,19 +94,33 @@ class VersionRepository extends ServiceEntityRepository
     }
 
     /**
-     * Soft-delete a version with a reason. Schedules a fresh Updater run so dependents/suggesters
-     * and the V2 dump get recomputed without the version (frozen packages only get marked for dump).
+     * Soft-delete a version with a reason. On a first soft-delete this schedules a fresh Updater run
+     * so dependents/suggesters and the V2 dump get recomputed without the version (frozen packages
+     * only get marked for dump). Changing the reason on an already soft-deleted version only
+     * rewrites the reason and audits it.
      */
     public function softDelete(Version $version, VersionDeletionReason $reason, ?string $reasonText, ?string $internalReasonText, ?User $actor): void
     {
         $em = $this->getEntityManager();
-        $version->setSoftDeletedAt(new \DateTimeImmutable());
+        $wasSoftDeleted = $version->isSoftDeleted();
+
+        // A reason change on an already soft-deleted version keeps the original removal time — the
+        // version really has been gone since then; the audit record carries when the reason changed.
+        if (!$wasSoftDeleted) {
+            $version->setSoftDeletedAt(new \DateTimeImmutable());
+        }
         $version->setDeletionReason($reason);
         $version->setDeletionReasonText($reasonText);
         $version->setInternalDeletionReasonText($internalReasonText);
         $em->persist($version);
 
         $em->persist(AuditRecord::versionSoftDeleted($version, $reason, $reasonText, $internalReasonText, $actor));
+
+        // Dumps and dependent/suggester data key off isSoftDeleted() only, never the reason, so a
+        // reason change on an already-deleted row has nothing to recompute.
+        if ($wasSoftDeleted) {
+            return;
+        }
 
         if (!$version->getPackage()->isFrozen()) {
             $this->scheduler->scheduleUpdate($version->getPackage(), 'version_recover');

--- a/templates/package/version_list.html.twig
+++ b/templates/package/version_list.html.twig
@@ -44,13 +44,16 @@
                     </span>
                 {% endif %}
 
+                {# admins can also hide a version that is already soft-deleted as gone-from-upstream
+                   or maintainer-pulled, without recovering it first #}
+                {% if canHideVersion|default(false) and (not softDeleted or reason is null or reason.isHideableByAdmin()) %}
+                    <form class="hide-version" action="{{ path("admin_hide_version", {"versionId": version.id}) }}" method="POST">
+                        <input type="hidden" name="_token" value="{{ manageVersionsCsrfToken }}" />
+                        <i class="submit glyphicon glyphicon-eye-close" data-toggle="tooltip" data-placement="top" title="Hide version from public" data-container="body"></i>
+                    </form>
+                {% endif %}
+
                 {% if not softDeleted and canDeleteVersion|default(false) %}
-                    {% if canHideVersion|default(false) %}
-                        <form class="hide-version" action="{{ path("admin_hide_version", {"versionId": version.id}) }}" method="POST">
-                            <input type="hidden" name="_token" value="{{ manageVersionsCsrfToken }}" />
-                            <i class="submit glyphicon glyphicon-eye-close" data-toggle="tooltip" data-placement="top" title="Hide version from public" data-container="body"></i>
-                        </form>
-                    {% endif %}
                     <form class="delete-version" action="{{ path("delete_version", {"versionId": version.id}) }}" method="DELETE"
                           {% if canAdminDeleteVersion|default(false) %}
                               data-admin="1"

--- a/tests/Controller/PackageControllerTest.php
+++ b/tests/Controller/PackageControllerTest.php
@@ -403,11 +403,11 @@ class PackageControllerTest extends IntegrationTestCase
      * maintainer-pulled; admin-pulled and already-hidden rows must be recovered first.
      */
     #[TestWith([null, true, 200])]
-    #[TestWith(['auto_missing', true, 200])]
-    #[TestWith(['maintainer', true, 200])]
-    #[TestWith(['admin', false, 403])]
-    #[TestWith(['hidden', false, 403])]
-    public function testAdminHideVersionAllowedTransitions(?string $reason, bool $buttonShown, int $expectedStatus): void
+    #[TestWith([VersionDeletionReason::AutoDeletedMissing, true, 200])]
+    #[TestWith([VersionDeletionReason::DeletedByMaintainer, true, 200])]
+    #[TestWith([VersionDeletionReason::DeletedByAdmin, false, 403])]
+    #[TestWith([VersionDeletionReason::Hidden, false, 403])]
+    public function testAdminHideVersionAllowedTransitions(?VersionDeletionReason $reason, bool $buttonShown, int $expectedStatus): void
     {
         $removedAt = new \DateTimeImmutable('2024-01-02 03:04:05');
 
@@ -418,7 +418,7 @@ class PackageControllerTest extends IntegrationTestCase
         $target = $this->createStableVersion($package, '1.0.0');
         if ($reason !== null) {
             $target->setSoftDeletedAt($removedAt);
-            $target->setDeletionReason(VersionDeletionReason::from($reason));
+            $target->setDeletionReason($reason);
         }
         // A never-deleted version always renders a hide form, giving us a valid CSRF token even in
         // the cases where the target row must not offer one.
@@ -434,7 +434,7 @@ class PackageControllerTest extends IntegrationTestCase
         self::assertSame(
             $buttonShown ? 1 : 0,
             $crawler->filter('li.version[data-version-id="1.0.0"] .hide-version')->count(),
-            'hide button visibility for reason '.var_export($reason, true)
+            'hide button visibility for reason '.($reason?->value ?? 'none')
         );
 
         $token = $crawler->filter('li.version[data-version-id="1.1.0"] .hide-version input[name="_token"]')->attr('value');
@@ -447,7 +447,7 @@ class PackageControllerTest extends IntegrationTestCase
         self::assertNotNull($reloaded);
 
         if ($expectedStatus !== 200) {
-            self::assertSame(VersionDeletionReason::from((string) $reason), $reloaded->getDeletionReason(), 'rejected request must not change the reason');
+            self::assertSame($reason, $reloaded->getDeletionReason(), 'rejected request must not change the reason');
 
             return;
         }
@@ -457,10 +457,10 @@ class PackageControllerTest extends IntegrationTestCase
         self::assertNotNull($reloaded->getSoftDeletedAt());
 
         if ($reason !== null) {
-            self::assertSame(
-                $removedAt->format('Y-m-d H:i:s'),
-                $reloaded->getSoftDeletedAt()->format('Y-m-d H:i:s'),
-                'hiding an already soft-deleted version must keep the original removal time'
+            self::assertGreaterThan(
+                $removedAt,
+                $reloaded->getSoftDeletedAt(),
+                'hiding an already soft-deleted version restamps it with the time of the hide'
             );
         }
     }

--- a/tests/Controller/PackageControllerTest.php
+++ b/tests/Controller/PackageControllerTest.php
@@ -398,6 +398,98 @@ class PackageControllerTest extends IntegrationTestCase
         self::assertStringContainsString('s-maxage=86400', $cacheControl);
     }
 
+    /**
+     * Admins can hide a version that is already soft-deleted as gone-from-upstream or
+     * maintainer-pulled; admin-pulled and already-hidden rows must be recovered first.
+     */
+    #[TestWith([null, true, 200])]
+    #[TestWith(['auto_missing', true, 200])]
+    #[TestWith(['maintainer', true, 200])]
+    #[TestWith(['admin', false, 403])]
+    #[TestWith(['hidden', false, 403])]
+    public function testAdminHideVersionAllowedTransitions(?string $reason, bool $buttonShown, int $expectedStatus): void
+    {
+        $removedAt = new \DateTimeImmutable('2024-01-02 03:04:05');
+
+        $maintainer = self::createUser('owner', 'owner@example.org');
+        $admin = self::createUser('admin', 'admin@example.org', roles: ['ROLE_ADMIN']);
+        $package = self::createPackage('test/pkg', 'https://example.com/test/pkg', maintainers: [$maintainer]);
+
+        $target = $this->createStableVersion($package, '1.0.0');
+        if ($reason !== null) {
+            $target->setSoftDeletedAt($removedAt);
+            $target->setDeletionReason(VersionDeletionReason::from($reason));
+        }
+        // A never-deleted version always renders a hide form, giving us a valid CSRF token even in
+        // the cases where the target row must not offer one.
+        $live = $this->createStableVersion($package, '1.1.0');
+
+        $this->store($maintainer, $admin, $package, $target, $live);
+        $targetId = $target->getId();
+
+        $this->client->loginUser($admin);
+        $crawler = $this->client->request('GET', '/packages/test/pkg');
+        self::assertResponseIsSuccessful();
+
+        self::assertSame(
+            $buttonShown ? 1 : 0,
+            $crawler->filter('li.version[data-version-id="1.0.0"] .hide-version')->count(),
+            'hide button visibility for reason '.var_export($reason, true)
+        );
+
+        $token = $crawler->filter('li.version[data-version-id="1.1.0"] .hide-version input[name="_token"]')->attr('value');
+        $this->client->request('POST', '/versions/'.$targetId.'/admin-hide', ['_token' => $token, 'reason' => 'spam']);
+        self::assertResponseStatusCodeSame($expectedStatus);
+
+        $em = self::getEM();
+        $em->clear();
+        $reloaded = $em->getRepository(Version::class)->find($targetId);
+        self::assertNotNull($reloaded);
+
+        if ($expectedStatus !== 200) {
+            self::assertSame(VersionDeletionReason::from((string) $reason), $reloaded->getDeletionReason(), 'rejected request must not change the reason');
+
+            return;
+        }
+
+        self::assertSame(VersionDeletionReason::Hidden, $reloaded->getDeletionReason());
+        self::assertSame('spam', $reloaded->getDeletionReasonText());
+        self::assertNotNull($reloaded->getSoftDeletedAt());
+
+        if ($reason !== null) {
+            self::assertSame(
+                $removedAt->format('Y-m-d H:i:s'),
+                $reloaded->getSoftDeletedAt()->format('Y-m-d H:i:s'),
+                'hiding an already soft-deleted version must keep the original removal time'
+            );
+        }
+    }
+
+    public function testAdminHideVersionDeniedForMaintainer(): void
+    {
+        $maintainer = self::createUser('owner', 'owner@example.org');
+        $package = self::createPackage('test/pkg', 'https://example.com/test/pkg', maintainers: [$maintainer]);
+        $version = $this->createStableVersion($package, '1.0.0');
+        $version->setSoftDeletedAt(new \DateTimeImmutable());
+        $version->setDeletionReason(VersionDeletionReason::AutoDeletedMissing);
+        $this->store($maintainer, $package, $version);
+        $versionId = $version->getId();
+
+        $this->client->loginUser($maintainer);
+        $crawler = $this->client->request('GET', '/packages/test/pkg');
+        self::assertResponseIsSuccessful();
+        self::assertCount(0, $crawler->filter('.hide-version'), 'maintainers are never offered the hide action');
+
+        $this->client->request('POST', '/versions/'.$versionId.'/admin-hide', ['_token' => 'x', 'reason' => 'spam']);
+        self::assertResponseStatusCodeSame(403);
+
+        self::getEM()->clear();
+        self::assertSame(
+            VersionDeletionReason::AutoDeletedMissing,
+            self::getEM()->getRepository(Version::class)->find($versionId)->getDeletionReason()
+        );
+    }
+
     private function createStableVersion(Package $package, string $version): Version
     {
         $v = new Version();

--- a/tests/Entity/VersionRepositoryTest.php
+++ b/tests/Entity/VersionRepositoryTest.php
@@ -123,21 +123,22 @@ class VersionRepositoryTest extends IntegrationTestCase
         self::assertSame('reporter john@example.com, ticket #42', $audit->attributes['internalReasonText']);
     }
 
-    public function testSoftDeleteOfAlreadySoftDeletedVersionKeepsRemovalTimeAndSkipsRecrawl(): void
+    public function testSoftDeleteOfAlreadySoftDeletedVersionRestampsAndSkipsRecrawl(): void
     {
         $em = self::getEM();
         $version = $this->seedStableVersion('vendor/sd-rehide', '2.0.0', '2.0.0.0');
         $packageId = $version->getPackage()->getId();
 
         $this->versionRepository->softDelete($version, VersionDeletionReason::AutoDeletedMissing, null, null, null);
+        // Backdate the first removal so the restamp below is unambiguous rather than same-second.
+        $originalSoftDeletedAt = new \DateTimeImmutable('2024-01-02 03:04:05');
+        $version->setSoftDeletedAt($originalSoftDeletedAt);
         $em->flush();
 
-        $originalSoftDeletedAt = $version->getSoftDeletedAt();
-        self::assertNotNull($originalSoftDeletedAt);
         $jobRepo = $em->getRepository(Job::class);
         self::assertCount(1, $jobRepo->findBy(['type' => 'package:updates', 'packageId' => $packageId]));
 
-        // An admin hiding the already soft-deleted version: reason is rewritten, removal time is not.
+        // An admin hiding the already soft-deleted version rewrites the reason and the removal time.
         $this->versionRepository->softDelete($version, VersionDeletionReason::Hidden, 'spam', 'ticket #7', null);
         $em->flush();
         $em->clear();
@@ -148,10 +149,10 @@ class VersionRepositoryTest extends IntegrationTestCase
         self::assertSame('spam', $reloaded->getDeletionReasonText());
         self::assertSame('ticket #7', $reloaded->getInternalDeletionReasonText());
         self::assertNotNull($reloaded->getSoftDeletedAt());
-        self::assertSame(
-            $originalSoftDeletedAt->format('Y-m-d H:i:s'),
-            $reloaded->getSoftDeletedAt()->format('Y-m-d H:i:s'),
-            'A reason change must keep the original removal time'
+        self::assertGreaterThan(
+            $originalSoftDeletedAt,
+            $reloaded->getSoftDeletedAt(),
+            'A reason change restamps the removal time; the audit log keeps the detailed timeline'
         );
 
         // Nothing to recompute: dumps filter on isSoftDeleted() alone, so no extra crawl is queued.

--- a/tests/Entity/VersionRepositoryTest.php
+++ b/tests/Entity/VersionRepositoryTest.php
@@ -15,6 +15,7 @@ namespace App\Tests\Entity;
 use App\Audit\AuditRecordType;
 use App\Audit\VersionDeletionReason;
 use App\Entity\AuditRecord;
+use App\Entity\Job;
 use App\Entity\Version;
 use App\Entity\VersionRepository;
 use App\Tests\IntegrationTestCase;
@@ -120,6 +121,51 @@ class VersionRepositoryTest extends IntegrationTestCase
         self::assertNotNull($audit);
         self::assertSame('legal takedown', $audit->attributes['reasonText']);
         self::assertSame('reporter john@example.com, ticket #42', $audit->attributes['internalReasonText']);
+    }
+
+    public function testSoftDeleteOfAlreadySoftDeletedVersionKeepsRemovalTimeAndSkipsRecrawl(): void
+    {
+        $em = self::getEM();
+        $version = $this->seedStableVersion('vendor/sd-rehide', '2.0.0', '2.0.0.0');
+        $packageId = $version->getPackage()->getId();
+
+        $this->versionRepository->softDelete($version, VersionDeletionReason::AutoDeletedMissing, null, null, null);
+        $em->flush();
+
+        $originalSoftDeletedAt = $version->getSoftDeletedAt();
+        self::assertNotNull($originalSoftDeletedAt);
+        $jobRepo = $em->getRepository(Job::class);
+        self::assertCount(1, $jobRepo->findBy(['type' => 'package:updates', 'packageId' => $packageId]));
+
+        // An admin hiding the already soft-deleted version: reason is rewritten, removal time is not.
+        $this->versionRepository->softDelete($version, VersionDeletionReason::Hidden, 'spam', 'ticket #7', null);
+        $em->flush();
+        $em->clear();
+
+        $reloaded = $this->versionRepository->find($version->getId());
+        self::assertNotNull($reloaded);
+        self::assertSame(VersionDeletionReason::Hidden, $reloaded->getDeletionReason());
+        self::assertSame('spam', $reloaded->getDeletionReasonText());
+        self::assertSame('ticket #7', $reloaded->getInternalDeletionReasonText());
+        self::assertNotNull($reloaded->getSoftDeletedAt());
+        self::assertSame(
+            $originalSoftDeletedAt->format('Y-m-d H:i:s'),
+            $reloaded->getSoftDeletedAt()->format('Y-m-d H:i:s'),
+            'A reason change must keep the original removal time'
+        );
+
+        // Nothing to recompute: dumps filter on isSoftDeleted() alone, so no extra crawl is queued.
+        self::assertCount(1, $em->getRepository(Job::class)->findBy(['type' => 'package:updates', 'packageId' => $packageId]));
+
+        $audits = $em->getRepository(AuditRecord::class)->findBy([
+            'type' => AuditRecordType::VersionSoftDeleted->value,
+            'packageId' => $packageId,
+        ]);
+        self::assertCount(2, $audits, 'The reason change should be audited as its own record');
+        self::assertSame(
+            [VersionDeletionReason::AutoDeletedMissing->value, VersionDeletionReason::Hidden->value],
+            array_map(static fn (AuditRecord $a): string => $a->attributes['reason'], $audits)
+        );
     }
 
     public function testRecoverClearsAllSoftDeleteState(): void


### PR DESCRIPTION
This is to smoothen admin workflows