### PR TITLE
[RFC][UI] Add more package details to package list

### DIFF
--- a/.env
+++ b/.env
@@ -43,10 +43,10 @@ SPAM_MODEL_FILE=
 MAILER_DSN=null://null
 ###< symfony/mailer ###
 
-ALGOLIA_APP_ID=
-ALGOLIA_ADMIN_KEY=
-ALGOLIA_SEARCH_KEY=
-ALGOLIA_INDEX_NAME=
+ALGOLIA_APP_ID=changeme
+ALGOLIA_ADMIN_KEY=changeme
+ALGOLIA_SEARCH_KEY=changeme
+ALGOLIA_INDEX_NAME=changeme
 
 # set those to values obtained by creating an application at https://github.com/settings/applications
 APP_GITHUB_CLIENT_ID=

--- a/.env.test
+++ b/.env.test
@@ -7,3 +7,7 @@ REDIS_URL=redis://localhost/14
 APP_MAILER_FROM_EMAIL=packagist@example.org
 APP_HOSTNAME=packagist.wip
 DEFAULT_URI=http://packagist.wip
+ALGOLIA_APP_ID=dummy
+ALGOLIA_ADMIN_KEY=dummy
+ALGOLIA_SEARCH_KEY=dummy
+ALGOLIA_INDEX_NAME=packagist

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-apcu": "*",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "algolia/algoliasearch-client-php": "^3.4",
+        "algolia/algoliasearch-client-php": "^4.0",
         "babdev/pagerfanta-bundle": "^4.2",
         "beelab/recaptcha2-bundle": "^2.3",
         "cebe/markdown": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,56 +4,48 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eadf29e8d8146dc1718ebcd5e4aaa2e3",
+    "content-hash": "a700a97094f1357487e2122b461353ea",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
-            "version": "3.4.2",
+            "version": "4.47.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/algolia/algoliasearch-client-php.git",
-                "reference": "7505959737f7944507be7ef476752ad761873c4a"
+                "reference": "d2ad9378c66681536d49f29134717a1d4cd66b6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/algolia/algoliasearch-client-php/zipball/7505959737f7944507be7ef476752ad761873c4a",
-                "reference": "7505959737f7944507be7ef476752ad761873c4a",
+                "url": "https://api.github.com/repos/algolia/algoliasearch-client-php/zipball/d2ad9378c66681536d49f29134717a1d4cd66b6c",
+                "reference": "d2ad9378c66681536d49f29134717a1d4cd66b6c",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "ext-json": "*",
                 "ext-mbstring": "*",
-                "php": "^7.3 || ^8.0",
+                "guzzlehttp/psr7": "^2.0",
+                "php": ">=8.1 !=8.3.0",
                 "psr/http-message": "^1.1 || ^2.0",
                 "psr/log": "^1.0 || ^2.0 || ^3.0",
                 "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.0",
-                "fzaninotto/faker": "^1.8",
-                "phpunit/phpunit": "^8.0 || ^9.0",
-                "symfony/yaml": "^2.0 || ^4.0"
+                "friendsofphp/php-cs-fixer": "^3.91.3",
+                "phpstan/phpstan": "^1.12",
+                "phpunit/phpunit": "^10.0",
+                "vlucas/phpdotenv": "^5.4"
             },
             "suggest": {
                 "guzzlehttp/guzzle": "If you prefer to use Guzzle HTTP client instead of the Http Client implementation provided by the package"
             },
