### PR TITLE
Fix null-CVE security advisory matching

### DIFF
--- a/src/Entity/SecurityAdvisory.php
+++ b/src/Entity/SecurityAdvisory.php
@@ -192,7 +192,7 @@ class SecurityAdvisory
     public function calculateDifferenceScore(RemoteSecurityAdvisory $advisory): int
     {
         // Regard advisories where CVE + package name match as identical as the remaining data on GitHub and FriendsOfPhp can be quite different
-        if ($advisory->cve === $this->getCve() && $advisory->packageName === $this->getPackageName()) {
+        if ($advisory->cve !== null && $advisory->cve === $this->getCve() && $advisory->packageName === $this->getPackageName()) {
             return 0;
         }
 

--- a/tests/Entity/SecurityAdvisoryTest.php
+++ b/tests/Entity/SecurityAdvisoryTest.php
@@ -21,19 +21,6 @@ use PHPUnit\Framework\TestCase;
 
 class SecurityAdvisoryTest extends TestCase
 {
-    private const NULL_CVE_INITIAL_TITLE = 'Remote Code Execution';
-    private const NULL_CVE_UPDATED_TITLE = 'Cross-Site Request Forgery';
-    private const NULL_CVE_INITIAL_LINK = 'https://example.org/advisory/one';
-    private const NULL_CVE_UPDATED_LINK = 'https://example.org/advisory/two';
-    private const NULL_CVE_BRANCH = '1.x';
-    private const NULL_CVE_PUBLISHED_AT = 1494806400;
-    private const NULL_CVE_INITIAL_VERSIONS = ['<1.2'];
-    private const NULL_CVE_UPDATED_VERSIONS = ['>=2.0', '<2.1'];
-    private const NULL_CVE_REFERENCE = 'composer://acme/security-package';
-    private const NULL_CVE_INITIAL_FILENAME = 'acme/security-package/2017-05-15.yaml';
-    private const NULL_CVE_UPDATED_FILENAME = 'acme/security-package/2026-08-25.yaml';
-    private const ADVISORY_MATCH_THRESHOLD = 3;
-
     public function testCalculateDifferenceScore(): void
     {
         $data = [
@@ -60,29 +47,28 @@ class SecurityAdvisoryTest extends TestCase
     public function testCalculateDifferenceScoreDoesNotMatchNullCves(): void
     {
         $data = [
-            'title' => self::NULL_CVE_INITIAL_TITLE,
-            'link' => self::NULL_CVE_INITIAL_LINK,
+            'title' => 'Remote Code Execution',
+            'link' => 'https://example.org/advisory/one',
             'cve' => null,
             'branches' => [
-                self::NULL_CVE_BRANCH => [
-                    'time' => self::NULL_CVE_PUBLISHED_AT,
-                    'versions' => self::NULL_CVE_INITIAL_VERSIONS,
+                '1.x' => [
+                    'time' => 1494806400,
+                    'versions' => ['<1.2'],
                 ],
             ],
-            'reference' => self::NULL_CVE_REFERENCE,
+            'reference' => 'composer://acme/security-package',
         ];
 
-        $advisory = new SecurityAdvisory(
-            RemoteSecurityAdvisory::createFromFriendsOfPhp(self::NULL_CVE_INITIAL_FILENAME, $data),
-            FriendsOfPhpSecurityAdvisoriesSource::SOURCE_NAME,
-        );
+        $remoteAdvisory = RemoteSecurityAdvisory::createFromFriendsOfPhp('acme/security-package/2017-05-15.yaml', $data);
 
-        $data['title'] = self::NULL_CVE_UPDATED_TITLE;
-        $data['link'] = self::NULL_CVE_UPDATED_LINK;
-        $data['branches'][self::NULL_CVE_BRANCH]['versions'] = self::NULL_CVE_UPDATED_VERSIONS;
-        $otherAdvisory = RemoteSecurityAdvisory::createFromFriendsOfPhp(self::NULL_CVE_UPDATED_FILENAME, $data);
+        $data['title'] = 'Cross-Site Request Forgery';
+        $data['link'] = 'https://example.org/advisory/two';
+        $data['branches']['1.x']['versions'] = ['>=2.0', '<2.1'];
+        $unrelatedRemoteAdvisory = RemoteSecurityAdvisory::createFromFriendsOfPhp('acme/security-package/2026-08-25.yaml', $data);
 
-        $this->assertGreaterThan(self::ADVISORY_MATCH_THRESHOLD, $advisory->calculateDifferenceScore($otherAdvisory));
+        $advisory = new SecurityAdvisory($remoteAdvisory, FriendsOfPhpSecurityAdvisoriesSource::SOURCE_NAME);
+
+        $this->assertSame(5, $advisory->calculateDifferenceScore($unrelatedRemoteAdvisory));
     }
 
     public function testCalculateDifferenceScoreChangeNameAndCVE(): void

--- a/tests/Entity/SecurityAdvisoryTest.php
+++ b/tests/Entity/SecurityAdvisoryTest.php
@@ -21,6 +21,19 @@ use PHPUnit\Framework\TestCase;
 
 class SecurityAdvisoryTest extends TestCase
 {
+    private const NULL_CVE_INITIAL_TITLE = 'Remote Code Execution';
+    private const NULL_CVE_UPDATED_TITLE = 'Cross-Site Request Forgery';
+    private const NULL_CVE_INITIAL_LINK = 'https://example.org/advisory/one';
+    private const NULL_CVE_UPDATED_LINK = 'https://example.org/advisory/two';
+    private const NULL_CVE_BRANCH = '1.x';
+    private const NULL_CVE_PUBLISHED_AT = 1494806400;
+    private const NULL_CVE_INITIAL_VERSIONS = ['<1.2'];
+    private const NULL_CVE_UPDATED_VERSIONS = ['>=2.0', '<2.1'];
+    private const NULL_CVE_REFERENCE = 'composer://acme/security-package';
+    private const NULL_CVE_INITIAL_FILENAME = 'acme/security-package/2017-05-15.yaml';
+    private const NULL_CVE_UPDATED_FILENAME = 'acme/security-package/2026-08-25.yaml';
+    private const ADVISORY_MATCH_THRESHOLD = 3;
+
     public function testCalculateDifferenceScore(): void
     {
         $data = [
@@ -42,6 +55,34 @@ class SecurityAdvisoryTest extends TestCase
         $advisory = new SecurityAdvisory($remoteAdvisory, 'source');
 
         $this->assertSame(0, $advisory->calculateDifferenceScore($updatedAdvisory));
+    }
+
+    public function testCalculateDifferenceScoreDoesNotMatchNullCves(): void
+    {
+        $data = [
+            'title' => self::NULL_CVE_INITIAL_TITLE,
+            'link' => self::NULL_CVE_INITIAL_LINK,
+            'cve' => null,
+            'branches' => [
+                self::NULL_CVE_BRANCH => [
+                    'time' => self::NULL_CVE_PUBLISHED_AT,
+                    'versions' => self::NULL_CVE_INITIAL_VERSIONS,
+                ],
+            ],
+            'reference' => self::NULL_CVE_REFERENCE,
+        ];
+
+        $advisory = new SecurityAdvisory(
+            RemoteSecurityAdvisory::createFromFriendsOfPhp(self::NULL_CVE_INITIAL_FILENAME, $data),
+            FriendsOfPhpSecurityAdvisoriesSource::SOURCE_NAME,
+        );
+
+        $data['title'] = self::NULL_CVE_UPDATED_TITLE;
+        $data['link'] = self::NULL_CVE_UPDATED_LINK;
+        $data['branches'][self::NULL_CVE_BRANCH]['versions'] = self::NULL_CVE_UPDATED_VERSIONS;
+        $otherAdvisory = RemoteSecurityAdvisory::createFromFriendsOfPhp(self::NULL_CVE_UPDATED_FILENAME, $data);
+
+        $this->assertGreaterThan(self::ADVISORY_MATCH_THRESHOLD, $advisory->calculateDifferenceScore($otherAdvisory));
     }
 
     public function testCalculateDifferenceScoreChangeNameAndCVE(): void


### PR DESCRIPTION
## Summary

Fix #1709

- Require a non-null CVE before treating a matching package/CVE pair as the same advisory.
- Add regression coverage proving two distinct CVE-less advisories for one package keep their calculated difference score.

## Test verification (RED → GREEN)

RED — upstream base `66183939` (`main`), production code untouched, only the new test applied:

```
1) App\Tests\Entity\SecurityAdvisoryTest::testCalculateDifferenceScoreDoesNotMatchNullCves
Failed asserting that 0 is identical to 5.
```

GREEN — this branch:

```
OK (4 tests, 4 assertions)
```

The expected score of 5 is the sum of the differences the fixture actually introduces:
remote id, title, link, affected versions and date.

## Full local CI replay

Replayed the `CI`, `PHPStan` and `PHP Lint` jobs on PHP 8.4 (intl/zip/apcu) with MySQL 8 and Redis 6:

| | baseline (`main` 66183939) | this branch |
|---|---|---|
| PHPUnit | 726 tests, 2552 assertions, 1 skipped | 727 tests, 2553 assertions, 1 skipped |
| PHPStan | no errors | no errors |
| PHP Lint | pass | pass |

Both runs share one identical failure, `PackageControllerTest::testEdit`, which shells out to
`git clone --mirror git@github.com:composer/composer.git` and cannot reach GitHub from the
sandboxed container; it is green on this PR's GitHub CI run. Changed executable production
lines: 1/1 covered.

## Files changed

| File | Change |
|---|---|
| `src/Entity/SecurityAdvisory.php` | Exclude null CVEs from the identity shortcut |
| `tests/Entity/SecurityAdvisoryTest.php` | Cover two distinct CVE-less advisories for one package |

*Generated by Ora Studio — vibe coded by ousama*
