### PR TITLE
Only send the document security headers on documents

### DIFF
--- a/config/packages/nelmio_security.yaml
+++ b/config/packages/nelmio_security.yaml
@@ -2,6 +2,8 @@ nelmio_security:
     clickjacking:
         paths:
             '^/.*': DENY
+        # Only documents can be framed, and the JSON APIs serve millions of responses per day
+        content_types: ['text/html']
     forced_ssl:
         enabled: '%force_ssl%'
         hosts: '%forced_ssl_hosts%'
@@ -10,7 +12,8 @@ nelmio_security:
         enabled: true
         report_logger_service: logger
         hosts: []
-        content_types: []
+        # CSP only governs document loading, so sending it on API responses is pure overhead
+        content_types: ['text/html']
         enforce:
             browser_adaptive:
                 enabled: false

--- a/tests/Controller/SecurityHeadersTest.php
+++ b/tests/Controller/SecurityHeadersTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Packagist.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *     Nils Adermann <naderman@naderman.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Controller;
+
+use App\Tests\IntegrationTestCase;
+
+class SecurityHeadersTest extends IntegrationTestCase
+{
+    public function testHtmlPagesCarryTheDocumentSecurityHeaders(): void
+    {
+        $package = self::createPackage('test/pkg', 'https://example.com/test/pkg');
+        $this->store($package);
+
+        $this->client->request('GET', '/packages/test/pkg');
+
+        self::assertResponseIsSuccessful();
+        self::assertResponseHeaderSame('X-Frame-Options', 'DENY');
+        self::assertResponseHasHeader('Content-Security-Policy');
+    }
+
+    public function testJsonApiResponsesSkipTheDocumentSecurityHeaders(): void
+    {
+        // Neither header does anything for a non-document response, and these endpoints carry
+        // millions of responses per day, so they must not pay for ~600 bytes of CSP each.
+        $this->client->request('GET', '/packages/list.json');
+
+        self::assertResponseIsSuccessful();
+        self::assertResponseNotHasHeader('X-Frame-Options');
+        self::assertResponseNotHasHeader('Content-Security-Policy');
+    }
+}


### PR DESCRIPTION
`content_types` defaulted to an empty list for both the CSP and clickjacking listeners, which nelmio treats as "every content type" (`AbstractContentTypeRestrictableListener::isContentTypeValid`). So every JSON API response carried the full ~600 byte `Content-Security-Policy` plus an `X-Frame-Options` header. The security-advisory and download-tracking endpoints alone account for ~4.5M responses per APM period.

Neither header does anything for a non-document response: CSP governs document loading and `X-Frame-Options` governs framing, and a JSON body is neither.

Restricting both listeners to `text/html` is route-drift-proof, unlike enumerating API path prefixes in `clickjacking.paths` — new endpoints are covered automatically, and HTML pages are unaffected.

### Verification

`composer phpstan` clean, full suite green. New `SecurityHeadersTest` asserts both halves: an HTML page still gets `X-Frame-Options: DENY` and a CSP, and `/packages/list.json` gets neither. Confirmed the JSON assertion fails against the previous config, so it isn't vacuous.