-            "bin": [
-                "bin/algolia-doctor"
-            ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-2.0": "2.0.x-dev"
-                }
-            },
             "autoload": {
                 "files": [
-                    "src/Http/Psr7/functions.php",
-                    "src/functions.php"
+                    "lib/Http/Psr7/functions.php"
                 ],
                 "psr-4": {
-                    "Algolia\\AlgoliaSearch\\": "src/"
+                    "Algolia\\AlgoliaSearch\\": "lib/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -63,10 +55,11 @@
             "authors": [
                 {
                     "name": "Algolia Team",
-                    "email": "contact@algolia.com"
+                    "homepage": "https://alg.li/support"
                 }
             ],
-            "description": "Algolia Search API Client for PHP",
+            "description": "API powering the features of Algolia.",
+            "homepage": "https://github.com/algolia/algoliasearch-client-php",
             "keywords": [
                 "algolia",
                 "api",
@@ -76,9 +69,9 @@
             ],
             "support": {
                 "issues": "https://github.com/algolia/algoliasearch-client-php/issues",
-                "source": "https://github.com/algolia/algoliasearch-client-php/tree/3.4.2"
+                "source": "https://github.com/algolia/algoliasearch-client-php/tree/4.47.0"
             },
-            "time": "2025-01-22T11:13:54+00:00"
+            "time": "2026-08-18T12:43:34+00:00"
         },
         {
             "name": "babdev/pagerfanta-bundle",

--- a/config/algolia_settings.yml
+++ b/config/algolia_settings.yml
@@ -35,3 +35,4 @@ paginationLimitedTo: 300
 attributesForFaceting:
     - "type"
     - "searchable(tags)"
+    - "meta.license"

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -126,9 +126,9 @@ services:
         tags:
             - { name: knp_menu.menu, alias: organization_menu }
 
-    Algolia\AlgoliaSearch\SearchClient:
+    Algolia\AlgoliaSearch\Api\SearchClient:
         arguments: ['%env(ALGOLIA_APP_ID)%', '%env(ALGOLIA_ADMIN_KEY)%']
-        factory: ['Algolia\AlgoliaSearch\SearchClient', create]
+        factory: ['Algolia\AlgoliaSearch\Api\SearchClient', create]
 
     App\Service\QueueWorker:
         $jobWorkers:

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -10,10 +10,6 @@ services:
     App\Service\Scheduler:
         public: true
 
-    Algolia\AlgoliaSearch\SearchClient:
-        public: true
-        factory: ['Algolia\AlgoliaSearch\SearchClient', create]
-
     # stub to replace 2FA code generation
     App\Tests\Mock\TotpAuthenticatorStub:
         arguments:

--- a/css/app.scss
+++ b/css/app.scss
@@ -664,7 +664,8 @@ strong {
 .search-facets-active-filters .active-filter-remove {
     padding: 0;
 }
-.search-facets .ais-Menu-item--selected {
+.search-facets .ais-Menu-item--selected,
+.search-facets .ais-NumericMenu-item--selected {
     font-weight: bold;
 }
 .search-facets .ais-Panel-header {
@@ -673,22 +674,22 @@ strong {
     margin-bottom: 10px;
     font-weight: bold;
 }
-.search-facets .ais-Menu-list, .search-facets .ais-RefinementList-list {
+.search-facets .ais-Menu-list, .search-facets .ais-RefinementList-list, .search-facets .ais-NumericMenu-list {
     list-style: none;
     padding-left: 0;
     margin: 0;
 }
-.search-facets .ais-Menu-item, .search-facets .ais-RefinementList-item {
+.search-facets .ais-Menu-item, .search-facets .ais-RefinementList-item, .search-facets .ais-NumericMenu-item {
     padding: 0;
     line-height: 1.4;
     font-size: 13px;
 }
-.search-facets .ais-RefinementList-label {
+.search-facets .ais-RefinementList-label, .search-facets .ais-NumericMenu-label {
     display: flex;
     align-items: center;
     cursor: pointer;
 }
-.search-facets .ais-RefinementList-checkbox {
+.search-facets .ais-RefinementList-checkbox, .search-facets .ais-NumericMenu-radio {
     margin-right: 6px;
     margin-top: 0;
 }
@@ -698,7 +699,7 @@ strong {
     text-decoration: none;
     color: inherit;
 }
-.search-facets .ais-RefinementList-labelText, .search-facets .ais-Menu-label {
+.search-facets .ais-RefinementList-labelText, .search-facets .ais-Menu-label, .search-facets .ais-NumericMenu-labelText {
     flex: 1;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -962,6 +963,17 @@ input:focus:invalid:focus, textarea:focus:invalid:focus, select:focus:invalid:fo
 }
 .packages .metadata-block:last-child {
   margin-bottom: 0;
+}
+
+.packages .release-metadata {
+  margin-bottom: 5px;
+}
+.packages .release-metadata-block {
+  margin-right: 15px;
+  white-space: nowrap;
+}
+.packages .package-item .tags {
+  margin-bottom: 5px;
 }
 
 
@@ -1282,10 +1294,12 @@ input:focus:invalid:focus, textarea:focus:invalid:focus, select:focus:invalid:fo
     width: 100px;
 }
 
-.package .tags a:before {
+.package .tags a:before,
+.packages .package-item .tags a:before {
   content: "#";
 }
-.package .tags a {
+.package .tags a,
+.packages .package-item .tags a {
   margin-right: 10px;
   display: inline-block;
 }

--- a/esbuild.js
+++ b/esbuild.js
@@ -19,7 +19,7 @@
             '.woff':'file',
             '.woff2':'file',
         },
-        target: ['chrome58', 'firefox57', 'safari11', 'edge95'],
+        target: ['chrome63', 'firefox57', 'safari12', 'edge95'],
         plugins: [sassPlugin()],
     })
 

--- a/js/search.jsx
+++ b/js/search.jsx
@@ -1,8 +1,11 @@
-import algoliasearch from 'algoliasearch/lite';
+/** @jsx h */
+/** @jsxFrag Fragment */
+import { h, Fragment } from 'preact';
 import instantsearch from 'instantsearch.js';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import historyRouter from 'instantsearch.js/es/lib/routers/history';
 import { connectSearchBox, connectCurrentRefinements } from 'instantsearch.js/es/connectors';
-import { hits, pagination, clearRefinements, menu, refinementList, configure, panel } from 'instantsearch.js/es/widgets';
+import { hits, pagination, clearRefinements, menu, numericMenu, refinementList, configure, panel } from 'instantsearch.js/es/widgets';
 
 // this file is imported by app.js ahead of every other module, so an unguarded lookup here would
 // take out view.js, the tooltips and the bootstrap data-api handlers on any page without the search
@@ -68,7 +71,7 @@ var customSearchClient = {
 // Show search container on initial load if URL has search params
 var urlParams = new URLSearchParams(window.location.search);
 var hasQuery = (urlParams.get('query') || '').trim() !== '' || (urlParams.get('q') || '').trim() !== '';
-var hasFilters = urlParams.get('type') || urlParams.get('tags');
+var hasFilters = urlParams.get('type') || urlParams.get('tags') || urlParams.get('license') || urlParams.get('released');
 if (!isSearchPage && !hasQuery && hasFilters) {
     // Redirect to canonical /search/ URL with the filter params
     location.replace('/search/' + location.search);
@@ -84,8 +87,11 @@ var opts = {
         var searchResults = document.querySelector('#search-container');
 
         var hasQuery = indexState.query && indexState.query.trim() !== '';
+        var refined = indexState.refinementList || {};
         var hasFilters = (indexState.menu && indexState.menu.type)
-            || (indexState.refinementList && indexState.refinementList.tags && indexState.refinementList.tags.length > 0);
+            || (refined.tags && refined.tags.length > 0)
+            || (refined['meta.license'] && refined['meta.license'].length > 0)
+            || (indexState.numericMenu && Object.keys(indexState.numericMenu).length > 0);
         var hasSearch = hasQuery || (isSearchPage && hasFilters);
 
         if (!hasSearch) {
@@ -126,10 +132,13 @@ var opts = {
         stateMapping: {
             stateToRoute: function (uiState) {
                 var indexUiState = uiState[indexName] || {};
+                var refined = indexUiState.refinementList || {};
                 return {
                     query: indexUiState.query && indexUiState.query.replace(/([^\s])--/g, '$1-'),
                     type: indexUiState.menu && indexUiState.menu.type,
-                    tags: indexUiState.refinementList && indexUiState.refinementList.tags && indexUiState.refinementList.tags.join('~'),
+                    tags: refined.tags && refined.tags.join('~'),
+                    license: refined['meta.license'] && refined['meta.license'].join('~'),
+                    released: indexUiState.numericMenu && indexUiState.numericMenu['meta.released_ts'],
                     page: indexUiState.page,
                 };
             },
@@ -140,7 +149,9 @@ var opts = {
 
                 var hasQuery = routeState.query && routeState.query.trim() !== '';
                 var hasFilters = (routeState.type && routeState.type !== '')
-                    || (routeState.tags && routeState.tags !== '');
+                    || (routeState.tags && routeState.tags !== '')
+                    || (routeState.license && routeState.license !== '')
+                    || (routeState.released && routeState.released !== '');
                 if (!hasQuery && !(isSearchPage && hasFilters)) {
                     return { [indexName]: {} };
                 }
@@ -153,7 +164,9 @@ var opts = {
                         },
                         refinementList: {
                             tags: routeState.tags && routeState.tags.replace(/[\s-]+/g, ' ').split('~'),
+                            'meta.license': routeState.license && routeState.license.split('~'),
                         },
+                        numericMenu: routeState.released ? { 'meta.released_ts': routeState.released } : undefined,
                         page: routeState.page,
                     }
                 };
@@ -213,9 +226,10 @@ var customCurrentRefinements = connectCurrentRefinements(function (renderOptions
         wrapper.style.display = items.length > 0 ? '' : 'none';
     }
 
+    var attributeLabels = { tags: 'tag', 'meta.license': 'license' };
     var html = '';
     items.forEach(function (item) {
-        var label = item.attribute === 'tags' ? 'tag' : item.attribute;
+        var label = attributeLabels[item.attribute] || item.attribute;
         item.refinements.forEach(function (refinement) {
             html += '<span class="badge bg-primary active-filter-item">'
                 + escapeHtml(label) + ': ' + escapeHtml(refinement.label)
@@ -247,6 +261,75 @@ var panelRefinementList = panel({
     templates: { header: function () { return 'Tags'; } },
     hidden: function (_ref) { return _ref.items.length === 0; },
 })(refinementList);
+var panelLicense = panel({
+    templates: { header: function () { return 'License'; } },
+    hidden: function (_ref) { return _ref.items.length === 0; },
+})(refinementList);
+var panelReleased = panel({ templates: { header: function () { return 'Released'; } } })(numericMenu);
+
+var releasedNow = Date.now();
+function releasedStart(daysAgo) {
+    return Math.floor((releasedNow - daysAgo * 86400000) / 1000);
+}
+
+function PackageHit(hit) {
+    var nameHighlight = hit._highlightResult && hit._highlightResult.name ? hit._highlightResult.name.value : hit.name;
+    var descHighlight = hit._highlightResult && hit._highlightResult.description ? hit._highlightResult.description.value : (hit.description || '');
+    var license = hit.meta && hit.meta.license && hit.meta.license.length ? hit.meta.license.join(', ') : '';
+
+    return (
+        <div data-url={hit.url} class="col-12 package-item">
+            <div class="row align-items-center">
+                <div class="col-md-9 col-xl-10">
+                    <p class="float-end language">{hit.language || ''}</p>
+                    <h4 class="font-bold">
+                        <a href={hit.url} tabindex="2" rel="nofollow noindex" dangerouslySetInnerHTML={{ __html: nameHighlight }} />
+                        {hit.extension ? <span title="PIE installable extension package">🥧</span> : null}
+                        {hit.virtual ? <Fragment>{' '}<small>(Virtual Package)</small></Fragment> : null}
+                    </h4>
+                    <p dangerouslySetInnerHTML={{ __html: descHighlight }} />
+                    {hit.meta && hit.meta.release ? (
+                        <p class="release-metadata">
+                            <span class="release-metadata-block" title="Latest version">{hit.meta.release}</span>
+                            {hit.meta.released ? (
+                                <span class="release-metadata-block"><i class="bi bi-clock-fill" title="Release date" />{' '}{hit.meta.released}</span>
+                            ) : null}
+                            {license ? (
+                                <span class="release-metadata-block"><i class="bi bi-c-circle" title="License" />{' '}{license}</span>
+                            ) : null}
+                        </p>
+                    ) : null}
+                    {hit.tags && hit.tags.length ? (
+                        <p class="tags">
+                            <i class="bi bi-tag-fill" title="Tags" />{' '}
+                            {hit.tags.slice(0, 10).map(function (tag) {
+                                return (
+                                    <a key={tag} rel="nofollow noindex" href={'/search/?tags=' + encodeURIComponent(tag)}>{tag}</a>
+                                );
+                            })}
+                        </p>
+                    ) : null}
+                    {hit.abandoned ? (
+                        <p class="abandoned">
+                            <i class="bi bi-exclamation-circle-fill" /> Abandoned!
+                            {hit.replacementPackage ? (
+                                <Fragment>{' '}See <a href={hit.replacementPackageUrl} rel="nofollow noindex">{hit.replacementPackage}</a></Fragment>
+                            ) : null}
+                        </p>
+                    ) : null}
+                </div>
+                <div class="col-md-3 col-xl-2">
+                    {hit.meta ? (
+                        <p class="metadata">
+                            <span class="metadata-block"><i class="bi bi-download" />{' '}{hit.meta.downloads_formatted}</span>
+                            <span class="metadata-block"><i class="bi bi-star-fill" />{' '}{hit.meta.favers_formatted}</span>
+                        </p>
+                    ) : null}
+                </div>
+            </div>
+        </div>
+    );
+}
 
 search.addWidgets([
     customSearchBox({}),
@@ -275,47 +358,7 @@ search.addWidgets([
         },
         templates: {
             empty: function () { return 'No packages found.'; },
-            item: function (hit) {
-                var abandonedHtml = '';
-                if (hit.abandoned) {
-                    var replacementHtml = '';
-                    if (hit.replacementPackage) {
-                        replacementHtml = ` See <a href="${hit.replacementPackageUrl}" rel="nofollow noindex">${hit.replacementPackage}</a>`;
-                    }
-                    abandonedHtml = `<p class="abandoned"><i class="bi bi-exclamation-circle-fill"></i> Abandoned!${replacementHtml}</p>`;
-                }
-
-                var virtualHtml = hit.virtual ? '<small>(Virtual Package)</small>' : '';
-                var extensionHtml = hit.extension ? '<span title="PIE installable extension package">🥧</span>' : '';
-
-                var metaHtml = '';
-                if (hit.meta) {
-                    metaHtml = `<p class="metadata">
-                        <span class="metadata-block"><i class="bi bi-download"></i> ${hit.meta.downloads_formatted}</span>
-                        <span class="metadata-block"><i class="bi bi-star-fill"></i> ${hit.meta.favers_formatted}</span>
-                    </p>`;
-                }
-
-                var nameHighlight = hit._highlightResult && hit._highlightResult.name ? hit._highlightResult.name.value : hit.name;
-                var descHighlight = hit._highlightResult && hit._highlightResult.description ? hit._highlightResult.description.value : (hit.description || '');
-
-                return `<div data-url="${hit.url}" class="col-12 package-item">
-                    <div class="row">
-                        <div class="col-md-9 col-xl-10">
-                            <p class="float-end language">${hit.language || ''}</p>
-                            <h4 class="font-bold">
-                                <a href="${hit.url}" tabindex="2" rel="nofollow noindex">${nameHighlight}</a>${extensionHtml}
-                                ${virtualHtml}
-                            </h4>
-                            <p>${descHighlight}</p>
-                            ${abandonedHtml}
-                        </div>
-                        <div class="col-md-3 col-xl-2">
-                            ${metaHtml}
-                        </div>
-                    </div>
-                </div>`;
-            },
+            item: function (hit) { return PackageHit(hit); },
         },
         cssClasses: {
             root: 'packages',
@@ -345,12 +388,34 @@ search.addWidgets([
         },
     }),
 
-    customCurrentRefinements({}),
+    customCurrentRefinements({ excludedAttributes: ['query', 'meta.released_ts'] }),
 
     panelMenu({
         container: '.search-facets-type',
         attribute: 'type',
         limit: 15,
+    }),
+
+    panelLicense({
+        container: '.search-facets-license',
+        attribute: 'meta.license',
+        limit: 10,
+        showMore: true,
+        cssClasses: {
+            checkbox: 'form-check-input',
+        },
+    }),
+
+    panelReleased({
+        container: '.search-facets-released',
+        attribute: 'meta.released_ts',
+        items: [
+            { label: 'Any time' },
+            { label: 'Past week', start: releasedStart(7) },
+            { label: 'Past month', start: releasedStart(30) },
+            { label: 'Past 3 months', start: releasedStart(90) },
+            { label: 'Past year', start: releasedStart(365) },
+        ],
     }),
 
     panelRefinementList({

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,14 +7,15 @@
             "name": "packagist.org",
             "dependencies": {
                 "@popperjs/core": "^2.11.8",
-                "algoliasearch": "^4.24.0",
+                "algoliasearch": "^5.57.0",
                 "bootstrap": "^5.3.8",
                 "bootstrap-icons": "^1.13.1",
                 "d3": "^3.5.17",
-                "instantsearch.js": "^4.75.6",
+                "instantsearch.js": "^4.112.0",
                 "jquery": "^3.7.1",
                 "nvd3": "^1.8.6",
                 "plausible-tracker": "^0.3",
+                "preact": "^10.29.8",
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
                 "zustand": "^3.6.9"
@@ -27,83 +28,118 @@
                 "npm": ">=11.10"
             }
         },
-        "node_modules/@algolia/cache-browser-local-storage": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.27.0.tgz",
-            "integrity": "sha512-YGog2s57sO20lvpa+hv5XLAAmiTI1kHsCMRtPVfiaOdIQnvRla21lfH08onqEbZihOPVI8GULwt79zQB2ymKzg==",
+        "node_modules/@algolia/abtesting": {
+            "version": "1.23.0",
+            "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.23.0.tgz",
+            "integrity": "sha512-j45MBISstltys9QyQ4xf6quRiN1g7vMuwQL9VM4dx8YuRZvCQ173b9royZAx6iAbRX3IB1VnG1z//NuwyQ8jpQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/cache-common": "4.27.0"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
-        "node_modules/@algolia/cache-common": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.27.0.tgz",
-            "integrity": "sha512-Sr8zjNXj82p6lO4W9CdzfF0m0/9h/H6VAdSHOTtimm/cTzXIYXRI2IZq7+Nt2ljJ7Ukx+7dIFcxQjE57eQSPsw==",
-            "license": "MIT"
-        },
-        "node_modules/@algolia/cache-in-memory": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.27.0.tgz",
-            "integrity": "sha512-abgMRTcVD0IllNvMM9JFhxtyLn1v6Ey7mQ7+BGS3JCzvkCX7KZqlS0BIuVUDgx9sPIfOeNsG/awGzMmP50TwZw==",
+        "node_modules/@algolia/client-abtesting": {
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.57.0.tgz",
+            "integrity": "sha512-JVFFujiZUCguk5tz3LZr4fTQxqpIrj4/Jw3SI7kMljSqtfLxYn/s/TWH0J2s4iNfsDpxPhgFGMotCpmDI4kZ8w==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/cache-common": "4.27.0"
-            }
-        },
-        "node_modules/@algolia/client-account": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.27.0.tgz",
-            "integrity": "sha512-sSHxwrKTKJrwfoR/LcQJZfmiWJcM5d9Rp7afMChxOcdGdkSdIwrNBC8SCcHRenA3GsZ6mg+j6px7KWYxJ34btA==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "4.27.0",
-                "@algolia/client-search": "4.27.0",
-                "@algolia/transporter": "4.27.0"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-analytics": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.27.0.tgz",
-            "integrity": "sha512-MqIDyxODljn9ZC4oqjQD0kez2a4zjIJ9ywA/b7cIiUiK/tDjZNTVjYd9WXMKQlXnWUwfrfXJZClVVqN1iCXS+Q==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.57.0.tgz",
+            "integrity": "sha512-6KqECK4ED3JJQEoDrQWnGPQzElA828xAD4qK5ceawNNyP/LcSvzAoLHjFkoTPksZ/kxj6VUtCRH+IHZesLltng==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "4.27.0",
-                "@algolia/client-search": "4.27.0",
-                "@algolia/requester-common": "4.27.0",
-                "@algolia/transporter": "4.27.0"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-common": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.27.0.tgz",
-            "integrity": "sha512-ZrT6l/YPQgyIUuBCxcYPeXol2VBLUMuNb1rKXrm6z1f/iTiwqtnEEb16/6CC11+Re0ZGXrdcMVrgDRrzveQ1aQ==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.57.0.tgz",
+            "integrity": "sha512-uqpGF3oXYsoCbQq5d7BzNrNTfIfuvJyGP1CKvSW27T9boUg7KOwyxsAw1AX0a3jSW2HrYEJ/NN+Z4MiGivbpeQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/@algolia/client-insights": {
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.57.0.tgz",
+            "integrity": "sha512-u5NboJVJXDEFplvNnqqX4CxkXPYysjJRj47hOSh9329H8kG5gFLKJBIiS5utMQ+GZm8xQl3Te7NInDk6elEADQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/requester-common": "4.27.0",
-                "@algolia/transporter": "4.27.0"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-personalization": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.27.0.tgz",
-            "integrity": "sha512-OZqaFFVm+10hAlmxpiTWi/o2n+YKBESbSqSy2yXAumPH/kaK4moJHFblbh8IkV3KZR0lLm4hzPtn8Q2nWNiDUA==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.57.0.tgz",
+            "integrity": "sha512-uzc0b2LmHAK9/QID4xeo35OG84AkZl4YewkCqawqAOGLjT2eZpM/OZx45ESygMHG30Ws+ZTSdluPtMJcUnrbWQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "4.27.0",
-                "@algolia/requester-common": "4.27.0",
-                "@algolia/transporter": "4.27.0"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/@algolia/client-query-suggestions": {
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.57.0.tgz",
+            "integrity": "sha512-dIAhnM6ue/ssa5PjgNfu4g8A4yTojl9ZOUzZU3wIaIKRerL2R/3Emuf9n/D6ICXXP167KC6XCeC7nliSw7cuSw==",
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-search": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.27.0.tgz",
-            "integrity": "sha512-qmX/f67ay0eZ4V5Io8fWWOcUVo/gqre2yei1PnmEhQU2Gul6ushg25QnNrfu4BODiRrw1rwYveZaLCiHvcUxrQ==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.57.0.tgz",
+            "integrity": "sha512-2TTPTTKSJmCptvhCm4Xf3bBYMqZni+Pgc2hVdqc4l9wsBpSJNVTVIKpnd10OubUgkGcmppVDj1XQqYaf6EnPSQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "4.27.0",
-                "@algolia/requester-common": "4.27.0",
-                "@algolia/transporter": "4.27.0"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/events": {
@@ -112,73 +148,85 @@
             "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ==",
             "license": "MIT"
         },
-        "node_modules/@algolia/logger-common": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.27.0.tgz",
-            "integrity": "sha512-pIrmQRXtDV+zTMVXKtKCosC2rWhn0F0TdUeb9etA6RiAz6jY6bY6f0+JX7YekDK09SnmZMLIyUa7Jci+Ied9bw==",
-            "license": "MIT"
-        },
-        "node_modules/@algolia/logger-console": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.27.0.tgz",
-            "integrity": "sha512-UWvta8BxsR/u5z9eI088mOSLQaGtmoCtXeN3DYJurlxAdJwPuKtEb5+433kxA6/E9f2/JgoW89KZ1vNP9pcHBQ==",
+        "node_modules/@algolia/ingestion": {
+            "version": "1.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.57.0.tgz",
+            "integrity": "sha512-W4JseHKt+pzOxlFV+T3MWEG0h4Z2Se5zjoXUD0ewlw8aOWMG/yjRdopUdLQsXULepB/My2tDuZjkwk2sMfsUrQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/logger-common": "4.27.0"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/@algolia/monitoring": {
+            "version": "1.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.57.0.tgz",
+            "integrity": "sha512-BrxJVE0/eLinEPICCD7BKN/2xnt0nkjge70u8zzE2ISP3fuB3tjLgcwpanUycvlHBFLI4gK0l5ol54p6IYuR/Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/recommend": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.27.0.tgz",
-            "integrity": "sha512-CFy54xDjrsazPi3KN04yPmLRDT72AKokc3RLOdWQvG0/uEUjj7dhWqe9qenxpL4ydsjO7S1eY5YqmX+uMGonlg==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.57.0.tgz",
+            "integrity": "sha512-Gc29jkeiLKlVfHvyrIgyUHHE+aYTdXEeLfK42rjr5/1TTVsYwUJz0XkvoIBIqfMjcDg6gXeHb1jTUZ0H+SYIlQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/cache-browser-local-storage": "4.27.0",
-                "@algolia/cache-common": "4.27.0",
-                "@algolia/cache-in-memory": "4.27.0",
-                "@algolia/client-common": "4.27.0",
-                "@algolia/client-search": "4.27.0",
-                "@algolia/logger-common": "4.27.0",
-                "@algolia/logger-console": "4.27.0",
-                "@algolia/requester-browser-xhr": "4.27.0",
-                "@algolia/requester-common": "4.27.0",
-                "@algolia/requester-node-http": "4.27.0",
-                "@algolia/transporter": "4.27.0"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/requester-browser-xhr": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.27.0.tgz",
-            "integrity": "sha512-dTenMBIIpyp5o3C2ZnfbsuSlD/lL9jPkk6T+2+qm38fyw2nf49ANbcHFE79NgiGrnmw7QrYveCs9NIP3Wk4v6g==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.57.0.tgz",
+            "integrity": "sha512-PIPnPN7MP3fp2VAi01BVXhCWmD366ZB2Hkq5TlYKtThd4KxUtMmaaNDpFgVCTXtSIqWVZLJntOHRvxg/sIPd8Q==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/requester-common": "4.27.0"
+                "@algolia/client-common": "5.57.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
-        "node_modules/@algolia/requester-common": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.27.0.tgz",
-            "integrity": "sha512-VC3prAQVgWTubMStb3mJz6i61Hqbtagi2LeIbgNtoFJFff3XZDcAaO1D5r0GYl2+DrB2VzUHnQXbkiuI+HHYyg==",
-            "license": "MIT"
+        "node_modules/@algolia/requester-fetch": {
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.57.0.tgz",
+            "integrity": "sha512-AX3RlOudXMdTwtwUqdAf5hAVLvXfOZZH1FZh6ALDdrhVLT0TtAIe48N6nYcWcTnwoTxK/wDIQqZ19IMjK8zJAA==",
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/client-common": "5.57.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
         },
         "node_modules/@algolia/requester-node-http": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.27.0.tgz",
-            "integrity": "sha512-y8nUqaUQeSOQ5oaNo0b2QPznyBFW9LoIwljyUphJ+gUZpU6O/j2/C8ovoqDpIe6J0etqHg5RCcBizrCFZuLpyw==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.57.0.tgz",
+            "integrity": "sha512-cWZc1dKb7wy9/wPpwMtL1y89gK2G7y2A47Coa7zwf1ydtIeJm4+S+XxoQ2b/ZRiQnrC1YHavLjYUPDCdnT7Khg==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/requester-common": "4.27.0"
-            }
-        },
-        "node_modules/@algolia/transporter": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.27.0.tgz",
-            "integrity": "sha512-PvSbELU4VjN3xSX79ki+zIdOGhTxyJXWvRDzkUjfTx2iNfPWDdTjzKbP1o+268coJztxrkuBwJz90Urek7o1Kw==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/cache-common": "4.27.0",
-                "@algolia/logger-common": "4.27.0",
-                "@algolia/requester-common": "4.27.0"
+                "@algolia/client-common": "5.57.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@esbuild/android-arm": {
@@ -262,32 +310,34 @@
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "node_modules/algoliasearch": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.27.0.tgz",
-            "integrity": "sha512-C88C5grLa5VOCp9eYZJt+q99ik7yNdm92l7Q9+4XK0Md8kL05Lg8l2v9ZVX0uMW3mH9pAFxMMXlLOvqNumA4lw==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.57.0.tgz",
+            "integrity": "sha512-HpND7MBGctOAkd1GoQoDZCGoCpqNTS5NG1LuhElFet3RdLJkwnyTYZXZhXwtpAQPrI36fqQ3eT6KQrdKDTKu3A==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/cache-browser-local-storage": "4.27.0",
-                "@algolia/cache-common": "4.27.0",
-                "@algolia/cache-in-memory": "4.27.0",
-                "@algolia/client-account": "4.27.0",
-                "@algolia/client-analytics": "4.27.0",
-                "@algolia/client-common": "4.27.0",
-                "@algolia/client-personalization": "4.27.0",
-                "@algolia/client-search": "4.27.0",
-                "@algolia/logger-common": "4.27.0",
-                "@algolia/logger-console": "4.27.0",
-                "@algolia/recommend": "4.27.0",
-                "@algolia/requester-browser-xhr": "4.27.0",
-                "@algolia/requester-common": "4.27.0",
-                "@algolia/requester-node-http": "4.27.0",
-                "@algolia/transporter": "4.27.0"
+                "@algolia/abtesting": "1.23.0",
+                "@algolia/client-abtesting": "5.57.0",
+                "@algolia/client-analytics": "5.57.0",
+                "@algolia/client-common": "5.57.0",
+                "@algolia/client-insights": "5.57.0",
+                "@algolia/client-personalization": "5.57.0",
+                "@algolia/client-query-suggestions": "5.57.0",
+                "@algolia/client-search": "5.57.0",
+                "@algolia/ingestion": "1.57.0",
+                "@algolia/monitoring": "1.57.0",
+                "@algolia/recommend": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/algoliasearch-helper": {
-            "version": "3.28.0",
-            "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.28.0.tgz",
-            "integrity": "sha512-GBN0xsxGggaCPElZq24QzMdfphrjIiV2xA+hRXE4/UMpN3nsF2WrM8q+x80OGvGpJWtB7F+4Hq5eSfWwuejXrg==",
+            "version": "3.29.3",
+            "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.29.3.tgz",
+            "integrity": "sha512-gVOMbbPVrCO3Xs+B+BLAIGFqIQow6qHMTYCEeBqLQB9m4ZmKUqMwkEumlal2iyyezHEd4Y0FvFTLbCRutCutIQ==",
             "license": "MIT",
             "dependencies": {
                 "@algolia/events": "^4.0.1"
@@ -1085,21 +1135,19 @@
             "dev": true
         },
         "node_modules/instantsearch-ui-components": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/instantsearch-ui-components/-/instantsearch-ui-components-0.22.0.tgz",
-            "integrity": "sha512-28V7ZmGuPpYB/XWQdxXdgpUErSMj87gK9VoTwyLaZcNCL1Qxr/rJmbJpkTluYFMAYT/tIAehYAoL+1lNT2BRnw==",
+            "version": "0.36.0",
+            "resolved": "https://registry.npmjs.org/instantsearch-ui-components/-/instantsearch-ui-components-0.36.0.tgz",
+            "integrity": "sha512-9Zd/E2X7ash9MF+WYN6ouoDlFbgGtCKr33uZyH3EGHRz+VHHulXwKdGFdydN4iMwKywPCS0ObgoQSC9oI2SI7A==",
             "license": "MIT",
             "dependencies": {
                 "@swc/helpers": "0.5.18",
-                "markdown-to-jsx": "^7.7.15",
-                "zod": "^3.25.76 || ^4",
-                "zod-to-json-schema": "3.24.6"
+                "markdown-to-jsx": "^7.7.15"
             }
         },
         "node_modules/instantsearch.js": {
-            "version": "4.92.0",
-            "resolved": "https://registry.npmjs.org/instantsearch.js/-/instantsearch.js-4.92.0.tgz",
-            "integrity": "sha512-mkbP3uPwk4NuW66vXRGFSRzOpWoztvIquQ1sh/gCa4BoiYQ27XFtj/5529nPLIdPAWYJyN0I6B+fs+wOmRPjOA==",
+            "version": "4.112.0",
+            "resolved": "https://registry.npmjs.org/instantsearch.js/-/instantsearch.js-4.112.0.tgz",
+            "integrity": "sha512-1bx0QMq12IvNXCaLVEmYdrkkjEdaKdvU7f13S6C8vuRhmtBtl5kF7q7Ivw/N/Zjhogw0MFnMVTl59C5pWINx+Q==",
             "license": "MIT",
             "dependencies": {
                 "@algolia/events": "^4.0.1",
@@ -1108,16 +1156,14 @@
                 "@types/google.maps": "^3.55.12",
                 "@types/hogan.js": "^3.0.0",
                 "@types/qs": "^6.5.3",
-                "algoliasearch-helper": "3.28.0",
+                "algoliasearch-helper": "3.29.3",
                 "hogan.js": "^3.0.2",
                 "htm": "^3.0.0",
-                "instantsearch-ui-components": "0.22.0",
+                "instantsearch-ui-components": "0.36.0",
                 "preact": "^10.10.0",
                 "qs": "^6.5.1",
                 "react": ">= 0.14.0",
-                "search-insights": "^2.17.2",
-                "zod": "^3.25.76 || ^4",
-                "zod-to-json-schema": "3.24.6"
+                "search-insights": "^2.17.2"
             },
             "peerDependencies": {
                 "algoliasearch": ">= 3.1 < 6"
@@ -1341,13 +1387,21 @@
             }
         },
         "node_modules/preact": {
-            "version": "10.29.0",
-            "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.0.tgz",
-            "integrity": "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg==",
+            "version": "10.29.8",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+            "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
             "license": "MIT",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/preact"
+            },
+            "peerDependencies": {
+                "preact-render-to-string": ">=5"
+            },
+            "peerDependenciesMeta": {
+                "preact-render-to-string": {
+                    "optional": true
+                }
             }
         },
         "node_modules/qs": {
@@ -1585,24 +1639,6 @@
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true
         },
-        "node_modules/zod": {
-            "version": "3.25.76",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
-            }
-        },
-        "node_modules/zod-to-json-schema": {
-            "version": "3.24.6",
-            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-            "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
-            "license": "ISC",
-            "peerDependencies": {
-                "zod": "^3.24.1"
-            }
-        },
         "node_modules/zustand": {
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
@@ -1621,75 +1657,86 @@
         }
     },
     "dependencies": {
-        "@algolia/cache-browser-local-storage": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.27.0.tgz",
-            "integrity": "sha512-YGog2s57sO20lvpa+hv5XLAAmiTI1kHsCMRtPVfiaOdIQnvRla21lfH08onqEbZihOPVI8GULwt79zQB2ymKzg==",
+        "@algolia/abtesting": {
+            "version": "1.23.0",
+            "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.23.0.tgz",
+            "integrity": "sha512-j45MBISstltys9QyQ4xf6quRiN1g7vMuwQL9VM4dx8YuRZvCQ173b9royZAx6iAbRX3IB1VnG1z//NuwyQ8jpQ==",
             "requires": {
-                "@algolia/cache-common": "4.27.0"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
             }
         },
-        "@algolia/cache-common": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.27.0.tgz",
-            "integrity": "sha512-Sr8zjNXj82p6lO4W9CdzfF0m0/9h/H6VAdSHOTtimm/cTzXIYXRI2IZq7+Nt2ljJ7Ukx+7dIFcxQjE57eQSPsw=="
-        },
-        "@algolia/cache-in-memory": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.27.0.tgz",
-            "integrity": "sha512-abgMRTcVD0IllNvMM9JFhxtyLn1v6Ey7mQ7+BGS3JCzvkCX7KZqlS0BIuVUDgx9sPIfOeNsG/awGzMmP50TwZw==",
+        "@algolia/client-abtesting": {
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.57.0.tgz",
+            "integrity": "sha512-JVFFujiZUCguk5tz3LZr4fTQxqpIrj4/Jw3SI7kMljSqtfLxYn/s/TWH0J2s4iNfsDpxPhgFGMotCpmDI4kZ8w==",
             "requires": {
-                "@algolia/cache-common": "4.27.0"
-            }
-        },
-        "@algolia/client-account": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.27.0.tgz",
-            "integrity": "sha512-sSHxwrKTKJrwfoR/LcQJZfmiWJcM5d9Rp7afMChxOcdGdkSdIwrNBC8SCcHRenA3GsZ6mg+j6px7KWYxJ34btA==",
-            "requires": {
-                "@algolia/client-common": "4.27.0",
-                "@algolia/client-search": "4.27.0",
-                "@algolia/transporter": "4.27.0"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
             }
         },
         "@algolia/client-analytics": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.27.0.tgz",
-            "integrity": "sha512-MqIDyxODljn9ZC4oqjQD0kez2a4zjIJ9ywA/b7cIiUiK/tDjZNTVjYd9WXMKQlXnWUwfrfXJZClVVqN1iCXS+Q==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.57.0.tgz",
+            "integrity": "sha512-6KqECK4ED3JJQEoDrQWnGPQzElA828xAD4qK5ceawNNyP/LcSvzAoLHjFkoTPksZ/kxj6VUtCRH+IHZesLltng==",
             "requires": {
-                "@algolia/client-common": "4.27.0",
-                "@algolia/client-search": "4.27.0",
-                "@algolia/requester-common": "4.27.0",
-                "@algolia/transporter": "4.27.0"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
             }
         },
         "@algolia/client-common": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.27.0.tgz",
-            "integrity": "sha512-ZrT6l/YPQgyIUuBCxcYPeXol2VBLUMuNb1rKXrm6z1f/iTiwqtnEEb16/6CC11+Re0ZGXrdcMVrgDRrzveQ1aQ==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.57.0.tgz",
+            "integrity": "sha512-uqpGF3oXYsoCbQq5d7BzNrNTfIfuvJyGP1CKvSW27T9boUg7KOwyxsAw1AX0a3jSW2HrYEJ/NN+Z4MiGivbpeQ=="
+        },
+        "@algolia/client-insights": {
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.57.0.tgz",
+            "integrity": "sha512-u5NboJVJXDEFplvNnqqX4CxkXPYysjJRj47hOSh9329H8kG5gFLKJBIiS5utMQ+GZm8xQl3Te7NInDk6elEADQ==",
             "requires": {
-                "@algolia/requester-common": "4.27.0",
-                "@algolia/transporter": "4.27.0"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
             }
         },
         "@algolia/client-personalization": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.27.0.tgz",
-            "integrity": "sha512-OZqaFFVm+10hAlmxpiTWi/o2n+YKBESbSqSy2yXAumPH/kaK4moJHFblbh8IkV3KZR0lLm4hzPtn8Q2nWNiDUA==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.57.0.tgz",
+            "integrity": "sha512-uzc0b2LmHAK9/QID4xeo35OG84AkZl4YewkCqawqAOGLjT2eZpM/OZx45ESygMHG30Ws+ZTSdluPtMJcUnrbWQ==",
             "requires": {
-                "@algolia/client-common": "4.27.0",
-                "@algolia/requester-common": "4.27.0",
-                "@algolia/transporter": "4.27.0"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
+            }
+        },
+        "@algolia/client-query-suggestions": {
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.57.0.tgz",
+            "integrity": "sha512-dIAhnM6ue/ssa5PjgNfu4g8A4yTojl9ZOUzZU3wIaIKRerL2R/3Emuf9n/D6ICXXP167KC6XCeC7nliSw7cuSw==",
+            "requires": {
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
             }
         },
         "@algolia/client-search": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.27.0.tgz",
-            "integrity": "sha512-qmX/f67ay0eZ4V5Io8fWWOcUVo/gqre2yei1PnmEhQU2Gul6ushg25QnNrfu4BODiRrw1rwYveZaLCiHvcUxrQ==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.57.0.tgz",
+            "integrity": "sha512-2TTPTTKSJmCptvhCm4Xf3bBYMqZni+Pgc2hVdqc4l9wsBpSJNVTVIKpnd10OubUgkGcmppVDj1XQqYaf6EnPSQ==",
             "requires": {
-                "@algolia/client-common": "4.27.0",
-                "@algolia/requester-common": "4.27.0",
-                "@algolia/transporter": "4.27.0"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
             }
         },
         "@algolia/events": {
@@ -1697,66 +1744,61 @@
             "resolved": "https://registry.npmjs.org/@algolia/events/-/events-4.0.1.tgz",
             "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
         },
-        "@algolia/logger-common": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.27.0.tgz",
-            "integrity": "sha512-pIrmQRXtDV+zTMVXKtKCosC2rWhn0F0TdUeb9etA6RiAz6jY6bY6f0+JX7YekDK09SnmZMLIyUa7Jci+Ied9bw=="
-        },
-        "@algolia/logger-console": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.27.0.tgz",
-            "integrity": "sha512-UWvta8BxsR/u5z9eI088mOSLQaGtmoCtXeN3DYJurlxAdJwPuKtEb5+433kxA6/E9f2/JgoW89KZ1vNP9pcHBQ==",
+        "@algolia/ingestion": {
+            "version": "1.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.57.0.tgz",
+            "integrity": "sha512-W4JseHKt+pzOxlFV+T3MWEG0h4Z2Se5zjoXUD0ewlw8aOWMG/yjRdopUdLQsXULepB/My2tDuZjkwk2sMfsUrQ==",
             "requires": {
-                "@algolia/logger-common": "4.27.0"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
+            }
+        },
+        "@algolia/monitoring": {
+            "version": "1.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.57.0.tgz",
+            "integrity": "sha512-BrxJVE0/eLinEPICCD7BKN/2xnt0nkjge70u8zzE2ISP3fuB3tjLgcwpanUycvlHBFLI4gK0l5ol54p6IYuR/Q==",
+            "requires": {
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
             }
         },
         "@algolia/recommend": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.27.0.tgz",
-            "integrity": "sha512-CFy54xDjrsazPi3KN04yPmLRDT72AKokc3RLOdWQvG0/uEUjj7dhWqe9qenxpL4ydsjO7S1eY5YqmX+uMGonlg==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.57.0.tgz",
+            "integrity": "sha512-Gc29jkeiLKlVfHvyrIgyUHHE+aYTdXEeLfK42rjr5/1TTVsYwUJz0XkvoIBIqfMjcDg6gXeHb1jTUZ0H+SYIlQ==",
             "requires": {
-                "@algolia/cache-browser-local-storage": "4.27.0",
-                "@algolia/cache-common": "4.27.0",
-                "@algolia/cache-in-memory": "4.27.0",
-                "@algolia/client-common": "4.27.0",
-                "@algolia/client-search": "4.27.0",
-                "@algolia/logger-common": "4.27.0",
-                "@algolia/logger-console": "4.27.0",
-                "@algolia/requester-browser-xhr": "4.27.0",
-                "@algolia/requester-common": "4.27.0",
-                "@algolia/requester-node-http": "4.27.0",
-                "@algolia/transporter": "4.27.0"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
             }
         },
         "@algolia/requester-browser-xhr": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.27.0.tgz",
-            "integrity": "sha512-dTenMBIIpyp5o3C2ZnfbsuSlD/lL9jPkk6T+2+qm38fyw2nf49ANbcHFE79NgiGrnmw7QrYveCs9NIP3Wk4v6g==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.57.0.tgz",
+            "integrity": "sha512-PIPnPN7MP3fp2VAi01BVXhCWmD366ZB2Hkq5TlYKtThd4KxUtMmaaNDpFgVCTXtSIqWVZLJntOHRvxg/sIPd8Q==",
             "requires": {
-                "@algolia/requester-common": "4.27.0"
+                "@algolia/client-common": "5.57.0"
             }
         },
-        "@algolia/requester-common": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.27.0.tgz",
-            "integrity": "sha512-VC3prAQVgWTubMStb3mJz6i61Hqbtagi2LeIbgNtoFJFff3XZDcAaO1D5r0GYl2+DrB2VzUHnQXbkiuI+HHYyg=="
+        "@algolia/requester-fetch": {
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.57.0.tgz",
+            "integrity": "sha512-AX3RlOudXMdTwtwUqdAf5hAVLvXfOZZH1FZh6ALDdrhVLT0TtAIe48N6nYcWcTnwoTxK/wDIQqZ19IMjK8zJAA==",
+            "requires": {
+                "@algolia/client-common": "5.57.0"
+            }
         },
         "@algolia/requester-node-http": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.27.0.tgz",
-            "integrity": "sha512-y8nUqaUQeSOQ5oaNo0b2QPznyBFW9LoIwljyUphJ+gUZpU6O/j2/C8ovoqDpIe6J0etqHg5RCcBizrCFZuLpyw==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.57.0.tgz",
+            "integrity": "sha512-cWZc1dKb7wy9/wPpwMtL1y89gK2G7y2A47Coa7zwf1ydtIeJm4+S+XxoQ2b/ZRiQnrC1YHavLjYUPDCdnT7Khg==",
             "requires": {
-                "@algolia/requester-common": "4.27.0"
-            }
-        },
-        "@algolia/transporter": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.27.0.tgz",
-            "integrity": "sha512-PvSbELU4VjN3xSX79ki+zIdOGhTxyJXWvRDzkUjfTx2iNfPWDdTjzKbP1o+268coJztxrkuBwJz90Urek7o1Kw==",
-            "requires": {
-                "@algolia/cache-common": "4.27.0",
-                "@algolia/logger-common": "4.27.0",
-                "@algolia/requester-common": "4.27.0"
+                "@algolia/client-common": "5.57.0"
             }
         },
         "@esbuild/android-arm": {
@@ -1812,31 +1854,30 @@
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "algoliasearch": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.27.0.tgz",
-            "integrity": "sha512-C88C5grLa5VOCp9eYZJt+q99ik7yNdm92l7Q9+4XK0Md8kL05Lg8l2v9ZVX0uMW3mH9pAFxMMXlLOvqNumA4lw==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.57.0.tgz",
+            "integrity": "sha512-HpND7MBGctOAkd1GoQoDZCGoCpqNTS5NG1LuhElFet3RdLJkwnyTYZXZhXwtpAQPrI36fqQ3eT6KQrdKDTKu3A==",
             "requires": {
-                "@algolia/cache-browser-local-storage": "4.27.0",
-                "@algolia/cache-common": "4.27.0",
-                "@algolia/cache-in-memory": "4.27.0",
-                "@algolia/client-account": "4.27.0",
-                "@algolia/client-analytics": "4.27.0",
-                "@algolia/client-common": "4.27.0",
-                "@algolia/client-personalization": "4.27.0",
-                "@algolia/client-search": "4.27.0",
-                "@algolia/logger-common": "4.27.0",
-                "@algolia/logger-console": "4.27.0",
-                "@algolia/recommend": "4.27.0",
-                "@algolia/requester-browser-xhr": "4.27.0",
-                "@algolia/requester-common": "4.27.0",
-                "@algolia/requester-node-http": "4.27.0",
-                "@algolia/transporter": "4.27.0"
+                "@algolia/abtesting": "1.23.0",
+                "@algolia/client-abtesting": "5.57.0",
+                "@algolia/client-analytics": "5.57.0",
+                "@algolia/client-common": "5.57.0",
+                "@algolia/client-insights": "5.57.0",
+                "@algolia/client-personalization": "5.57.0",
+                "@algolia/client-query-suggestions": "5.57.0",
+                "@algolia/client-search": "5.57.0",
+                "@algolia/ingestion": "1.57.0",
+                "@algolia/monitoring": "1.57.0",
+                "@algolia/recommend": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
             }
         },
         "algoliasearch-helper": {
-            "version": "3.28.0",
-            "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.28.0.tgz",
-            "integrity": "sha512-GBN0xsxGggaCPElZq24QzMdfphrjIiV2xA+hRXE4/UMpN3nsF2WrM8q+x80OGvGpJWtB7F+4Hq5eSfWwuejXrg==",
+            "version": "3.29.3",
+            "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.29.3.tgz",
+            "integrity": "sha512-gVOMbbPVrCO3Xs+B+BLAIGFqIQow6qHMTYCEeBqLQB9m4ZmKUqMwkEumlal2iyyezHEd4Y0FvFTLbCRutCutIQ==",
             "requires": {
                 "@algolia/events": "^4.0.1"
             }
@@ -2306,20 +2347,18 @@
             "dev": true
         },
         "instantsearch-ui-components": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/instantsearch-ui-components/-/instantsearch-ui-components-0.22.0.tgz",
-            "integrity": "sha512-28V7ZmGuPpYB/XWQdxXdgpUErSMj87gK9VoTwyLaZcNCL1Qxr/rJmbJpkTluYFMAYT/tIAehYAoL+1lNT2BRnw==",
+            "version": "0.36.0",
+            "resolved": "https://registry.npmjs.org/instantsearch-ui-components/-/instantsearch-ui-components-0.36.0.tgz",
+            "integrity": "sha512-9Zd/E2X7ash9MF+WYN6ouoDlFbgGtCKr33uZyH3EGHRz+VHHulXwKdGFdydN4iMwKywPCS0ObgoQSC9oI2SI7A==",
             "requires": {
                 "@swc/helpers": "0.5.18",
-                "markdown-to-jsx": "^7.7.15",
-                "zod": "^3.25.76 || ^4",
-                "zod-to-json-schema": "3.24.6"
+                "markdown-to-jsx": "^7.7.15"
             }
         },
         "instantsearch.js": {
-            "version": "4.92.0",
-            "resolved": "https://registry.npmjs.org/instantsearch.js/-/instantsearch.js-4.92.0.tgz",
-            "integrity": "sha512-mkbP3uPwk4NuW66vXRGFSRzOpWoztvIquQ1sh/gCa4BoiYQ27XFtj/5529nPLIdPAWYJyN0I6B+fs+wOmRPjOA==",
+            "version": "4.112.0",
+            "resolved": "https://registry.npmjs.org/instantsearch.js/-/instantsearch.js-4.112.0.tgz",
+            "integrity": "sha512-1bx0QMq12IvNXCaLVEmYdrkkjEdaKdvU7f13S6C8vuRhmtBtl5kF7q7Ivw/N/Zjhogw0MFnMVTl59C5pWINx+Q==",
             "requires": {
                 "@algolia/events": "^4.0.1",
                 "@swc/helpers": "0.5.18",
@@ -2327,16 +2366,14 @@
                 "@types/google.maps": "^3.55.12",
                 "@types/hogan.js": "^3.0.0",
                 "@types/qs": "^6.5.3",
-                "algoliasearch-helper": "3.28.0",
+                "algoliasearch-helper": "3.29.3",
                 "hogan.js": "^3.0.2",
                 "htm": "^3.0.0",
-                "instantsearch-ui-components": "0.22.0",
+                "instantsearch-ui-components": "0.36.0",
                 "preact": "^10.10.0",
                 "qs": "^6.5.1",
                 "react": ">= 0.14.0",
-                "search-insights": "^2.17.2",
-                "zod": "^3.25.76 || ^4",
-                "zod-to-json-schema": "3.24.6"
+                "search-insights": "^2.17.2"
             }
         },
         "is-binary-path": {
@@ -2485,9 +2522,10 @@
             "integrity": "sha512-lmOWYQ7s9KOUJ1R+YTOR3HrjdbxIS2Z4de0P/Jx2dQPteznJl2eX3tXxKClpvbfyGP59B5bbhW8ftN59HbbFSg=="
         },
         "preact": {
-            "version": "10.29.0",
-            "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.0.tgz",
-            "integrity": "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg=="
+            "version": "10.29.8",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+            "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
+            "requires": {}
         },
         "qs": {
             "version": "6.16.0",
@@ -2650,17 +2688,6 @@
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true
-        },
-        "zod": {
-            "version": "3.25.76",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
-        },
-        "zod-to-json-schema": {
-            "version": "3.24.6",
-            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-            "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
-            "requires": {}
         },
         "zustand": {
             "version": "3.7.2",

--- a/package.json
+++ b/package.json
@@ -2,14 +2,15 @@
     "name": "packagist.org",
     "dependencies": {
         "@popperjs/core": "^2.11.8",
-        "algoliasearch": "^4.24.0",
+        "algoliasearch": "^5.57.0",
         "bootstrap": "^5.3.8",
         "bootstrap-icons": "^1.13.1",
         "d3": "^3.5.17",
-        "instantsearch.js": "^4.75.6",
+        "instantsearch.js": "^4.112.0",
         "jquery": "^3.7.1",
         "nvd3": "^1.8.6",
         "plausible-tracker": "^0.3",
+        "preact": "^10.29.8",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "zustand": "^3.6.9"

--- a/src/Command/CleanIndexCommand.php
+++ b/src/Command/CleanIndexCommand.php
@@ -12,7 +12,7 @@
 
 namespace App\Command;
 
-use Algolia\AlgoliaSearch\SearchClient;
+use Algolia\AlgoliaSearch\Api\SearchClient;
 use App\Service\Locker;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Command\Command;
@@ -69,20 +69,20 @@ class CleanIndexCommand extends Command
             return 0;
         }
 
-        $index = $this->algolia->initIndex($this->algoliaIndexName);
-
         $page = 0;
         $perPage = 100;
         do {
-            $results = $index->search('', ['facets' => '*,type,tags', 'facetFilters' => ['type:virtual-package'], 'numericFilters' => ['trendiness=100'], 'hitsPerPage' => $perPage, 'page' => $page]);
+            /** @var array{hits: list<array{objectID: string, name: string}>} $results */
+            $results = $this->algolia->searchSingleIndex($this->algoliaIndexName, ['facets' => ['*', 'type', 'tags'], 'facetFilters' => ['type:virtual-package'], 'numericFilters' => ['trendiness=100'], 'hitsPerPage' => $perPage, 'page' => $page]);
             foreach ($results['hits'] as $result) {
                 if (!str_starts_with($result['objectID'], 'virtual:')) {
-                    $duplicate = $index->search('', ['facets' => '*,objectID,type,tags', 'facetFilters' => ['objectID:virtual:'.$result['objectID']]]);
+                    /** @var array{hits: list<array{objectID: string}>} $duplicate */
+                    $duplicate = $this->algolia->searchSingleIndex($this->algoliaIndexName, ['facets' => ['*', 'objectID', 'type', 'tags'], 'facetFilters' => ['objectID:virtual:'.$result['objectID']]]);
                     if (\count($duplicate['hits']) === 1) {
                         if ($verbose) {
                             $output->writeln('Deleting '.$result['objectID'].' which is a duplicate of '.$duplicate['hits'][0]['objectID']);
                         }
-                        $index->deleteObject($result['objectID']);
+                        $this->algolia->deleteObject($this->algoliaIndexName, $result['objectID']);
                         continue;
                     }
                 }
@@ -91,7 +91,7 @@ class CleanIndexCommand extends Command
                     if ($verbose) {
                         $output->writeln('Deleting '.$result['objectID'].' which has no provider anymore');
                     }
-                    $index->deleteObject($result['objectID']);
+                    $this->algolia->deleteObject($this->algoliaIndexName, $result['objectID']);
                 }
             }
             $page++;

--- a/src/Command/ConfigureAlgoliaCommand.php
+++ b/src/Command/ConfigureAlgoliaCommand.php
@@ -12,7 +12,7 @@
 
 namespace App\Command;
 
-use Algolia\AlgoliaSearch\SearchClient;
+use Algolia\AlgoliaSearch\Api\SearchClient;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -40,9 +40,7 @@ class ConfigureAlgoliaCommand extends Command
 
         $settings = Yaml::parse($yaml);
 
-        $index = $this->algolia->initIndex($this->algoliaIndexName);
-
-        $index->setSettings($settings);
+        $this->algolia->setSettings($this->algoliaIndexName, $settings);
 
         return 0;
     }

--- a/src/Command/IndexPackagesCommand.php
+++ b/src/Command/IndexPackagesCommand.php
@@ -12,7 +12,7 @@
 
 namespace App\Command;
 
-use Algolia\AlgoliaSearch\SearchClient;
+use Algolia\AlgoliaSearch\Api\SearchClient;
 use App\Entity\Package;
 use App\Entity\Version;
 use App\Model\DownloadManager;
@@ -84,8 +84,6 @@ class IndexPackagesCommand extends Command
             return 0;
         }
 
-        $index = $this->algolia->initIndex($this->algoliaIndexName);
-
         if ($package) {
             $packageEntity = $this->getEM()->getRepository(Package::class)->findOneBy(['name' => $package]);
             if ($packageEntity === null) {
@@ -116,7 +114,7 @@ class IndexPackagesCommand extends Command
                 $output->writeln('Deleting existing index');
             }
 
-            $index->clear();
+            $this->algolia->clearObjects($this->algoliaIndexName);
         }
 
         $total = \count($ids);
@@ -127,6 +125,7 @@ class IndexPackagesCommand extends Command
             $indexTime = new \DateTime();
             $idsSlice = array_splice($ids, 0, 50);
             $packages = $this->getEM()->getRepository(Package::class)->findBy(['id' => $idsSlice]);
+            $releaseMetadata = $this->getEM()->getRepository(Package::class)->getPackagesLatestReleaseMetadata(array_map(intval(...), $idsSlice));
 
             $idsToUpdate = [];
             $records = [];
@@ -140,7 +139,7 @@ class IndexPackagesCommand extends Command
                 // delete suppressed (spam/malware) packages from the search index
                 if ($package->isFrozen() && $package->getFreezeReason()?->suppressesPackage()) {
                     try {
-                        $index->deleteObject($package->getName());
+                        $this->algolia->deleteObject($this->algoliaIndexName, $package->getName());
                         $idsToUpdate[] = $package->getId();
                         continue;
                     } catch (\Algolia\AlgoliaSearch\Exceptions\AlgoliaException $e) {
@@ -150,7 +149,7 @@ class IndexPackagesCommand extends Command
                 try {
                     $tags = $this->getTags($package);
 
-                    $records[] = $this->packageToSearchableArray($package, $tags);
+                    $records[] = $this->packageToSearchableArray($package, $tags, $releaseMetadata[$package->getId()] ?? null);
 
                     $idsToUpdate[] = $package->getId();
                 } catch (\Exception $e) {
@@ -166,7 +165,7 @@ class IndexPackagesCommand extends Command
             }
 
             try {
-                $index->saveObjects($records);
+                $this->algolia->saveObjects($this->algoliaIndexName, $records);
             } catch (\Exception $e) {
                 $output->writeln('<error>'.$e::class.': '.$e->getMessage().', occurred while processing packages: '.implode(',', $idsSlice).'</error>');
                 continue;
@@ -192,10 +191,11 @@ class IndexPackagesCommand extends Command
 
     /**
      * @param string[] $tags
+     * @param array{version: string, releasedAt: \DateTimeImmutable|null, license: list<string>}|null $latestRelease
      *
-     * @return array<string, int|string|float|array<string, string|int>|null>
+     * @return array<string, mixed>
      */
-    private function packageToSearchableArray(Package $package, array $tags): array
+    private function packageToSearchableArray(Package $package, array $tags, ?array $latestRelease): array
     {
         $faversCount = $this->favoriteManager->getFaverCount($package);
         $downloads = $this->downloadManager->getDownloads($package);
@@ -226,6 +226,13 @@ class IndexPackagesCommand extends Command
             ],
         ];
 
+        if ($latestRelease !== null) {
+            $record['meta']['release'] = $latestRelease['version'];
+            $record['meta']['released'] = $latestRelease['releasedAt']?->format('Y-m-d');
+            $record['meta']['released_ts'] = $latestRelease['releasedAt']?->getTimestamp();
+            $record['meta']['license'] = $latestRelease['license'];
+        }
+
         if ($package->isAbandoned()) {
             $record['abandoned'] = 1;
             $record['replacementPackage'] = $package->getReplacementPackage() ?: '';
@@ -238,7 +245,7 @@ class IndexPackagesCommand extends Command
             $record['extension'] = 1;
             $latestVersion = $this->getEM()->getRepository(Version::class)->getQueryBuilderForLatestVersionWithPackage(package: $package->getName())
                 ->getQuery()->setMaxResults(1)->getOneOrNullResult();
-            if ($latestVersion) {
+            if ($latestVersion instanceof Version) {
                 $record['extensionName'] = $latestVersion->getPieName();
             }
         }

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -38,16 +38,15 @@ abstract class Controller extends AbstractController
     /**
      * @param array<Package|array{id: int}> $packages
      *
-     * @return array{downloads: array<int, int>, favers: array<int, int>}
+     * @return array{downloads: array<int, int>, favers: array<int, int>, releases: array<int, array{version: string, releasedAt: \DateTimeImmutable|null, license: list<string>}>, tags: array<int, list<string>>}
      */
     protected function getPackagesMetadata(FavoriteManager $favMgr, DownloadManager $dlMgr, iterable $packages): array
     {
         $downloads = [];
         $favorites = [];
+        $ids = [];
 
         try {
-            $ids = [];
-
             $search = false;
             foreach ($packages as $package) {
                 if ($package instanceof Package) {
@@ -70,7 +69,14 @@ abstract class Controller extends AbstractController
         } catch (\Predis\Connection\ConnectionException $e) {
         }
 
-        return ['downloads' => $downloads, 'favers' => $favorites];
+        $packageRepo = $this->doctrine->getRepository(Package::class);
+
+        return [
+            'downloads' => $downloads,
+            'favers' => $favorites,
+            'releases' => $packageRepo->getPackagesLatestReleaseMetadata($ids),
+            'tags' => $packageRepo->getTagsByPackageIds($ids),
+        ];
     }
 
     protected function blockAbusers(Request $req): ?JsonResponse

--- a/src/Entity/PackageRepository.php
+++ b/src/Entity/PackageRepository.php
@@ -620,6 +620,46 @@ class PackageRepository extends ServiceEntityRepository
     }
 
     /**
+     * @param list<int> $ids
+     *
+     * @return array<int, array{version: string, releasedAt: \DateTimeImmutable|null, license: list<string>}>
+     */
+    public function getPackagesLatestReleaseMetadata(array $ids): array
+    {
+        if (\count($ids) === 0) {
+            return [];
+        }
+
+        $rows = $this->getEntityManager()->getConnection()->fetchAllAssociative(
+            'SELECT package_id AS pid, version, releasedAt, license
+             FROM (
+                 SELECT package_id, version, releasedAt, license,
+                     ROW_NUMBER() OVER (
+                         PARTITION BY package_id
+                         ORDER BY development ASC, releasedAt DESC, id DESC
+                     ) AS rn
+                 FROM package_version
+                 WHERE package_id IN (:ids) AND softDeletedAt IS NULL
+             ) ranked
+             WHERE rn = 1',
+            ['ids' => $ids],
+            ['ids' => ArrayParameterType::INTEGER],
+        );
+
+        $byId = [];
+        foreach ($rows as $row) {
+            $license = json_decode((string) $row['license'], true);
+            $byId[(int) $row['pid']] = [
+                'version' => (string) $row['version'],
+                'releasedAt' => null !== $row['releasedAt'] ? new \DateTimeImmutable((string) $row['releasedAt']) : null,
+                'license' => \is_array($license) ? array_values(array_filter(array_map(strval(...), $license))) : [],
+            ];
+        }
+
+        return $byId;
+    }
+
+    /**
      * @param string   $name Package name to find the dependents of
      * @param int|null $type One of Dependent::TYPE_*
      *

--- a/src/Model/PackageManager.php
+++ b/src/Model/PackageManager.php
@@ -12,8 +12,8 @@
 
 namespace App\Model;
 
+use Algolia\AlgoliaSearch\Api\SearchClient;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
-use Algolia\AlgoliaSearch\SearchClient;
 use App\Entity\AuditRecord;
 use App\Entity\Dependent;
 use App\Entity\Download;
@@ -198,10 +198,7 @@ class PackageManager
     public function deletePackageSearchIndex(string $packageName): void
     {
         try {
-            $indexName = $this->algoliaIndexName;
-            $algolia = $this->algoliaClient;
-            $index = $algolia->initIndex($indexName);
-            $index->deleteObject($packageName);
+            $this->algoliaClient->deleteObject($this->algoliaIndexName, $packageName);
         } catch (AlgoliaException $e) {
         }
     }

--- a/src/Search/Algolia.php
+++ b/src/Search/Algolia.php
@@ -12,11 +12,12 @@
 
 namespace App\Search;
 
+use Algolia\AlgoliaSearch\Api\SearchClient;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
-use Algolia\AlgoliaSearch\SearchClient;
 
 /**
  * @phpstan-import-type SearchResult from ResultTransformer
+ * @phpstan-import-type AlgoliaResults from ResultTransformer
  */
 final class Algolia
 {
@@ -34,11 +35,12 @@ final class Algolia
      */
     public function search(Query $query): array
     {
-        $index = $this->algolia->initIndex($this->algoliaIndexName);
-
-        return $this->transformer->transform(
-            $query,
-            $index->search($query->query, $query->getOptions())
+        /** @var AlgoliaResults $results */
+        $results = $this->algolia->searchSingleIndex(
+            $this->algoliaIndexName,
+            ['query' => $query->query] + $query->getOptions(),
         );
+
+        return $this->transformer->transform($query, $results);
     }
 }

--- a/src/Search/ResultTransformer.php
+++ b/src/Search/ResultTransformer.php
@@ -29,6 +29,20 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  *         abandoned?: true|string
  *     }>
  * }
+ * @phpstan-type AlgoliaResults array{
+ *     nbHits: int,
+ *     page: int,
+ *     nbPages: int,
+ *     hits: array<array{
+ *         id: int,
+ *         name: string,
+ *         description: string,
+ *         repository: string,
+ *         meta: array{downloads: int, favers: int},
+ *         abandoned?: bool,
+ *         replacementPackage?: string
+ *     }>
+ * }
  */
 final class ResultTransformer
 {
@@ -37,20 +51,7 @@ final class ResultTransformer
     }
 
     /**
-     * @param array{
-     *     nbHits: int,
-     *     page: int,
-     *     nbPages: int,
-     *     hits: array<array{
-     *         id: int,
-     *         name: string,
-     *         description: string,
-     *         repository: string,
-     *         meta: array{downloads: int, favers: int},
-     *         abandoned?: bool,
-     *         replacementPackage?: string
-     *     }>
-     * } $results
+     * @param AlgoliaResults $results
      *
      * @phpstan-return SearchResult
      */

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -167,6 +167,8 @@
                                     <div class="search-facets-active-filters"></div>
                                 </div>
                                 <div class="search-facets-type"></div>
+                                <div class="search-facets-license"></div>
+                                <div class="search-facets-released"></div>
                                 <div class="search-facets-tags"></div>
                             </div>
                         </div>

--- a/templates/macros.html.twig
+++ b/templates/macros.html.twig
@@ -12,7 +12,7 @@
             {% endif %}
             <li data-url="{{ packageUrl }}" class="row">
                 <div class="col-12 package-item">
-                    <div class="row">
+                    <div class="row align-items-center">
                         <div class="col-md-9 col-xl-10">
                             {% if package.language is defined and package.language is not empty %}<p class="float-end language">{{ package.language }}</p>{% endif %}
                             <h4 class="font-bold">
@@ -35,6 +35,25 @@
                             </h4>
                             {% if package.description is defined and package.description %}
                                 <p>{{ package.description|u.truncate(300) }}</p>
+                            {% endif %}
+                            {% if meta %}
+                                {% set release = meta.releases[package.id]|default(null) %}
+                                {% if release %}
+                                    <p class="release-metadata">
+                                        <span class="release-metadata-block" title="Latest version">{{ release.version }}</span>
+                                        {% if release.releasedAt %}<span class="release-metadata-block"><i class="bi bi-clock-fill" title="Release date"></i> {{ release.releasedAt|date('Y-m-d') }}</span>{% endif %}
+                                        {% if release.license is not empty %}<span class="release-metadata-block"><i class="bi bi-c-circle" title="License"></i> {{ release.license|join(', ') }}</span>{% endif %}
+                                    </p>
+                                {% endif %}
+                                {% set packageTags = meta.tags[package.id]|default([]) %}
+                                {% if packageTags is not empty %}
+                                    <p class="tags">
+                                        <i class="bi bi-tag-fill" title="Tags"></i>
+                                        {% for tag in packageTags|slice(0, 10) -%}
+                                            <a rel="nofollow noindex" href="{{ path('search_web', {tags: tag}) }}">{{ tag }}</a>
+                                        {%- endfor %}
+                                    </p>
+                                {% endif %}
                             {% endif %}
                             {% if meta.spamScores is defined and meta.spamScores[package.id] is defined %}
                                 {% set score = meta.spamScores[package.id] %}

--- a/tests/Search/AlgoliaMock.php
+++ b/tests/Search/AlgoliaMock.php
@@ -12,7 +12,7 @@
 
 namespace App\Tests\Search;
 
-use Algolia\AlgoliaSearch\SearchClient;
+use Algolia\AlgoliaSearch\Api\SearchClient;
 use App\Search\Query;
 use PHPUnit\Framework\Assert;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -39,21 +39,12 @@ final class AlgoliaMock extends SearchClient
     }
 
     /**
-     * @override \Algolia\AlgoliaSearch\SearchClient::initIndex
+     * @override \Algolia\AlgoliaSearch\Api\SearchClient::searchSingleIndex
      */
-    public function initIndex($indexName): self
+    public function searchSingleIndex($indexName, $searchParams = null, $requestOptions = []): array
     {
-        return $this;
-    }
-
-    /**
-     * @override \Algolia\AlgoliaSearch\SearchIndex::search
-     */
-    public function search($query, $requestOptions = []): array
-    {
-        $queryMessage = \sprintf('AlgoliaMock expected query string \'%s\', but got \'%s\'.', $this->query->query, $query);
-        Assert::assertSame($this->query->query, $query, $queryMessage);
-        Assert::assertSame($this->query->getOptions(), $requestOptions, 'AlgoliaMock expected different request options.');
+        $expected = ['query' => $this->query->query] + $this->query->getOptions();
+        Assert::assertSame($expected, $searchParams, 'AlgoliaMock expected different search parameters.');
 
         return $this->result;
     }


### PR DESCRIPTION
Package listings (a user's packages, explore/popular, vendor pages, dependents) and Algolia search results now show npmjs-inspired details:

- latest version, release date, license
- keyword tags

Adds filters for release date and licence:

<img width="1352" height="708" alt="image" src="https://github.com/user-attachments/assets/5c9c101a-b405-45aa-adc4-d513bad05484" />


Download/star counters are vertically centered:

<img width="1352" height="900" alt="image" src="https://github.com/user-attachments/assets/e9789344-6369-4126-bda1-ce1b488d6702" />

## Caveats

- Search records only expose the new `meta.release`/`released`/`license` after their next indexing run; the hit template guards on it, so stale records render as before. A full `packagist:index --force` backfills everything.
- `bin/console algolia:configure` required for the new `meta.license` facet. The released numeric filter needs no settings change (Algolia allows numeric filtering on any numeric attribute).

- Algolia client upgraded: PHP `algolia/algoliasearch-client-php` 3 -> 4 (API rewrite - index name now passed per call) and JS `algoliasearch` v4 -> v5 / `instantsearch.js`-> v4.112. 
The search hit template moves to Preact JSX (`search.js` becomes `search.jsx`), with `preact` declared explicitly and the esbuild target raised for v5's async generators.

- V4's client rejects an empty appId, so .`env` Algolia keys are now `changeme `placeholders and .`env.test` carries dummy values (real values still come from `.env.local` / deploy env).

Replaces #1410
Somewhat fixes #1290 and fixes #1368