### PR TITLE
Drop the Composer 1 default branch fallback from download tracking

### DIFF
--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -305,15 +305,6 @@ class ApiController extends Controller
         ];
         $jobs = $failed = [];
         foreach ($payload as $package) {
-            // support legacy composer v1 normalized default branches
-            if ($package['version'] === '9999999-dev' && !isset($package['id'], $package['vid'])) {
-                $result = $this->getDefaultPackageAndVersionId($package['name']);
-                if ($result) {
-                    $package['id'] = $result['id'];
-                    $package['vid'] = $result['vid'];
-                }
-            }
-
             if (!isset($package['id'], $package['vid'])) {
                 $failed[] = $package;
                 continue;
@@ -432,29 +423,6 @@ class ApiController extends Controller
         }
 
         return new JsonResponse($response, 200);
-    }
-
-    /**
-     * @return array{id: int, vid: int}|false
-     */
-    protected function getDefaultPackageAndVersionId(string $name): array|false
-    {
-        /** @var array{id: string, vid: string}|false $result */
-        $result = $this->getEM()->getConnection()->fetchAssociative(
-            'SELECT p.id, v.id vid
-            FROM package p
-            LEFT JOIN package_version v ON p.id = v.package_id
-            WHERE p.name = ?
-            AND v.defaultBranch = true
-            LIMIT 1',
-            [$name]
-        );
-
-        if (false === $result) {
-            return false;
-        }
-
-        return ['id' => (int) $result['id'], 'vid' => (int) $result['vid']];
     }
 
     /**

--- a/tests/Controller/ApiControllerTest.php
+++ b/tests/Controller/ApiControllerTest.php
@@ -16,6 +16,7 @@ use App\Entity\SecurityAdvisory;
 use App\SecurityAdvisory\GitHubSecurityAdvisoriesSource;
 use App\SecurityAdvisory\RemoteSecurityAdvisory;
 use App\SecurityAdvisory\Severity;
+use App\Model\VersionIdCache;
 use App\Tests\IntegrationTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
@@ -329,5 +330,56 @@ class ApiControllerTest extends IntegrationTestCase
 
         $this->assertSame(502, $response->getStatusCode());
         $this->assertJsonStringEqualsJsonString('{"status":"error","message":"Failed to fetch upstream version data, please try again later."}', (string) $response->getContent());
+    }
+
+    public function testTrackDownloadsCountsAResolvableVersion(): void
+    {
+        $package = self::createPackage('test/pkg', 'https://example.org/pkg');
+        $this->store($package);
+
+        // the endpoint resolves name+version to ids straight out of Redis, never MySQL
+        self::getService(VersionIdCache::class)->insertVersionRaw($package->getId(), 'test/pkg', 4242, '1.0.0.0');
+
+        $this->client->request(
+            'POST',
+            '/downloads/',
+            server: ['HTTP_USER_AGENT' => 'Composer/2.8.0 (Linux; 6.1.0; PHP 8.4.0; curl 8.5)'],
+            content: json_encode(['downloads' => [['name' => 'test/pkg', 'version' => '1.0.0.0']]], flags: \JSON_THROW_ON_ERROR),
+        );
+
+        self::assertResponseStatusCodeSame(201);
+        self::assertSame(['status' => 'success'], $this->decodeResponse());
+    }
+
+    public function testTrackDownloadsReportsUnresolvableVersionsAsPartial(): void
+    {
+        $package = self::createPackage('test/pkg', 'https://example.org/pkg');
+        $this->store($package);
+
+        // Composer 1 sent the default branch as 9999999-dev. Support for it was shut down on
+        // 2025-09-01 and there is no longer a MySQL fallback resolving it via defaultBranch, so an
+        // unknown version is reported back like any other.
+        $this->client->request(
+            'POST',
+            '/downloads/',
+            server: ['HTTP_USER_AGENT' => 'Composer/1.10.26 (Linux; 6.1.0; PHP 8.4.0; curl 8.5)'],
+            content: json_encode(['downloads' => [['name' => 'test/pkg', 'version' => '9999999-dev']]], flags: \JSON_THROW_ON_ERROR),
+        );
+
+        self::assertResponseStatusCodeSame(200);
+        $body = $this->decodeResponse();
+        self::assertSame('partial', $body['status']);
+        self::assertStringContainsString('9999999-dev', $body['message'], 'the unresolved entry is reported back to the client');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeResponse(): array
+    {
+        $body = json_decode((string) $this->client->getResponse()->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+        self::assertIsArray($body);
+
+        return $body;
     }
 }


### PR DESCRIPTION
`trackDownloadsAction` resolved Composer 1's `9999999-dev` default branch with a `SELECT` against `package` + `package_version` — **per package, inside the per-package loop**, on an endpoint taking ~2M requests per APM period.

It was the only synchronous MySQL left there (everything else resolves ids through a single Lua call against Redis, and the write is a single `EVALSHA`), and with `PDO::ATTR_TIMEOUT` at 1.3s it's the most likely explanation for the endpoint's 10.6s tail.

Support for Composer 1 was shut down on 2025-09-01, which `packages.json` has been announcing via its `warning` field since.

> [!IMPORTANT]
> This is a behaviour change, not a pure removal. The few remaining Composer 1 clients that hit this path now get a `partial` response and their downloads stop being counted, instead of being resolved via the package's default branch. Given you said a few requests do still land here, that's your call — happy to close this one if you'd rather keep the resolution and instead seed a `9999999-dev` alias into the Redis `ids:` hash, which would keep the behaviour with no MySQL.

### Verification

`composer phpstan` clean, full suite green. The endpoint had **no** test coverage at all, so this adds the two cases that matter: a resolvable version is counted (201 `success`), and an unresolvable one is reported back (200 `partial`).