### PR TITLE
Catch the right Redis exception type in graceful-degradation blocks

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -67,7 +67,7 @@ abstract class Controller extends AbstractController
             if ($search) {
                 $favorites = $favMgr->getFaverCounts($ids);
             }
-        } catch (\Predis\Connection\ConnectionException $e) {
+        } catch (\Predis\PredisException $e) {
         }
 
         return ['downloads' => $downloads, 'favers' => $favorites];

--- a/src/Controller/ExploreController.php
+++ b/src/Controller/ExploreController.php
@@ -16,10 +16,10 @@ use App\Entity\Package;
 use App\Entity\Version;
 use App\Model\DownloadManager;
 use App\Model\FavoriteManager;
-use Doctrine\DBAL\ConnectionException;
 use Pagerfanta\Adapter\FixedAdapter;
 use Pagerfanta\Pagerfanta;
 use Predis\Client as RedisClient;
+use Predis\PredisException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -53,7 +53,7 @@ class ExploreController extends Controller
                     return array_search($a->getId(), $popularIds) > array_search($b->getId(), $popularIds) ? 1 : -1;
                 });
             }
-        } catch (ConnectionException $e) {
+        } catch (PredisException $e) {
             $popular = [];
         }
 
@@ -96,7 +96,7 @@ class ExploreController extends Controller
             $packages->setNormalizeOutOfRangePages(true);
             $packages->setMaxPerPage($perPage);
             $packages->setCurrentPage(max(1, $req->query->getInt('page', 1)));
-        } catch (ConnectionException $e) {
+        } catch (PredisException $e) {
             $packages = new Pagerfanta(new FixedAdapter(0, []));
         }
 

--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -61,7 +61,7 @@ use Pagerfanta\Adapter\FixedAdapter;
 use Pagerfanta\Doctrine\ORM\QueryAdapter;
 use Pagerfanta\Pagerfanta;
 use Predis\Client as RedisClient;
-use Predis\Connection\ConnectionException;
+use Predis\PredisException;
 use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -418,7 +418,7 @@ class PackageController extends Controller
 
                 return $trendiness[$a->getId()] > $trendiness[$b->getId()] ? -1 : 1;
             });
-        } catch (ConnectionException $e) {
+        } catch (PredisException $e) {
         }
 
         if ($req->getRequestFormat() === 'json') {
@@ -581,7 +581,7 @@ class PackageController extends Controller
                 }
                 $data['downloads'] = $this->downloadManager->getDownloads($package);
                 $data['favers'] = $this->favoriteManager->getFaverCount($package);
-            } catch (\RuntimeException|ConnectionException $e) {
+            } catch (\RuntimeException|PredisException $e) {
                 $data['downloads'] = null;
                 $data['favers'] = null;
             }
@@ -681,7 +681,7 @@ class PackageController extends Controller
             if ($user) {
                 $data['is_favorite'] = $this->favoriteManager->isMarked($user, $package);
             }
-        } catch (\RuntimeException|ConnectionException) {
+        } catch (\RuntimeException|PredisException) {
         }
 
         $data['dependents'] = Killswitch::isEnabled(Killswitch::PAGE_DETAILS_ENABLED) && Killswitch::isEnabled(Killswitch::LINKS_ENABLED) ? $repo->getDependentCount($package->getName()) : 0;
@@ -799,7 +799,7 @@ class PackageController extends Controller
         try {
             $data['downloads']['total'] = $this->downloadManager->getDownloads($package);
             $data['favers'] = $this->favoriteManager->getFaverCount($package);
-        } catch (ConnectionException) {
+        } catch (PredisException) {
             $data['downloads']['total'] = null;
             $data['favers'] = null;
         }
@@ -807,7 +807,7 @@ class PackageController extends Controller
         foreach ($versions as $version) {
             try {
                 $data['downloads']['versions'][$version->getVersion()] = $this->downloadManager->getDownloads($package, $version);
-            } catch (ConnectionException) {
+            } catch (PredisException) {
                 $data['downloads']['versions'][$version->getVersion()] = null;
             }
         }

