### PR TITLE
Only build the package management forms for visitors who can use them

### DIFF
--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -722,10 +722,17 @@ class PackageController extends Controller
                 }
             }
 
-            $data['addMaintainerForm'] = $this->createAddMaintainerForm($package)->createView();
-            $data['removeMaintainerForm'] = $this->createRemoveMaintainerForm($package)->createView();
-            $data['transferPackageForm'] = $this->createTransferPackageForm($package)->createView();
-            $data['deleteForm'] = $this->createDeletePackageForm($package)->createView();
+            // The template renders each of these behind the matching voter grant, and building them
+            // is not free - createView() on the remove-maintainer form materialises an EntityType
+            // choice list with a DB query - so visitors who cannot see a form must not pay for it.
+            $data['addMaintainerForm'] = $this->isGranted(PackageActions::AddMaintainer->value, $package)
+                ? $this->createAddMaintainerForm($package)->createView() : null;
+            $data['removeMaintainerForm'] = $this->isGranted(PackageActions::RemoveMaintainer->value, $package)
+                ? $this->createRemoveMaintainerForm($package)->createView() : null;
+            $data['transferPackageForm'] = $this->isGranted(PackageActions::TransferPackage->value, $package)
+                ? $this->createTransferPackageForm($package)->createView() : null;
+            $data['deleteForm'] = $this->isGranted(PackageActions::Delete->value, $package)
+                ? $this->createDeletePackageForm($package)->createView() : null;
         } else {
             $data['hasVersionSecurityAdvisories'] = [];
             $data['hasVersionsFlaggedAsMalware'] = [];

--- a/tests/Controller/PackageControllerTest.php
+++ b/tests/Controller/PackageControllerTest.php
@@ -47,6 +47,35 @@ class PackageControllerTest extends IntegrationTestCase
         self::assertStringContainsString('noindex', (string) $auditLink->attr('rel'));
     }
 
+    public function testPackagePageOmitsManagementFormsForVisitorsWhoCannotUseThem(): void
+    {
+        $owner = self::createUser('owner', 'owner@example.org');
+        // a second maintainer is required for remove_maintainer to be granted at all
+        $comaintainer = self::createUser('comaintainer', 'comaintainer@example.org');
+        $package = self::createPackage('test/pkg', 'https://example.com/test/pkg', maintainers: [$owner, $comaintainer]);
+        $this->store($owner, $comaintainer, $package);
+
+        $crawler = $this->client->request('GET', '/packages/test/pkg');
+        self::assertResponseIsSuccessful();
+
+        // The controller skips building these entirely when the visitor lacks the grant, which also
+        // skips the EntityType choice-list query behind the remove-maintainer form.
+        self::assertCount(0, $crawler->filter('[name="add_maintainer_form"]'));
+        self::assertCount(0, $crawler->filter('[name="remove_maintainer_form"]'));
+        self::assertCount(0, $crawler->filter('[name="transfer_package_form"]'));
+        self::assertCount(0, $crawler->filter('form.delete.action'));
+
+        // ...and still builds them for someone who can, so the skip is keyed on the grant only.
+        $this->client->loginUser($owner);
+        $crawler = $this->client->request('GET', '/packages/test/pkg');
+        self::assertResponseIsSuccessful();
+
+        self::assertCount(1, $crawler->filter('[name="add_maintainer_form"]'));
+        self::assertCount(1, $crawler->filter('[name="remove_maintainer_form"]'));
+        self::assertCount(1, $crawler->filter('[name="transfer_package_form"]'));
+        self::assertCount(1, $crawler->filter('form.delete.action'));
+    }
+
     public function testFreezePackageAsModeratorAuditsAndSchedulesPurge(): void
     {
         $mod = self::createUser('mod', 'mod@example.org', roles: ['ROLE_DISABLE_PACKAGES']);


### PR DESCRIPTION
`viewPackageAction` built and `createView()`'d the add-maintainer, remove-maintainer, transfer and delete forms for **every** visitor, including anonymous ones. The template already renders each of them behind the matching voter grant (`view_package.html.twig:103,173,191,211`), so for the overwhelming majority of the ~4.5M package page views per APM period all four were discarded unrendered.

`createView()` is not free either: `RemoveMaintainerRequestType` uses an `EntityType`, so materialising its choice list runs a real query against the package's maintainers (`UserRepository::getPackageMaintainersQueryBuilder`).

Gating on the same grants the template uses keeps the rendered output identical while dropping four form builds and one query from almost every package page view.

### Verification

`composer phpstan` clean, full suite green. The existing `testCreateMaintainer` / `testRemoveMaintainer` / `testTransferPackage` tests already cover the granted side end-to-end (they crawl the page and submit the forms); the new test covers the other half — that an anonymous visitor gets none of the four, and a maintainer still gets all four.