### PR TITLE
Minor BS5 and chart migration fixes

### DIFF
--- a/css/app.scss
+++ b/css/app.scss
@@ -42,6 +42,8 @@
     --bs-body-font-size: 14px;
     --bs-body-line-height: 1.428571429;
 
+    --bs-border-radius: 2px;
+
     --heading-margin-top-lg: 20px;
     --heading-margin-top-sm: 10px;
     --heading-margin-bottom: 10px;
@@ -473,19 +475,6 @@ strong {
     margin-bottom: 6px;
 }
 
-.nav-user .signin-box .input-group-text {
-    background: #fff;
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
-}
-
-.nav-user .signin-box .form-control {
-    border-left: 0;
-    box-shadow: none;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
-}
-
 .nav-user .signin-box div {
     font-size: 13px;
 }
@@ -825,7 +814,6 @@ button {
     padding: 7px 11px 6px 9px;
     font-size: 14px;
     box-shadow: none;
-    border-radius: 2px;
     font-family: var(--font-sans);
 
     transition: none;
@@ -847,7 +835,7 @@ button {
     padding: 6px 9px 5px;
     box-shadow: none;
     border-width: 2px;
-    border-radius: 0 2px 2px 0;
+    border-radius: 0 var(--bs-border-radius) var(--bs-border-radius) 0;
 }
 
 .form-control[readonly] {
@@ -856,7 +844,7 @@ button {
 
 .form-control[readonly]:focus {
     padding: 7px 11px 6px 9px;
-    border-radius: 2px;
+    border-radius: var(--bs-border-radius);
     box-shadow: none;
 }
 

--- a/css/app.scss
+++ b/css/app.scss
@@ -469,6 +469,10 @@ strong {
     padding: 15px 20px 12px;
 }
 
+.nav-user .signin-box .input-group {
+    margin-bottom: 6px;
+}
+
 .nav-user .signin-box .input-group-text {
     background: #fff;
     border-top-left-radius: 3px;
@@ -517,6 +521,7 @@ strong {
 
 .nav-user .btn-github {
     font-weight: 600;
+    line-height: 21px;
     padding: 9px 12px;
     width: 56%;
 }
@@ -882,15 +887,16 @@ input:focus:invalid:focus, textarea:focus:invalid:focus, select:focus:invalid:fo
 }
 
 .input-group .form-control:focus {
-    border-color: rgba(82, 168, 236, 0.8);
+    border-color: #52a8ec;
     box-shadow: none;
     z-index: 1;
 }
 
 .input-group:focus-within .input-group-text {
     border-width: 2px;
-    border-color: rgba(82, 168, 236, 0.8);
-    color: rgb(82, 168, 236);
+    padding: 5px 12px 5px 11px;
+    border-color: #52a8ec;
+    color: #52a8ec;
 }
 
 .input-group .form-control:invalid:focus {
@@ -899,6 +905,7 @@ input:focus:invalid:focus, textarea:focus:invalid:focus, select:focus:invalid:fo
 
 .input-group:has(.form-control:invalid:focus) .input-group-text {
     border-width: 2px;
+    padding: 5px 12px 5px 11px;
     border-color: #fa3a15;
     color: #fa3a15;
 }

--- a/css/charts.css
+++ b/css/charts.css
@@ -35,10 +35,6 @@
     display: block;
     margin: 2px 0px 1px;
 }
-.version-stats-chart {
-  width: 70%;
-  margin-right: 5%;
-}
 .stats-toggle-wrapper {
     display: flex;
 }


### PR DESCRIPTION
1. Fixes chart responsiveness issue reported in https://github.com/composer/packagist/pull/1812#issuecomment-5539960365
>happens on mobile:
![image](https://github.com/user-attachments/assets/725ef599-7654-481d-8a51-16982b3b8376)
3. Fixes nav login and other form inputs - inconsistent border colour and thickness (because of the opacity) - cherry-picked from #1827

Before:
<img width="400" height="250" alt="Screen Recording 2026-09-04 at 16 22 39 (1)" src="https://github.com/user-attachments/assets/5ffbb59b-6e98-4836-8830-9e9e10c63fcb" />


After: 
<img width="400" height="250" alt="Screen Recording 2026-09-04 at 16 31 05" src="https://github.com/user-attachments/assets/d7cb594a-618a-416d-a1ad-361e5c97053e" />