--- a/src/Controller/WebController.php
+++ b/src/Controller/WebController.php
@@ -21,7 +21,7 @@ use App\Search\Query;
 use App\Service\BlogRssFetcher;
 use App\Util\Killswitch;
 use Predis\Client as RedisClient;
-use Predis\Connection\ConnectionException;
+use Predis\PredisException;
 use Psr\Cache\CacheItemInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -181,7 +181,7 @@ class WebController extends Controller
                 'labels' => array_keys($dlChartMonthly),
                 'values' => $redis->mget(array_values($dlChartMonthly)),
             ];
-        } catch (ConnectionException $e) {
+        } catch (PredisException $e) {
             $downloads = 'N/A';
             $dlChart = $dlChartMonthly = null;
         }

--- a/src/Model/PackageManager.php
+++ b/src/Model/PackageManager.php
@@ -158,7 +158,7 @@ class PackageManager
         // delete redis stats
         try {
             $this->redis->del('views:'.$packageId);
-        } catch (\Predis\Connection\ConnectionException $e) {
+        } catch (\Predis\PredisException $e) {
         }
 
         // attempt search index cleanup

--- a/src/Security/RecaptchaHelper.php
+++ b/src/Security/RecaptchaHelper.php
@@ -14,7 +14,7 @@ namespace App\Security;
 
 use App\Entity\User;
 use Predis\Client;
-use Predis\Connection\ConnectionException;
+use Predis\PredisException;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
@@ -52,7 +52,7 @@ class RecaptchaHelper
 
         try {
             $result = $this->redisCache->mget($keys);
-        } catch (ConnectionException) {
+        } catch (PredisException) {
             return false;
         }
         foreach ($result as $count) {

--- a/src/Security/Voter/PackageVoter.php
+++ b/src/Security/Voter/PackageVoter.php
@@ -15,7 +15,7 @@ namespace App\Security\Voter;
 use App\Entity\Package;
 use App\Entity\User;
 use App\Model\DownloadManager;
-use Predis\Connection\ConnectionException;
+use Predis\PredisException;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Vote;
@@ -85,7 +85,7 @@ class PackageVoter extends Voter
 
         try {
             $downloads = $this->downloadManager->getDownloads($package);
-        } catch (ConnectionException $e) {
+        } catch (PredisException $e) {
             return false;
         }
 

--- a/src/Validator/PopularPackageSafetyValidator.php
+++ b/src/Validator/PopularPackageSafetyValidator.php
@@ -17,7 +17,7 @@ use App\Entity\User;
 use App\Model\DownloadManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\Persistence\ManagerRegistry;
-use Predis\Connection\ConnectionException;
+use Predis\PredisException;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -61,7 +61,7 @@ class PopularPackageSafetyValidator extends ConstraintValidator
 
         try {
             $downloads = $this->downloadManager->getTotalDownloads($value);
-        } catch (ConnectionException $e) {
+        } catch (PredisException $e) {
             $downloads = \PHP_INT_MAX;
         }
 


### PR DESCRIPTION
ExploreController imports Doctrine\DBAL\ConnectionException for its two Redis-related catches, but that class is an empty legacy type nothing in DBAL throws. The actual failure is Predis\Connection\ConnectionException, so a Redis outage produced an uncaught 500 on /explore instead of degrading gracefully. Predis also raises Response\ServerException as a sibling of the connection error (for LOADING/MISCONF/OOM/READONLY replies), so even the narrower Predis\Connection\ConnectionException catch used elsewhere would still miss a restart or failover.

This switches ExploreController to catch Predis\PredisException, and widens the same narrow catch in WebController, PackageController, Controller, RecaptchaHelper, PackageVoter, PopularPackageSafetyValidator and PackageManager, since each of those catch bodies is already a plain "Redis unavailable, continue without it" fallback.

Fixes #1829