### PR TITLE
Only count package page views while the spam heuristic can use them

### DIFF
--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -672,8 +672,8 @@ class PackageController extends Controller
             // so a package that fails this check can never need the counter again.
             if (
                 !$package->isSuspect()
-                && $data['downloads']['total'] <= 10
-                && $package->getCreatedAt()->getTimestamp() >= strtotime('2019-05-01')
+                && $data['downloads']['total'] <= PackageRepository::SUSPECT_VIEWS_MAX_DOWNLOADS
+                && $package->getCreatedAt()->getTimestamp() >= strtotime(PackageRepository::SUSPECT_VIEWS_MIN_CREATED_AT)
                 && $this->downloadManager->incrementViews($package) >= 100
             ) {
                 $vendorRepo = $this->getEM()->getRepository(Vendor::class);
@@ -681,6 +681,12 @@ class PackageController extends Controller
                     $package->setSuspect('Too many views');
                     $repo->markPackageSuspect($package);
                 }
+
+                // The counter has served its purpose either way, so drop it: a package we just
+                // marked suspect stops counting above, and for a verified vendor nothing can ever
+                // come of it. Restarting from zero also spaces the isVerified() lookup back out to
+                // once per 100 views instead of once per view from here on.
+                $this->downloadManager->deleteViews($package->getId());
             }
 
             if ($user) {

--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -664,12 +664,17 @@ class PackageController extends Controller
             if (!Killswitch::isEnabled(Killswitch::DOWNLOADS_ENABLED)) {
                 throw new \RuntimeException();
             }
-            $data['downloads'] = $this->downloadManager->getDownloads($package, null, true);
+            $data['downloads'] = $this->downloadManager->getDownloads($package);
 
+            // The view counter exists only to spot packages that get traffic but no installs, so
+            // it is only worth a Redis write while that can still be concluded. Downloads and
+            // createdAt never move back below these thresholds, and suspect is never unset here,
+            // so a package that fails this check can never need the counter again.
             if (
                 !$package->isSuspect()
-                && $data['downloads']['total'] <= 10 && ($data['downloads']['views'] ?? 0) >= 100
+                && $data['downloads']['total'] <= 10
                 && $package->getCreatedAt()->getTimestamp() >= strtotime('2019-05-01')
+                && $this->downloadManager->incrementViews($package) >= 100
             ) {
                 $vendorRepo = $this->getEM()->getRepository(Vendor::class);
                 if (!$vendorRepo->isVerified($package->getVendor())) {

--- a/src/Entity/PackageRepository.php
+++ b/src/Entity/PackageRepository.php
@@ -28,6 +28,14 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 class PackageRepository extends ServiceEntityRepository
 {
+    /**
+     * Bounds of the "lots of views, no installs" spam heuristic implemented in
+     * PackageController::viewPackageAction(), shared so packagist:clean-view-counters can tell which
+     * view counters are still live by exactly the same rules.
+     */
+    public const SUSPECT_VIEWS_MIN_CREATED_AT = '2019-05-01';
+    public const SUSPECT_VIEWS_MAX_DOWNLOADS = 10;
+
     private const LISTING_FIELDS = 'id, name, description, type, gitHubStars, frozen, language, abandoned, replacementPackage';
     // @phpstan-ignore classConstant.unused
     private const LISTING_WITH_AUTO_UPDATE_WARNINGS_FIELDS = 'id, name, description, type, gitHubStars, frozen, language, abandoned, replacementPackage, autoUpdated, repository';
@@ -562,6 +570,41 @@ class PackageRepository extends ServiceEntityRepository
             FROM package p WHERE p.suspect IS NOT NULL AND p.frozen IS NULL ORDER BY p.vendor ASC, p.name ASC';
 
         return $this->getEntityManager()->getConnection()->fetchAllAssociative($sql);
+    }
+
+    /**
+     * Narrows a list of package ids down to those the "too many views" heuristic could still flag:
+     * still present, not already suspect, still publicly viewable, new enough, and not owned by a
+     * vendor a moderator has verified (which blocks the flagging for good). The download half of
+     * the check lives in Redis, so callers have to apply SUSPECT_VIEWS_MAX_DOWNLOADS themselves.
+     *
+     * @param list<int> $ids
+     *
+     * @return list<int>
+     */
+    public function getPackageIdsFlaggableByViews(array $ids): array
+    {
+        if (\count($ids) === 0) {
+            return [];
+        }
+
+        // a suppressing freeze 404s the package page for everyone, so no views can come in anymore,
+        // while a gentle freeze keeps serving it and thus keeps the counter live
+        $sql = 'SELECT p.id FROM package p
+            LEFT JOIN vendor v ON v.name = p.vendor
+            WHERE p.id IN (:ids)
+                AND p.suspect IS NULL
+                AND (p.frozen IS NULL OR p.frozen NOT IN (:suppressed))
+                AND p.createdAt >= :minCreatedAt
+                AND COALESCE(v.verified, 0) = 0';
+
+        $rows = $this->getEntityManager()->getConnection()->fetchFirstColumn(
+            $sql,
+            ['ids' => $ids, 'suppressed' => PackageFreezeReason::suppressingValues(), 'minCreatedAt' => self::SUSPECT_VIEWS_MIN_CREATED_AT],
+            ['ids' => ArrayParameterType::INTEGER, 'suppressed' => ArrayParameterType::STRING]
+        );
+
+        return array_map('intval', $rows);
     }
 
     /**

--- a/src/Entity/VendorRepository.php
+++ b/src/Entity/VendorRepository.php
@@ -12,6 +12,7 @@
 
 namespace App\Entity;
 
+use App\Model\DownloadManager;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -22,7 +23,7 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 class VendorRepository extends ServiceEntityRepository
 {
-    public function __construct(ManagerRegistry $registry)
+    public function __construct(ManagerRegistry $registry, private readonly DownloadManager $downloadManager)
     {
         parent::__construct($registry, Vendor::class);
     }
@@ -50,5 +51,13 @@ class VendorRepository extends ServiceEntityRepository
             'UPDATE package SET suspect = NULL WHERE vendor = :vendor',
             ['vendor' => $vendor]
         );
+
+        // A verified vendor's packages can never be flagged again, so their view counters have
+        // lost their only reader - drop them instead of leaving them in Redis forever.
+        $packageIds = $this->getEntityManager()->getConnection()->fetchFirstColumn(
+            'SELECT id FROM package WHERE vendor = :vendor',
+            ['vendor' => $vendor]
+        );
+        $this->downloadManager->deleteViews(...array_map('intval', $packageIds));
     }
 }

--- a/src/Model/DownloadManager.php
+++ b/src/Model/DownloadManager.php
@@ -20,6 +20,7 @@ use Composer\Pcre\Preg;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\Persistence\ManagerRegistry;
 use Predis\Client;
+use Predis\PredisException;
 
 /**
  * Manages the download counts for packages.
@@ -109,6 +110,26 @@ class DownloadManager
         }
 
         return $this->redis->incr('views:'.$package);
+    }
+
+    /**
+     * Drops the view counters of the given packages.
+     *
+     * Safe to call as soon as the spam heuristic can no longer fire for a package: nothing else
+     * reads the counter, so from that point on the key is only taking up space in Redis. Losing a
+     * counter costs nothing either, hence the swallowed Redis failure - callers are mid-way through
+     * more important work (verifying a vendor, deleting a package) and must not fail over this.
+     */
+    public function deleteViews(int ...$packageIds): void
+    {
+        if (\count($packageIds) === 0) {
+            return;
+        }
+
+        try {
+            $this->redis->del(array_map(static fn (int $id) => 'views:'.$id, $packageIds));
+        } catch (PredisException) {
+        }
     }
 
     /**

--- a/src/Model/DownloadManager.php
+++ b/src/Model/DownloadManager.php
@@ -35,9 +35,9 @@ class DownloadManager
     /**
      * Gets the total, monthly, and daily download counts for an entire package or optionally a version.
      *
-     * @return array{total: int, monthly: int, daily: float, views?: int}
+     * @return array{total: int, monthly: int, daily: float}
      */
-    public function getDownloads(Package|int $package, Version|int|null $version = null, bool $incrViews = false): array
+    public function getDownloads(Package|int $package, Version|int|null $version = null): array
     {
         if ($package instanceof Package) {
             $package = $package->getId();
@@ -92,11 +92,23 @@ class DownloadManager
             'daily' => round(($redisData[0] ?? $dlData[$todayDate] ?? 0) + (($redisData[1] ?? $dlData[$yesterdayDate] ?? 0) * $dayRatio)),
         ];
 
-        if ($incrViews) {
-            $result['views'] = $this->redis->incr('views:'.$package);
+        return $result;
+    }
+
+    /**
+     * Counts a page view of the package and returns the running total.
+     *
+     * Only the "too many views with no downloads" spam heuristic reads this, so callers should
+     * skip it once that heuristic can no longer fire for the package - it is a Redis write on an
+     * otherwise read-only request.
+     */
+    public function incrementViews(Package|int $package): int
+    {
+        if ($package instanceof Package) {
+            $package = $package->getId();
         }
 
-        return $result;
+        return $this->redis->incr('views:'.$package);
     }
 
     /**

--- a/src/Model/PackageManager.php
+++ b/src/Model/PackageManager.php
@@ -61,6 +61,7 @@ class PackageManager
         private readonly CdnClient $cdnClient,
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly Scheduler $scheduler,
+        private readonly DownloadManager $downloadManager,
     ) {
     }
 
@@ -80,6 +81,9 @@ class PackageManager
 
         if ($reason->suppressesPackage()) {
             $this->scheduler->schedulePackagePurge($package, $actorId);
+            // the page 404s from here on, so the spam heuristic's view counter has no traffic left
+            // to read - and unfreezing legitimately starts the count over
+            $this->downloadManager->deleteViews($package->getId());
         }
     }
 
@@ -156,10 +160,7 @@ class PackageManager
         $this->deletePackageMetadata($packageName);
 
         // delete redis stats
-        try {
-            $this->redis->del('views:'.$packageId);
-        } catch (\Predis\Connection\ConnectionException $e) {
-        }
+        $this->downloadManager->deleteViews($packageId);
 
         // attempt search index cleanup
         $this->deletePackageSearchIndex($packageName);

--- a/tests/Controller/PackageControllerTest.php
+++ b/tests/Controller/PackageControllerTest.php
@@ -20,6 +20,7 @@ use App\Entity\Package;
 use App\Entity\PackageFreezeReason;
 use App\Entity\PackageReadme;
 use App\Entity\User;
+use App\Entity\Vendor;
 use App\Entity\Version;
 use App\Service\Spam\FeatureExtractor;
 use App\Service\Spam\SpamClassifier;
@@ -71,6 +72,52 @@ class PackageControllerTest extends IntegrationTestCase
         );
 
         $redis->del(['views:'.$fresh->getId(), 'dl:'.$established->getId()]);
+    }
+
+    public function testPackagePageDropsTheViewCounterOnceTheHeuristicHasFired(): void
+    {
+        $package = self::createPackage('test/spammy', 'https://example.com/test/spammy');
+        $this->store($package);
+
+        $redis = $this->redis();
+        $redis->set('views:'.$package->getId(), '99');
+
+        $this->client->request('GET', '/packages/test/spammy');
+        self::assertResponseIsSuccessful();
+
+        $em = self::getEM();
+        $em->clear();
+        $reloaded = $em->find(Package::class, $package->getId());
+        self::assertNotNull($reloaded);
+        self::assertSame('Too many views', $reloaded->getSuspect());
+        self::assertNull(
+            $redis->get('views:'.$package->getId()),
+            'the counter has done its job, keeping it would only grow a key nothing reads',
+        );
+    }
+
+    public function testPackagePageDropsTheViewCounterOfAVerifiedVendor(): void
+    {
+        $vendor = new Vendor('verifiedvendor');
+        $vendor->setVerified(true);
+        $package = self::createPackage('verifiedvendor/pkg', 'https://example.com/verifiedvendor/pkg');
+        $this->store($vendor, $package);
+
+        $redis = $this->redis();
+        $redis->set('views:'.$package->getId(), '99');
+
+        $this->client->request('GET', '/packages/verifiedvendor/pkg');
+        self::assertResponseIsSuccessful();
+
+        $em = self::getEM();
+        $em->clear();
+        $reloaded = $em->find(Package::class, $package->getId());
+        self::assertNotNull($reloaded);
+        self::assertFalse($reloaded->isSuspect(), 'a verified vendor is never flagged');
+        self::assertNull(
+            $redis->get('views:'.$package->getId()),
+            'nothing can ever come of this counter, and resetting it stops the isVerified() lookup running on every view',
+        );
     }
 
     private function redis(): Client

--- a/tests/Controller/PackageControllerTest.php
+++ b/tests/Controller/PackageControllerTest.php
@@ -29,6 +29,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\StreamedJsonResponse;
 use PHPUnit\Framework\Attributes\TestWith;
 use Psr\Log\NullLogger;
+use Predis\Client;
 
 class PackageControllerTest extends IntegrationTestCase
 {
@@ -45,6 +46,39 @@ class PackageControllerTest extends IntegrationTestCase
         self::assertCount(1, $auditLink);
         self::assertStringContainsString('package=test/pkg', (string) $auditLink->attr('href'));
         self::assertStringContainsString('noindex', (string) $auditLink->attr('rel'));
+    }
+
+    public function testPackagePageOnlyCountsViewsWhileTheSpamHeuristicCanUseThem(): void
+    {
+        $fresh = self::createPackage('test/fresh', 'https://example.com/test/fresh');
+        $established = self::createPackage('test/established', 'https://example.com/test/established');
+        $this->store($fresh, $established);
+
+        $redis = $this->redis();
+        $redis->del(['views:'.$fresh->getId(), 'views:'.$established->getId()]);
+        // getDownloads() reads the package total straight off this key
+        $redis->set('dl:'.$established->getId(), '5000');
+
+        $this->client->request('GET', '/packages/test/fresh');
+        self::assertResponseIsSuccessful();
+        self::assertSame('1', $redis->get('views:'.$fresh->getId()));
+
+        $this->client->request('GET', '/packages/test/established');
+        self::assertResponseIsSuccessful();
+        self::assertNull(
+            $redis->get('views:'.$established->getId()),
+            'a package past the download threshold can never trip the heuristic, so it must not pay for the counter',
+        );
+
+        $redis->del(['views:'.$fresh->getId(), 'dl:'.$established->getId()]);
+    }
+
+    private function redis(): Client
+    {
+        $client = static::getContainer()->get('snc_redis.default');
+        self::assertInstanceOf(Client::class, $client);
+
+        return $client;
     }
 
     public function testFreezePackageAsModeratorAuditsAndSchedulesPurge(): void

--- a/tests/Entity/PackageRepositoryTest.php
+++ b/tests/Entity/PackageRepositoryTest.php
@@ -15,6 +15,7 @@ namespace App\Tests\Entity;
 use App\Entity\Package;
 use App\Entity\PackageFreezeReason;
 use App\Entity\PackageRepository;
+use App\Entity\Vendor;
 use App\Tests\IntegrationTestCase;
 
 class PackageRepositoryTest extends IntegrationTestCase
@@ -196,5 +197,34 @@ class PackageRepositoryTest extends IntegrationTestCase
         $withFrozen = $names($this->packageRepository->getFilteredQueryBuilder([], true, includeFrozen: true)->getQuery()->getResult());
         self::assertContains('vendor/spam', $withFrozen);
         self::assertContains('vendor/malware', $withFrozen);
+    }
+
+    public function testGetPackageIdsFlaggableByViewsKeepsOnlyPackagesTheHeuristicCanStillReach(): void
+    {
+        $live = self::createPackage('vendor/live', 'https://example.org/live');
+        $suspect = self::createPackage('vendor/suspect', 'https://example.org/suspect');
+        $suspect->setSuspect('Too many views');
+        $old = self::createPackage('vendor/old', 'https://example.org/old');
+        $old->setCreatedAt(new \DateTimeImmutable('2018-01-01'));
+        $spam = self::createPackage('vendor/spam', 'https://example.org/spam');
+        $spam->freeze(PackageFreezeReason::Spam);
+        $temporary = self::createPackage('vendor/temporary', 'https://example.org/temporary');
+        $temporary->freeze(PackageFreezeReason::Temporary);
+        $verified = self::createPackage('verifiedvendor/pkg', 'https://example.org/verifiedvendor/pkg');
+        $vendor = new Vendor('verifiedvendor');
+        $vendor->setVerified(true);
+        $this->store($live, $suspect, $old, $spam, $temporary, $verified, $vendor);
+
+        $ids = $this->packageRepository->getPackageIdsFlaggableByViews([
+            $live->getId(), $suspect->getId(), $old->getId(), $spam->getId(), $temporary->getId(), $verified->getId(), 999999999,
+        ]);
+
+        self::assertContains($live->getId(), $ids);
+        self::assertContains($temporary->getId(), $ids, 'a gentle freeze keeps serving the page, so views still come in');
+        self::assertNotContains($suspect->getId(), $ids);
+        self::assertNotContains($old->getId(), $ids);
+        self::assertNotContains($spam->getId(), $ids, 'a suppressing freeze 404s the page, so no more views can arrive');
+        self::assertNotContains($verified->getId(), $ids, 'a verified vendor can never be flagged again');
+        self::assertNotContains(999999999, $ids, 'a deleted package cannot be flagged either');
     }
 }

--- a/tests/Entity/VendorRepositoryTest.php
+++ b/tests/Entity/VendorRepositoryTest.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Packagist.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *     Nils Adermann <naderman@naderman.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Entity;
+
+use App\Entity\Package;
+use App\Entity\Vendor;
+use App\Entity\VendorRepository;
+use App\Tests\IntegrationTestCase;
+use Predis\Client;
+
+class VendorRepositoryTest extends IntegrationTestCase
+{
+    public function testVerifyClearsSuspectAndDropsTheVendorsViewCounters(): void
+    {
+        $suspect = self::createPackage('spamvendor/one', 'https://example.org/spamvendor/one');
+        $suspect->setSuspect('Too many views');
+        $innocent = self::createPackage('spamvendor/two', 'https://example.org/spamvendor/two');
+        $unrelated = self::createPackage('othervendor/pkg', 'https://example.org/othervendor/pkg');
+        $this->store($suspect, $innocent, $unrelated);
+
+        $redis = $this->redis();
+        $redis->mset([
+            'views:'.$suspect->getId() => '120',
+            'views:'.$innocent->getId() => '7',
+            'views:'.$unrelated->getId() => '3',
+        ]);
+
+        $this->vendorRepo()->verify('spamvendor');
+
+        self::assertNull($redis->get('views:'.$suspect->getId()));
+        self::assertNull(
+            $redis->get('views:'.$innocent->getId()),
+            'a verified vendor is whitelisted wholesale, so none of its packages can be flagged again',
+        );
+        self::assertSame('3', $redis->get('views:'.$unrelated->getId()), 'other vendors must be left alone');
+
+        $em = self::getEM();
+        $em->clear();
+        $reloaded = $em->find(Package::class, $suspect->getId());
+        self::assertNotNull($reloaded);
+        self::assertFalse($reloaded->isSuspect());
+        self::assertTrue($this->vendorRepo()->isVerified('spamvendor'));
+
+        $redis->del(['views:'.$unrelated->getId()]);
+    }
+
+    private function vendorRepo(): VendorRepository
+    {
+        $repo = self::getEM()->getRepository(Vendor::class);
+        self::assertInstanceOf(VendorRepository::class, $repo);
+
+        return $repo;
+    }
+
+    private function redis(): Client
+    {
+        $client = static::getContainer()->get('snc_redis.default');
+        self::assertInstanceOf(Client::class, $client);
+
+        return $client;
+    }
+}

--- a/tests/Model/PackageManagerTest.php
+++ b/tests/Model/PackageManagerTest.php
@@ -15,10 +15,12 @@ namespace App\Tests\Model;
 use App\Audit\AuditRecordType;
 use App\Entity\AuditRecord;
 use App\Entity\Package;
+use App\Entity\PackageFreezeReason;
 use App\Entity\User;
 use App\Model\PackageManager;
 use App\Tests\IntegrationTestCase;
 use PHPUnit\Framework\Attributes\TestWith;
+use Predis\Client;
 
 class PackageManagerTest extends IntegrationTestCase
 {
@@ -129,5 +131,28 @@ class PackageManagerTest extends IntegrationTestCase
         $callable = fn (array $user) => $user['username'];
         $this->assertEqualsCanonicalizing($oldMaintainers, array_map($callable, $record->attributes['previous_maintainers']));
         $this->assertEqualsCanonicalizing($newMaintainers, array_map($callable, $record->attributes['current_maintainers']));
+    }
+
+    #[TestWith([PackageFreezeReason::Spam, true])]
+    #[TestWith([PackageFreezeReason::Temporary, false])]
+    public function testFreezeDropsTheViewCounterOnlyWhenThePageStopsBeingServed(PackageFreezeReason $reason, bool $expectDropped): void
+    {
+        $package = self::createPackage('test/frozen', 'https://example.org/test/frozen');
+        $this->store($package);
+
+        $redis = self::getContainer()->get('snc_redis.default');
+        self::assertInstanceOf(Client::class, $redis);
+        $key = 'views:'.$package->getId();
+        $redis->set($key, '42');
+
+        $this->packageManager->freeze($package, $reason);
+
+        if ($expectDropped) {
+            self::assertNull($redis->get($key), 'a suppressed package 404s, so nothing can read the counter anymore');
+        } else {
+            self::assertSame('42', $redis->get($key), 'a gentle freeze keeps serving the page, so the counter stays live');
+        }
+
+        $redis->del([$key]);
     }
 }


### PR DESCRIPTION
Every HTML package page view did an `INCR views:<id>` (`DownloadManager:96`) — a Redis **write** on ~4.5M otherwise read-only requests per APM period.

That counter has exactly one reader: the "too many views" suspect heuristic in `viewPackageAction`. It can only conclude anything while the package has ≤10 total downloads, was created after 2019-05-01, and is not already suspect. It is not displayed anywhere (grep-verified across `src/` and `templates/`).

None of those three conditions can revert — downloads and `createdAt` never move back below the thresholds, and `suspect` is not unset here — so once a package fails the check it can never need the counter again. Reordering the heuristic so the increment is the last term means the popular packages that make up the bulk of the traffic stop writing to Redis, while new low-download packages keep exact counts and detection is unchanged.

`getDownloads()` loses its `$incrViews` flag in favour of an explicit `incrementViews()`; mixing a write into the read was what made the call site hard to reason about. It was the only caller passing it.

### Verification

`composer phpstan` clean, full suite green. New test asserts a fresh package's page view increments the counter and an established one's does not.