### PR TITLE
Add the missing LIMIT 1 to findLatestExecutedJob

### DIFF
--- a/src/Entity/JobRepository.php
+++ b/src/Entity/JobRepository.php
@@ -86,7 +86,7 @@ class JobRepository extends ServiceEntityRepository
         $conn = $this->getEntityManager()->getConnection();
 
         $id = $conn->fetchOne(
-            'SELECT id FROM job WHERE packageId = :package AND status IN (:statuses) AND type = :type ORDER BY createdAt DESC',
+            'SELECT id FROM job WHERE packageId = :package AND status IN (:statuses) AND type = :type ORDER BY createdAt DESC LIMIT 1',
             [
                 'package' => $packageId,
                 'statuses' => [Job::STATUS_COMPLETED, Job::STATUS_ERRORED, Job::STATUS_FAILED],

--- a/tests/Entity/JobRepositoryTest.php
+++ b/tests/Entity/JobRepositoryTest.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of Packagist.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *     Nils Adermann <naderman@naderman.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Entity;
+
+use App\Entity\Job;
+use App\Entity\JobRepository;
+use App\Entity\Package;
+use App\Tests\IntegrationTestCase;
+
+class JobRepositoryTest extends IntegrationTestCase
+{
+    private JobRepository $jobRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->jobRepository = self::getEM()->getRepository(Job::class);
+    }
+
+    public function testFindLatestExecutedJobPicksTheNewestExecutedJobForThePackageAndType(): void
+    {
+        $package = self::createPackage('test/pkg', 'https://example.org/pkg');
+        $other = self::createPackage('test/other', 'https://example.org/other');
+        $this->store($package, $other);
+
+        $older = $this->createJob('older000', $package, 'package:updates', '2026-08-01 10:00:00', Job::STATUS_COMPLETED);
+        $newest = $this->createJob('newest00', $package, 'package:updates', '2026-08-03 10:00:00', Job::STATUS_FAILED);
+        $queued = $this->createJob('queued00', $package, 'package:updates', '2026-08-04 10:00:00', null);
+        $foreignType = $this->createJob('foreign0', $package, 'package:delete', '2026-08-05 10:00:00', Job::STATUS_COMPLETED);
+        $otherPackage = $this->createJob('otherpkg', $other, 'package:updates', '2026-08-06 10:00:00', Job::STATUS_COMPLETED);
+        $this->store($older, $newest, $queued, $foreignType, $otherPackage);
+
+        $found = $this->jobRepository->findLatestExecutedJob($package->getId(), 'package:updates');
+
+        // The query is ORDER BY createdAt DESC LIMIT 1, so the newest executed job must win over
+        // the older one, and the queued/foreign rows must not be considered at all.
+        self::assertNotNull($found);
+        self::assertSame('newest00', $found->getId());
+    }
+
+    public function testFindLatestExecutedJobReturnsNullWhenNothingHasRun(): void
+    {
+        $package = self::createPackage('test/pkg', 'https://example.org/pkg');
+        $this->store($package);
+        $this->store($this->createJob('queued00', $package, 'package:updates', '2026-08-04 10:00:00', null));
+
+        self::assertNull($this->jobRepository->findLatestExecutedJob($package->getId(), 'package:updates'));
+    }
+
+    private function createJob(string $id, Package $package, string $type, string $createdAt, ?string $status): Job
+    {
+        $job = new Job($id, $type, ['id' => $package->getId(), 'source' => 'test']);
+        $job->setPackageId($package->getId());
+        $job->setCreatedAt(new \DateTimeImmutable($createdAt));
+        if ($status !== null) {
+            $job->start();
+            $job->complete(['status' => $status, 'message' => 'done']);
+        }
+
+        return $job;
+    }
+}


### PR DESCRIPTION
The query only ever consumes one row — it's fed to `fetchOne()` — but had no `LIMIT`, so MySQL sorted every matching job row before discarding all but the first.

Job volume per package is low enough that this was never expensive, hence no new index. The `LIMIT` is free though, and it matches `findLatestMigrationJob()` immediately above it, which already uses `setMaxResults(1)` for the same shape of query.

The new tests pin the ordering semantics the `LIMIT` relies on — newest executed job wins, queued jobs and other packages/types are not considered — since a wrong `LIMIT` on an unstable sort is the failure mode worth guarding.

### Verification

`composer phpstan` clean, full suite green.