### PR TITLE
Upgrade algolia/algoliasearch-client-php to 4.x

### DIFF
--- a/.env
+++ b/.env
@@ -43,6 +43,7 @@ SPAM_MODEL_FILE=
 MAILER_DSN=null://null
 ###< symfony/mailer ###
 
+# leaving these empty is fine: search stops working, the rest of the site does not
 ALGOLIA_APP_ID=
 ALGOLIA_ADMIN_KEY=
 ALGOLIA_SEARCH_KEY=

--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ permissions.
 
 ### Search
 
-To use the search in your local development environment, setup an
+Search is optional locally: with no Algolia config the rest of the site works
+normally, `/search.json` returns an error response and the search page renders
+without results. To use the search, setup an
 [Algolia Account](https://www.algolia.com/) and configure following keys
 in your `.env.local`:
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-apcu": "*",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "algolia/algoliasearch-client-php": "^3.4",
+        "algolia/algoliasearch-client-php": "^4.47",
         "babdev/pagerfanta-bundle": "^4.2",
         "beelab/recaptcha2-bundle": "^2.3",
         "cebe/markdown": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -2362,22 +2362,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.15.3",
+            "version": "7.15.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc"
+                "reference": "ee80339fd9177ba44c49cdb653ff02a4d1106b9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc",
-                "reference": "ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ee80339fd9177ba44c49cdb653ff02a4d1106b9a",
+                "reference": "ee80339fd9177ba44c49cdb653ff02a4d1106b9a",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.5.2",
-                "guzzlehttp/psr7": "^2.13",
+                "guzzlehttp/promises": "^2.5.3",
+                "guzzlehttp/psr7": "^2.13.1",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
@@ -2470,7 +2470,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.15.3"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.5"
             },
             "funding": [
                 {
@@ -2486,20 +2486,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-08-05T19:48:21+00:00"
+            "time": "2026-08-24T09:21:06+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.5.2",
+            "version": "2.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "2823687acff28b2dbe67b2508a6b300e2c3fa4ce"
+                "reference": "cde49999552d185d64715fe9c1f77a2aadd2f9f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/2823687acff28b2dbe67b2508a6b300e2c3fa4ce",
-                "reference": "2823687acff28b2dbe67b2508a6b300e2c3fa4ce",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/cde49999552d185d64715fe9c1f77a2aadd2f9f1",
+                "reference": "cde49999552d185d64715fe9c1f77a2aadd2f9f1",
                 "shasum": ""
             },
             "require": {
@@ -2554,7 +2554,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.5.2"
+                "source": "https://github.com/guzzle/promises/tree/2.5.3"
             },
             "funding": [
                 {
@@ -2570,20 +2570,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-08-05T19:30:54+00:00"
+            "time": "2026-08-24T09:11:28+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.13.0",
+            "version": "2.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
+                "reference": "95e7828100de18b4e269fb1703be530082d5166d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
-                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/95e7828100de18b4e269fb1703be530082d5166d",
+                "reference": "95e7828100de18b4e269fb1703be530082d5166d",
                 "shasum": ""
             },
             "require": {
@@ -2673,7 +2673,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.13.1"
             },
             "funding": [
                 {
@@ -2689,7 +2689,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-16T22:23:49+00:00"
+            "time": "2026-08-24T09:13:11+00:00"
         },
         {
             "name": "justinrainbow/json-schema",

--- a/composer.lock
+++ b/composer.lock
@@ -4,56 +4,48 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eadf29e8d8146dc1718ebcd5e4aaa2e3",
+    "content-hash": "7860ef37135b2d91faed5b4ca93a982d",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
-            "version": "3.4.2",
+            "version": "4.47.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/algolia/algoliasearch-client-php.git",
-                "reference": "7505959737f7944507be7ef476752ad761873c4a"
+                "reference": "d2ad9378c66681536d49f29134717a1d4cd66b6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/algolia/algoliasearch-client-php/zipball/7505959737f7944507be7ef476752ad761873c4a",
-                "reference": "7505959737f7944507be7ef476752ad761873c4a",
+                "url": "https://api.github.com/repos/algolia/algoliasearch-client-php/zipball/d2ad9378c66681536d49f29134717a1d4cd66b6c",
+                "reference": "d2ad9378c66681536d49f29134717a1d4cd66b6c",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "ext-json": "*",
                 "ext-mbstring": "*",
-                "php": "^7.3 || ^8.0",
+                "guzzlehttp/psr7": "^2.0",
+                "php": ">=8.1 !=8.3.0",
                 "psr/http-message": "^1.1 || ^2.0",
                 "psr/log": "^1.0 || ^2.0 || ^3.0",
                 "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.0",
-                "fzaninotto/faker": "^1.8",
-                "phpunit/phpunit": "^8.0 || ^9.0",
-                "symfony/yaml": "^2.0 || ^4.0"
+                "friendsofphp/php-cs-fixer": "^3.91.3",
+                "phpstan/phpstan": "^1.12",
+                "phpunit/phpunit": "^10.0",
+                "vlucas/phpdotenv": "^5.4"
             },
             "suggest": {
                 "guzzlehttp/guzzle": "If you prefer to use Guzzle HTTP client instead of the Http Client implementation provided by the package"
             },
-            "bin": [
-                "bin/algolia-doctor"
-            ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-2.0": "2.0.x-dev"
-                }
-            },
             "autoload": {
                 "files": [
-                    "src/Http/Psr7/functions.php",
-                    "src/functions.php"
+                    "lib/Http/Psr7/functions.php"
                 ],
                 "psr-4": {
-                    "Algolia\\AlgoliaSearch\\": "src/"
+                    "Algolia\\AlgoliaSearch\\": "lib/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -63,10 +55,11 @@
             "authors": [
                 {
                     "name": "Algolia Team",
-                    "email": "contact@algolia.com"
+                    "homepage": "https://alg.li/support"
                 }
             ],
-            "description": "Algolia Search API Client for PHP",
+            "description": "API powering the features of Algolia.",
+            "homepage": "https://github.com/algolia/algoliasearch-client-php",
             "keywords": [
                 "algolia",
                 "api",
@@ -76,9 +69,9 @@
             ],
             "support": {
                 "issues": "https://github.com/algolia/algoliasearch-client-php/issues",
-                "source": "https://github.com/algolia/algoliasearch-client-php/tree/3.4.2"
+                "source": "https://github.com/algolia/algoliasearch-client-php/tree/4.47.0"
             },
-            "time": "2025-01-22T11:13:54+00:00"
+            "time": "2026-08-18T12:43:34+00:00"
         },
         {
             "name": "babdev/pagerfanta-bundle",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -126,9 +126,15 @@ services:
         tags:
             - { name: knp_menu.menu, alias: organization_menu }
 
-    Algolia\AlgoliaSearch\SearchClient:
+    # lazy: the client throws if no credentials are configured, and PackageManager (so every package
+    # page) depends on it transitively. Building it only when something actually searches keeps the
+    # rest of the site working for devs with no Algolia setup.
+    Algolia\AlgoliaSearch\Api\SearchClient:
+        lazy: true
         arguments: ['%env(ALGOLIA_APP_ID)%', '%env(ALGOLIA_ADMIN_KEY)%']
-        factory: ['Algolia\AlgoliaSearch\SearchClient', create]
+        factory: ['Algolia\AlgoliaSearch\Api\SearchClient', create]
+
+    App\Search\PackageIndex: '@App\Search\AlgoliaPackageIndex'
 
     App\Service\QueueWorker:
         $jobWorkers:

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -10,9 +10,10 @@ services:
     App\Service\Scheduler:
         public: true
 
-    Algolia\AlgoliaSearch\SearchClient:
+    # public so AlgoliaMock can be swapped in
+    App\Search\PackageIndex:
+        alias: App\Search\AlgoliaPackageIndex
         public: true
-        factory: ['Algolia\AlgoliaSearch\SearchClient', create]
 
     # stub to replace 2FA code generation
     App\Tests\Mock\TotpAuthenticatorStub:

--- a/src/Command/CleanIndexCommand.php
+++ b/src/Command/CleanIndexCommand.php
@@ -61,9 +61,7 @@ class CleanIndexCommand extends Command
             return 0;
         }
 
-        // Browsing uses a cursor, so deleting records while iterating cannot make it skip any -- the
-        // old page-by-page loop drifted every time it deleted something, and ran into
-        // paginationLimitedTo after 3 pages.
+        // Browsing uses a cursor, so deleting records while iterating cannot make it skip any
         /** @var iterable<array{objectID: string, name: string, type: string}> $records */
         $records = $this->packageIndex->browse(['filters' => 'type:"virtual-package" AND trendiness=100']);
 

--- a/src/Command/CleanIndexCommand.php
+++ b/src/Command/CleanIndexCommand.php
@@ -12,7 +12,7 @@
 
 namespace App\Command;
 
-use Algolia\AlgoliaSearch\SearchClient;
+use App\Search\PackageIndex;
 use App\Service\Locker;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Command\Command;
@@ -21,20 +21,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CleanIndexCommand extends Command
 {
-    private SearchClient $algolia;
-    private Locker $locker;
-    private EntityManagerInterface $doctrine;
-    private string $algoliaIndexName;
-    private string $cacheDir;
-
-    public function __construct(SearchClient $algolia, Locker $locker, EntityManagerInterface $doctrine, string $algoliaIndexName, string $cacheDir)
-    {
-        $this->algolia = $algolia;
-        $this->locker = $locker;
-        $this->doctrine = $doctrine;
-        $this->algoliaIndexName = $algoliaIndexName;
-        $this->cacheDir = $cacheDir;
-
+    public function __construct(
+        private PackageIndex $packageIndex,
+        private Locker $locker,
+        private EntityManagerInterface $doctrine,
+        private string $cacheDir,
+    ) {
         parent::__construct();
     }
 
@@ -69,33 +61,40 @@ class CleanIndexCommand extends Command
             return 0;
         }
 
-        $index = $this->algolia->initIndex($this->algoliaIndexName);
+        // Browsing uses a cursor, so deleting records while iterating cannot make it skip any -- the
+        // old page-by-page loop drifted every time it deleted something, and ran into
+        // paginationLimitedTo after 3 pages.
+        /** @var iterable<array{objectID: string, name: string, type: string}> $records */
+        $records = $this->packageIndex->browse(['filters' => 'type:"virtual-package" AND trendiness=100']);
 
-        $page = 0;
-        $perPage = 100;
-        do {
-            $results = $index->search('', ['facets' => '*,type,tags', 'facetFilters' => ['type:virtual-package'], 'numericFilters' => ['trendiness=100'], 'hitsPerPage' => $perPage, 'page' => $page]);
-            foreach ($results['hits'] as $result) {
-                if (!str_starts_with($result['objectID'], 'virtual:')) {
-                    $duplicate = $index->search('', ['facets' => '*,objectID,type,tags', 'facetFilters' => ['objectID:virtual:'.$result['objectID']]]);
-                    if (\count($duplicate['hits']) === 1) {
-                        if ($verbose) {
-                            $output->writeln('Deleting '.$result['objectID'].' which is a duplicate of '.$duplicate['hits'][0]['objectID']);
-                        }
-                        $index->deleteObject($result['objectID']);
-                        continue;
-                    }
-                }
+        foreach ($records as $record) {
+            // Deleting is driven by this loop, so it does not rely on the filters above having been
+            // applied: anything that is not a stale virtual package is left alone regardless.
+            if (($record['type'] ?? null) !== 'virtual-package') {
+                continue;
+            }
 
-                if (!$this->hasProviders($result['name'])) {
+            $objectId = $record['objectID'];
+
+            if (!str_starts_with($objectId, 'virtual:')) {
+                /** @var array{hits: list<array{objectID: string}>} $duplicate */
+                $duplicate = $this->packageIndex->search(['query' => '', 'facetFilters' => ['objectID:virtual:'.$objectId]]);
+                if (\count($duplicate['hits']) === 1) {
                     if ($verbose) {
-                        $output->writeln('Deleting '.$result['objectID'].' which has no provider anymore');
+                        $output->writeln('Deleting '.$objectId.' which is a duplicate of '.$duplicate['hits'][0]['objectID']);
                     }
-                    $index->deleteObject($result['objectID']);
+                    $this->packageIndex->deleteRecord($objectId);
+                    continue;
                 }
             }
-            $page++;
-        } while (\count($results['hits']) >= $perPage);
+
+            if (!$this->hasProviders($record['name'])) {
+                if ($verbose) {
+                    $output->writeln('Deleting '.$objectId.' which has no provider anymore');
+                }
+                $this->packageIndex->deleteRecord($objectId);
+            }
+        }
 
         $this->locker->unlockCommand(__CLASS__);
 

--- a/src/Command/CleanIndexCommand.php
+++ b/src/Command/CleanIndexCommand.php
@@ -62,7 +62,6 @@ class CleanIndexCommand extends Command
         }
 
         // Browsing uses a cursor, so deleting records while iterating cannot make it skip any
-        /** @var iterable<array{objectID: string, name: string, type: string}> $records */
         $records = $this->packageIndex->browse(['filters' => 'type:"virtual-package" AND trendiness=100']);
 
         foreach ($records as $record) {
@@ -75,7 +74,6 @@ class CleanIndexCommand extends Command
             $objectId = $record['objectID'];
 
             if (!str_starts_with($objectId, 'virtual:')) {
-                /** @var array{hits: list<array{objectID: string}>} $duplicate */
                 $duplicate = $this->packageIndex->search(['query' => '', 'facetFilters' => ['objectID:virtual:'.$objectId]]);
                 if (\count($duplicate['hits']) === 1) {
                     if ($verbose) {

--- a/src/Command/ConfigureAlgoliaCommand.php
+++ b/src/Command/ConfigureAlgoliaCommand.php
@@ -12,7 +12,7 @@
 
 namespace App\Command;
 
-use Algolia\AlgoliaSearch\SearchClient;
+use App\Search\PackageIndex;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -23,8 +23,7 @@ use Symfony\Component\Yaml\Yaml;
 class ConfigureAlgoliaCommand extends Command
 {
     public function __construct(
-        private SearchClient $algolia,
-        private string $algoliaIndexName,
+        private PackageIndex $packageIndex,
         private string $configDir,
     ) {
         parent::__construct();
@@ -40,9 +39,7 @@ class ConfigureAlgoliaCommand extends Command
 
         $settings = Yaml::parse($yaml);
 
-        $index = $this->algolia->initIndex($this->algoliaIndexName);
-
-        $index->setSettings($settings);
+        $this->packageIndex->updateSettings($settings);
 
         return 0;
     }

--- a/src/Command/IndexPackagesCommand.php
+++ b/src/Command/IndexPackagesCommand.php
@@ -50,7 +50,6 @@ class IndexPackagesCommand extends Command
         $this
             ->setName('packagist:index')
             ->setDefinition([
-                new InputOption('force', null, InputOption::VALUE_NONE, 'Disabled, see --all'),
                 new InputOption('all', null, InputOption::VALUE_NONE, 'Index all packages without clearing the index first'),
                 new InputArgument('package', InputArgument::OPTIONAL, 'Package name to index'),
             ])
@@ -61,17 +60,8 @@ class IndexPackagesCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $verbose = $input->getOption('verbose');
-        $force = $input->getOption('force');
         $indexAll = $input->getOption('all');
         $package = $input->getArgument('package');
-
-        // --force used to call a method that never existed on the client, so it has always died here
-        // rather than clearing anything. Wiring it up now would empty the live index for the hours a
-        // full reindex takes, so it stays disabled until that is done atomically. --all is the safe
-        // way to reindex everything.
-        if ($force) {
-            throw new \LogicException('--force is disabled: it would empty the live index for the duration of the reindex. Use --all to reindex every package in place.');
-        }
 
         $deployLock = $this->cacheDir.'/deploy.globallock';
         if (file_exists($deployLock)) {

--- a/src/Command/IndexPackagesCommand.php
+++ b/src/Command/IndexPackagesCommand.php
@@ -12,11 +12,11 @@
 
 namespace App\Command;
 
-use Algolia\AlgoliaSearch\SearchClient;
 use App\Entity\Package;
 use App\Entity\Version;
 use App\Model\DownloadManager;
 use App\Model\FavoriteManager;
+use App\Search\PackageIndex;
 use App\Service\Locker;
 use Composer\Pcre\Preg;
 use Doctrine\DBAL\ArrayParameterType;
@@ -33,13 +33,12 @@ class IndexPackagesCommand extends Command
     use \App\Util\DoctrineTrait;
 
     public function __construct(
-        private SearchClient $algolia,
+        private PackageIndex $packageIndex,
         private Locker $locker,
         private ManagerRegistry $doctrine,
         private Client $redis,
         private DownloadManager $downloadManager,
         private FavoriteManager $favoriteManager,
-        private string $algoliaIndexName,
         private string $cacheDir,
         private \Graze\DogStatsD\Client $statsd,
     ) {
@@ -51,7 +50,7 @@ class IndexPackagesCommand extends Command
         $this
             ->setName('packagist:index')
             ->setDefinition([
-                new InputOption('force', null, InputOption::VALUE_NONE, 'Force a re-indexing of all packages'),
+                new InputOption('force', null, InputOption::VALUE_NONE, 'Disabled, see --all'),
                 new InputOption('all', null, InputOption::VALUE_NONE, 'Index all packages without clearing the index first'),
                 new InputArgument('package', InputArgument::OPTIONAL, 'Package name to index'),
             ])
@@ -65,6 +64,14 @@ class IndexPackagesCommand extends Command
         $force = $input->getOption('force');
         $indexAll = $input->getOption('all');
         $package = $input->getArgument('package');
+
+        // --force used to call a method that never existed on the client, so it has always died here
+        // rather than clearing anything. Wiring it up now would empty the live index for the hours a
+        // full reindex takes, so it stays disabled until that is done atomically. --all is the safe
+        // way to reindex everything.
+        if ($force) {
+            throw new \LogicException('--force is disabled: it would empty the live index for the duration of the reindex. Use --all to reindex every package in place.');
+        }
 
         $deployLock = $this->cacheDir.'/deploy.globallock';
         if (file_exists($deployLock)) {
@@ -84,8 +91,6 @@ class IndexPackagesCommand extends Command
             return 0;
         }
 
-        $index = $this->algolia->initIndex($this->algoliaIndexName);
-
         if ($package) {
             $packageEntity = $this->getEM()->getRepository(Package::class)->findOneBy(['name' => $package]);
             if ($packageEntity === null) {
@@ -94,13 +99,10 @@ class IndexPackagesCommand extends Command
                 return 1;
             }
             $packages = [['id' => $packageEntity->getId()]];
-        } elseif ($force || $indexAll) {
+        } elseif ($indexAll) {
             $this->statsd->increment('nightly_job.start', 1, 1, ['job' => 'index-packages']);
 
             $packages = $this->getEM()->getConnection()->fetchAllAssociative('SELECT id FROM package ORDER BY id ASC');
-            if ($force) {
-                $this->getEM()->getConnection()->executeQuery('UPDATE package SET indexedAt = NULL');
-            }
         } else {
             $packages = $this->getEM()->getRepository(Package::class)->getStalePackagesForIndexing();
         }
@@ -108,15 +110,6 @@ class IndexPackagesCommand extends Command
         $ids = [];
         foreach ($packages as $row) {
             $ids[] = $row['id'];
-        }
-
-        // clear index before a full-update
-        if ($force && !$package) {
-            if ($verbose) {
-                $output->writeln('Deleting existing index');
-            }
-
-            $index->clear();
         }
 
         $total = \count($ids);
@@ -140,10 +133,10 @@ class IndexPackagesCommand extends Command
                 // delete suppressed (spam/malware) packages from the search index
                 if ($package->isFrozen() && $package->getFreezeReason()?->suppressesPackage()) {
                     try {
-                        $index->deleteObject($package->getName());
+                        $this->packageIndex->deleteRecord($package->getName());
                         $idsToUpdate[] = $package->getId();
                         continue;
-                    } catch (\Algolia\AlgoliaSearch\Exceptions\AlgoliaException $e) {
+                    } catch (\Algolia\AlgoliaSearch\Exceptions\AlgoliaException|\InvalidArgumentException $e) {
                     }
                 }
 
@@ -166,7 +159,7 @@ class IndexPackagesCommand extends Command
             }
 
             try {
-                $index->saveObjects($records);
+                $this->packageIndex->saveRecords($records);
             } catch (\Exception $e) {
                 $output->writeln('<error>'.$e::class.': '.$e->getMessage().', occurred while processing packages: '.implode(',', $idsSlice).'</error>');
                 continue;
@@ -183,7 +176,7 @@ class IndexPackagesCommand extends Command
         }
 
         $this->locker->unlockCommand(__CLASS__);
-        if ($force || $indexAll) {
+        if ($indexAll) {
             $this->statsd->increment('nightly_job.end', 1, 1, ['job' => 'index-packages']);
         }
 

--- a/src/Command/IndexPackagesCommand.php
+++ b/src/Command/IndexPackagesCommand.php
@@ -28,6 +28,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * @phpstan-import-type PackageRecord from PackageIndex
+ */
 class IndexPackagesCommand extends Command
 {
     use \App\Util\DoctrineTrait;
@@ -174,9 +177,9 @@ class IndexPackagesCommand extends Command
     }
 
     /**
-     * @param string[] $tags
+     * @param list<string> $tags
      *
-     * @return array<string, int|string|float|array<string, string|int>|null>
+     * @phpstan-return PackageRecord
      */
     private function packageToSearchableArray(Package $package, array $tags): array
     {
@@ -232,7 +235,7 @@ class IndexPackagesCommand extends Command
     }
 
     /**
-     * @return array<string, string|int|array{}>
+     * @phpstan-return PackageRecord
      */
     private function createSearchableProvider(string $provided): array
     {
@@ -272,7 +275,7 @@ class IndexPackagesCommand extends Command
     }
 
     /**
-     * @return string[]
+     * @return list<string>
      */
     private function getTags(Package $package): array
     {

--- a/src/Controller/WebController.php
+++ b/src/Controller/WebController.php
@@ -97,7 +97,7 @@ class WebController extends Controller
 
         try {
             $result = $algolia->search($query);
-        } catch (AlgoliaException) {
+        } catch (AlgoliaException|\InvalidArgumentException) {
             return new JsonResponse([
                 'status' => 'error',
                 'message' => 'Could not connect to the search server',

--- a/src/Model/PackageManager.php
+++ b/src/Model/PackageManager.php
@@ -13,7 +13,6 @@
 namespace App\Model;
 
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
-use Algolia\AlgoliaSearch\SearchClient;
 use App\Entity\AuditRecord;
 use App\Entity\Dependent;
 use App\Entity\Download;
@@ -23,6 +22,7 @@ use App\Entity\PackageFreezeReason;
 use App\Entity\PhpStat;
 use App\Entity\User;
 use App\Entity\Version;
+use App\Search\PackageIndex;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use App\Service\CdnClient;
 use App\Service\GitHubUserMigrationWorker;
@@ -52,8 +52,7 @@ class PackageManager
         /** @var array{from: string, fromName: string} */
         private array $options,
         private ProviderManager $providerManager,
-        private SearchClient $algoliaClient,
-        private string $algoliaIndexName,
+        private PackageIndex $packageIndex,
         private GitHubUserMigrationWorker $githubWorker,
         private string $metadataDir,
         private Client $redis,
@@ -198,11 +197,8 @@ class PackageManager
     public function deletePackageSearchIndex(string $packageName): void
     {
         try {
-            $indexName = $this->algoliaIndexName;
-            $algolia = $this->algoliaClient;
-            $index = $algolia->initIndex($indexName);
-            $index->deleteObject($packageName);
-        } catch (AlgoliaException $e) {
+            $this->packageIndex->deleteRecord($packageName);
+        } catch (AlgoliaException|\InvalidArgumentException $e) {
         }
     }
 

--- a/src/Search/Algolia.php
+++ b/src/Search/Algolia.php
@@ -13,16 +13,15 @@
 namespace App\Search;
 
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
-use Algolia\AlgoliaSearch\SearchClient;
 
 /**
  * @phpstan-import-type SearchResult from ResultTransformer
+ * @phpstan-import-type AlgoliaSearchResponse from ResultTransformer
  */
 final class Algolia
 {
     public function __construct(
-        private SearchClient $algolia,
-        private string $algoliaIndexName,
+        private PackageIndex $index,
         private ResultTransformer $transformer,
     ) {
     }
@@ -30,15 +29,14 @@ final class Algolia
     /**
      * @phpstan-return SearchResult
      *
-     * @throws AlgoliaException
+     * @throws AlgoliaException          on a transport or API error
+     * @throws \InvalidArgumentException on a malformed response body
      */
     public function search(Query $query): array
     {
-        $index = $this->algolia->initIndex($this->algoliaIndexName);
+        /** @var AlgoliaSearchResponse $results */
+        $results = $this->index->search($query->getSearchParams());
 
-        return $this->transformer->transform(
-            $query,
-            $index->search($query->query, $query->getOptions())
-        );
+        return $this->transformer->transform($query, $results);
     }
 }

--- a/src/Search/AlgoliaPackageIndex.php
+++ b/src/Search/AlgoliaPackageIndex.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Packagist.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *     Nils Adermann <naderman@naderman.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Search;
+
+use Algolia\AlgoliaSearch\Api\SearchClient;
+use Algolia\AlgoliaSearch\Exceptions\MissingObjectId;
+
+final class AlgoliaPackageIndex implements PackageIndex
+{
+    public function __construct(
+        private SearchClient $algolia,
+        private string $algoliaIndexName,
+    ) {
+    }
+
+    public function search(array $searchParams): array
+    {
+        // $searchParams is the request body. Anything passed as the client's third argument instead
+        // is silently dropped (RequestOptions only reads headers/queryParameters/body/timeouts), so
+        // filters and pagination must never be moved there.
+        $result = $this->algolia->searchSingleIndex($this->algoliaIndexName, $searchParams);
+        \assert(\is_array($result));
+
+        return $result;
+    }
+
+    public function browse(array $browseParams): iterable
+    {
+        return $this->algolia->browseObjects($this->algoliaIndexName, $browseParams);
+    }
+
+    public function saveRecords(array $records): void
+    {
+        // v3 rejected records without an objectID client-side; v4's saveObjects() would instead let
+        // Algolia generate one, creating a record we could never update or delete again.
+        foreach ($records as $record) {
+            if (!isset($record['objectID']) || $record['objectID'] === '') {
+                throw new MissingObjectId('All records must have an objectID to be indexed.');
+            }
+        }
+
+        $this->algolia->saveObjects($this->algoliaIndexName, $records);
+    }
+
+    public function deleteRecord(string $objectId): void
+    {
+        $this->algolia->deleteObject($this->algoliaIndexName, $objectId);
+    }
+
+    public function clear(): void
+    {
+        $this->algolia->clearObjects($this->algoliaIndexName);
+    }
+
+    public function updateSettings(array $settings): void
+    {
+        $this->algolia->setSettings($this->algoliaIndexName, $settings);
+    }
+}

--- a/src/Search/AlgoliaPackageIndex.php
+++ b/src/Search/AlgoliaPackageIndex.php
@@ -15,6 +15,12 @@ namespace App\Search;
 use Algolia\AlgoliaSearch\Api\SearchClient;
 use Algolia\AlgoliaSearch\Exceptions\MissingObjectId;
 
+/**
+ * @phpstan-import-type PackageRecord from PackageIndex
+ * @phpstan-import-type SearchParams from PackageIndex
+ * @phpstan-import-type BrowseParams from PackageIndex
+ * @phpstan-import-type SearchResponse from PackageIndex
+ */
 final class AlgoliaPackageIndex implements PackageIndex
 {
     public function __construct(
@@ -23,22 +29,38 @@ final class AlgoliaPackageIndex implements PackageIndex
     ) {
     }
 
+    /**
+     * @phpstan-param SearchParams $searchParams
+     *
+     * @phpstan-return SearchResponse
+     */
     public function search(array $searchParams): array
     {
         // $searchParams is the request body. Anything passed as the client's third argument instead
         // is silently dropped (RequestOptions only reads headers/queryParameters/body/timeouts), so
         // filters and pagination must never be moved there.
+        /** @var SearchResponse $result */
         $result = $this->algolia->searchSingleIndex($this->algoliaIndexName, $searchParams);
-        \assert(\is_array($result));
 
         return $result;
     }
 
+    /**
+     * @phpstan-param BrowseParams $browseParams
+     *
+     * @phpstan-return iterable<PackageRecord>
+     */
     public function browse(array $browseParams): iterable
     {
-        return $this->algolia->browseObjects($this->algoliaIndexName, $browseParams);
+        /** @var iterable<PackageRecord> $records */
+        $records = $this->algolia->browseObjects($this->algoliaIndexName, $browseParams);
+
+        return $records;
     }
 
+    /**
+     * @phpstan-param list<PackageRecord> $records
+     */
     public function saveRecords(array $records): void
     {
         // v3 rejected records without an objectID client-side; v4's saveObjects() would instead let

--- a/src/Search/PackageIndex.php
+++ b/src/Search/PackageIndex.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Packagist.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *     Nils Adermann <naderman@naderman.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Search;
+
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+
+/**
+ * Read/write access to the package search index.
+ *
+ * All contact with the search vendor's client goes through implementations of this, so that a client
+ * upgrade touches one class instead of every call site.
+ */
+interface PackageIndex
+{
+    /**
+     * @param array<string, mixed> $searchParams the request body: query, filters, hitsPerPage, page, ...
+     *
+     * @return array<string, mixed> the raw search response; callers narrow it to the shape they asked for
+     *
+     * @throws AlgoliaException          on a transport or API error
+     * @throws \InvalidArgumentException on a malformed response body
+     */
+    public function search(array $searchParams): array;
+
+    /**
+     * Iterates the whole index with a cursor, unaffected by records being deleted while iterating.
+     *
+     * @param array<string, mixed> $browseParams
+     *
+     * @return iterable<array<string, mixed>>
+     */
+    public function browse(array $browseParams): iterable;
+
+    /**
+     * @param list<array<string, mixed>> $records each must carry an objectID
+     */
+    public function saveRecords(array $records): void;
+
+    public function deleteRecord(string $objectId): void;
+
+    public function clear(): void;
+
+    /**
+     * @param array<string, mixed> $settings
+     */
+    public function updateSettings(array $settings): void;
+}

--- a/src/Search/PackageIndex.php
+++ b/src/Search/PackageIndex.php
@@ -19,13 +19,60 @@ use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
  *
  * All contact with the search vendor's client goes through implementations of this, so that a client
  * upgrade touches one class instead of every call site.
+ *
+ * The shapes below stay unsealed: the search API accepts far more parameters than we pass, and
+ * records gain attributes over time, so only what the app actually relies on is spelled out.
+ *
+ * @phpstan-type PackageRecord array{
+ *     id: int|string,
+ *     objectID: string,
+ *     name: string,
+ *     package_organisation: string,
+ *     package_name: string,
+ *     description: string,
+ *     type: string|null,
+ *     repository: string,
+ *     language: string|null,
+ *     trendiness: float|int,
+ *     popularity: float|int,
+ *     abandoned: int,
+ *     replacementPackage: string,
+ *     tags: list<string>,
+ *     meta?: array{downloads: int, downloads_formatted: string, favers: int, favers_formatted: string},
+ *     extension?: int,
+ *     extensionName?: string|null,
+ *     ...<string, mixed>
+ * }
+ * @phpstan-type SearchParams array{
+ *     query: string,
+ *     hitsPerPage?: int,
+ *     page?: int,
+ *     filters?: string,
+ *     facetFilters?: list<string>,
+ *     numericFilters?: list<string>,
+ *     ...<string, mixed>
+ * }
+ * @phpstan-type BrowseParams array{
+ *     filters?: string,
+ *     facetFilters?: list<string>,
+ *     numericFilters?: list<string>,
+ *     hitsPerPage?: int,
+ *     ...<string, mixed>
+ * }
+ * @phpstan-type SearchResponse array{
+ *     nbHits: int,
+ *     page: int,
+ *     nbPages: int,
+ *     hits: list<array<string, mixed>>,
+ *     ...<string, mixed>
+ * }
  */
 interface PackageIndex
 {
     /**
-     * @param array<string, mixed> $searchParams the request body: query, filters, hitsPerPage, page, ...
+     * @phpstan-param SearchParams $searchParams the request body
      *
-     * @return array<string, mixed> the raw search response; callers narrow it to the shape they asked for
+     * @phpstan-return SearchResponse hits stay loose; callers narrow them to what they queried for
      *
      * @throws AlgoliaException          on a transport or API error
      * @throws \InvalidArgumentException on a malformed response body
@@ -35,14 +82,14 @@ interface PackageIndex
     /**
      * Iterates the whole index with a cursor, unaffected by records being deleted while iterating.
      *
-     * @param array<string, mixed> $browseParams
+     * @phpstan-param BrowseParams $browseParams
      *
-     * @return iterable<array<string, mixed>>
+     * @phpstan-return iterable<PackageRecord>
      */
     public function browse(array $browseParams): iterable;
 
     /**
-     * @param list<array<string, mixed>> $records each must carry an objectID
+     * @phpstan-param list<PackageRecord> $records
      */
     public function saveRecords(array $records): void;
 

--- a/src/Search/Query.php
+++ b/src/Search/Query.php
@@ -16,7 +16,7 @@ use Composer\Pcre\Preg;
 use Symfony\Component\String\UnicodeString;
 
 /**
- * @phpstan-type SearchOptions array{hitsPerPage: int, page: int, filters?: string}
+ * @phpstan-type SearchParams array{query: string, hitsPerPage: int, page: int, filters?: string}
  */
 final class Query
 {
@@ -52,11 +52,15 @@ final class Query
     }
 
     /**
-     * @phpstan-return SearchOptions
+     * The search request body. These must not be passed as the client's request options instead:
+     * unknown request-option keys are silently discarded, which would drop filters and pagination.
+     *
+     * @phpstan-return SearchParams
      */
-    public function getOptions(): array
+    public function getSearchParams(): array
     {
         $queryParams = [
+            'query' => $this->query,
             'hitsPerPage' => $this->perPage,
             'page' => $this->page,
         ];

--- a/src/Search/ResultTransformer.php
+++ b/src/Search/ResultTransformer.php
@@ -15,6 +15,20 @@ namespace App\Search;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
+ * @phpstan-type AlgoliaSearchResponse array{
+ *     nbHits: int,
+ *     page: int,
+ *     nbPages: int,
+ *     hits: array<array{
+ *         id: int,
+ *         name: string,
+ *         description: string,
+ *         repository: string,
+ *         meta: array{downloads: int, favers: int},
+ *         abandoned?: bool,
+ *         replacementPackage?: string
+ *     }>
+ * }
  * @phpstan-type SearchResult array{
  *     total: int,
  *     next?: string,
@@ -37,20 +51,7 @@ final class ResultTransformer
     }
 
     /**
-     * @param array{
-     *     nbHits: int,
-     *     page: int,
-     *     nbPages: int,
-     *     hits: array<array{
-     *         id: int,
-     *         name: string,
-     *         description: string,
-     *         repository: string,
-     *         meta: array{downloads: int, favers: int},
-     *         abandoned?: bool,
-     *         replacementPackage?: string
-     *     }>
-     * } $results
+     * @phpstan-param AlgoliaSearchResponse $results
      *
      * @phpstan-return SearchResult
      */

--- a/src/Search/ResultTransformer.php
+++ b/src/Search/ResultTransformer.php
@@ -19,15 +19,17 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  *     nbHits: int,
  *     page: int,
  *     nbPages: int,
- *     hits: array<array{
- *         id: int,
+ *     hits: list<array{
+ *         id: int|string,
  *         name: string,
  *         description: string,
  *         repository: string,
- *         meta: array{downloads: int, favers: int},
- *         abandoned?: bool,
- *         replacementPackage?: string
- *     }>
+ *         meta?: array{downloads: int, favers: int},
+ *         abandoned?: bool|int,
+ *         replacementPackage?: string,
+ *         ...<string, mixed>
+ *     }>,
+ *     ...<string, mixed>
  * }
  * @phpstan-type SearchResult array{
  *     total: int,
@@ -76,8 +78,8 @@ final class ResultTransformer
                 'repository' => $package['repository'],
             ];
             if (ctype_digit((string) $package['id'])) {
-                $row['downloads'] = $package['meta']['downloads'];
-                $row['favers'] = $package['meta']['favers'];
+                $row['downloads'] = $package['meta']['downloads'] ?? 0;
+                $row['favers'] = $package['meta']['favers'] ?? 0;
             } else {
                 $row['virtual'] = true;
             }

--- a/tests/Search/AlgoliaMock.php
+++ b/tests/Search/AlgoliaMock.php
@@ -12,19 +12,27 @@
 
 namespace App\Tests\Search;
 
-use Algolia\AlgoliaSearch\SearchClient;
+use App\Search\PackageIndex;
 use App\Search\Query;
 use PHPUnit\Framework\Assert;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
-final class AlgoliaMock extends SearchClient
+/**
+ * Stands in for the real index and asserts the exact request body the app builds.
+ *
+ * That assertion is the point: search params passed to the client as request options instead are
+ * silently discarded, so a mistake there would quietly drop filters and pagination rather than fail.
+ */
+final class AlgoliaMock implements PackageIndex
 {
     private Query $query;
+
+    /** @var array<string, mixed> */
     private array $result;
 
     public static function setup(KernelBrowser $client, Query $query, string $resultName): self
     {
-        $mock = new \ReflectionClass(__CLASS__)->newInstanceWithoutConstructor();
+        $mock = new self();
         $mock->query = $query;
 
         if (false === $result = @include __DIR__.'/results/'.$resultName.'.php') {
@@ -33,28 +41,45 @@ final class AlgoliaMock extends SearchClient
 
         $mock->result = $result;
 
-        $client->getContainer()->set(SearchClient::class, $mock);
+        $client->getContainer()->set(PackageIndex::class, $mock);
 
         return $mock;
     }
 
-    /**
-     * @override \Algolia\AlgoliaSearch\SearchClient::initIndex
-     */
-    public function initIndex($indexName): self
+    public function search(array $searchParams): array
     {
-        return $this;
-    }
+        $expected = $this->query->getSearchParams();
 
-    /**
-     * @override \Algolia\AlgoliaSearch\SearchIndex::search
-     */
-    public function search($query, $requestOptions = []): array
-    {
-        $queryMessage = \sprintf('AlgoliaMock expected query string \'%s\', but got \'%s\'.', $this->query->query, $query);
-        Assert::assertSame($this->query->query, $query, $queryMessage);
-        Assert::assertSame($this->query->getOptions(), $requestOptions, 'AlgoliaMock expected different request options.');
+        // assert the query on its own first, so an escaping regression is not buried in a whole-array diff
+        $queryMessage = \sprintf('AlgoliaMock expected query string \'%s\', but got \'%s\'.', $expected['query'], $searchParams['query'] ?? '');
+        Assert::assertSame($expected['query'], $searchParams['query'] ?? null, $queryMessage);
+        Assert::assertSame($expected, $searchParams, 'AlgoliaMock expected different search params.');
 
         return $this->result;
+    }
+
+    public function browse(array $browseParams): iterable
+    {
+        Assert::fail('AlgoliaMock::browse() was not expected to be called.');
+    }
+
+    public function saveRecords(array $records): void
+    {
+        Assert::fail('AlgoliaMock::saveRecords() was not expected to be called.');
+    }
+
+    public function deleteRecord(string $objectId): void
+    {
+        Assert::fail('AlgoliaMock::deleteRecord() was not expected to be called.');
+    }
+
+    public function clear(): void
+    {
+        Assert::fail('AlgoliaMock::clear() was not expected to be called.');
+    }
+
+    public function updateSettings(array $settings): void
+    {
+        Assert::fail('AlgoliaMock::updateSettings() was not expected to be called.');
     }
 }

--- a/tests/Search/QueryTest.php
+++ b/tests/Search/QueryTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @phpstan-import-type SearchOptions from \App\Search\Query
+ * @phpstan-import-type SearchParams from \App\Search\Query
  */
 final class QueryTest extends TestCase
 {
@@ -136,52 +136,52 @@ final class QueryTest extends TestCase
     }
 
     /**
-     * @phpstan-param SearchOptions $expectedOptions
+     * @phpstan-param SearchParams $expectedParams
      */
-    #[DataProvider('provideQueryWithOptions')]
-    public function testGetOptions(Query $query, array $expectedOptions): void
+    #[DataProvider('provideQueryWithSearchParams')]
+    public function testGetSearchParams(Query $query, array $expectedParams): void
     {
-        static::assertSame($expectedOptions, $query->getOptions());
+        static::assertSame($expectedParams, $query->getSearchParams());
     }
 
     /**
-     * @phpstan-return iterable<string, array{0: Query, 1: SearchOptions}>
+     * @phpstan-return iterable<string, array{0: Query, 1: SearchParams}>
      */
-    public static function provideQueryWithOptions(): iterable
+    public static function provideQueryWithSearchParams(): iterable
     {
         yield 'empty_tag_type' => [
             new Query('monolog', [], '', 15, 1),
-            ['hitsPerPage' => 15, 'page' => 0],
+            ['query' => 'monolog', 'hitsPerPage' => 15, 'page' => 0],
         ];
 
         yield 'with_single_tag' => [
             new Query('monolog', ['testing"quote'], '', 15, 1),
-            ['hitsPerPage' => 15, 'page' => 0, 'filters' => '(tags:"testing\"quote")'],
+            ['query' => 'monolog', 'hitsPerPage' => 15, 'page' => 0, 'filters' => '(tags:"testing\"quote")'],
         ];
 
         yield 'with_single_tag_but_space' => [
             new Query('monolog', ['testing mock'], '', 15, 1),
-            ['hitsPerPage' => 15, 'page' => 0, 'filters' => '(tags:"testing mock" OR tags:"testing-mock")'],
+            ['query' => 'monolog', 'hitsPerPage' => 15, 'page' => 0, 'filters' => '(tags:"testing mock" OR tags:"testing-mock")'],
         ];
 
         yield 'with_multiple_tags' => [
             new Query('monolog', ['testing', 'mock'], '', 15, 1),
-            ['hitsPerPage' => 15, 'page' => 0, 'filters' => '(tags:"testing" OR tags:"mock")'],
+            ['query' => 'monolog', 'hitsPerPage' => 15, 'page' => 0, 'filters' => '(tags:"testing" OR tags:"mock")'],
         ];
 
         yield 'with_type' => [
             new Query('monolog', [], 'symfony-bundle"quote', 15, 1),
-            ['hitsPerPage' => 15, 'page' => 0, 'filters' => 'type:"symfony-bundle\"quote"'],
+            ['query' => 'monolog', 'hitsPerPage' => 15, 'page' => 0, 'filters' => 'type:"symfony-bundle\"quote"'],
         ];
 
         yield 'with_single_tag_and_type' => [
             new Query('monolog', ['testing'], 'symfony-bundle', 15, 1),
-            ['hitsPerPage' => 15, 'page' => 0, 'filters' => 'type:"symfony-bundle" AND (tags:"testing")'],
+            ['query' => 'monolog', 'hitsPerPage' => 15, 'page' => 0, 'filters' => 'type:"symfony-bundle" AND (tags:"testing")'],
         ];
 
         yield 'with_multiple_tags_and_type' => [
             new Query('monolog', ['testing', 'mock'], 'symfony-bundle', 15, 1),
-            ['hitsPerPage' => 15, 'page' => 0, 'filters' => 'type:"symfony-bundle" AND (tags:"testing" OR tags:"mock")'],
+            ['query' => 'monolog', 'hitsPerPage' => 15, 'page' => 0, 'filters' => 'type:"symfony-bundle" AND (tags:"testing" OR tags:"mock")'],
         ];
     }
 }


### PR DESCRIPTION
v4 removes initIndex() and the SearchIndex object: every operation is now a method on the client taking the index name. Rather than translate each call site, all contact with the client moves behind App\Search\PackageIndex, so a future client upgrade touches one class and tests stop subclassing vendor code.

Search parameters now go in the request body argument rather than the request options. v3 folded unrecognised request options into the body; v4 discards them without complaint, which would have silently dropped filters and pagination. Query::getOptions() is renamed getSearchParams() so the two are not confused.

packagist:index --force is disabled. It called $index->clear(), which never existed on the v3 client either, so it has always died before clearing anything. Pointing it at clearObjects() would genuinely empty the live index for the hours a full reindex takes, so that wants doing atomically as its own change. --all still reindexes everything in place.

packagist:clean-index now browses with a cursor instead of paging by hand. The old loop drifted every time it deleted a record and could not see past paginationLimitedTo, so it only ever examined the first 300 of the ~557 stale virtual packages. It also checks each record's type before deleting, so it stays safe even if the query's filters were to stop applying.

The client is registered lazily because it throws when constructed without credentials. PackageManager depends on it transitively, so every package page would otherwise fail for anyone with no Algolia config; now only search itself degrades, and .env needs no placeholder credentials.

saveRecords() rejects records with no objectID, which v3 did client-side. v4's saveObjects() would instead let Algolia generate one, creating a record we could never update or delete again.

WebController and PackageManager also catch \InvalidArgumentException, which v4 throws for missing required parameters and for malformed response bodies.