### PR TITLE
chore: Update Rector config

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -7,31 +7,25 @@ use App\Validator\Password;
 use App\Validator\TypoSquatters;
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
-use Rector\Doctrine\Set\DoctrineSetList;
 use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
 use Rector\Php80\ValueObject\AnnotationToAttribute;
-use Rector\PHPUnit\Set\PHPUnitLevelSetList;
-use Rector\Symfony\Set\SymfonySetList;
 
-return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->paths([
+return RectorConfig::configure()
+    ->withPaths([
         __DIR__ . '/src',
         __DIR__ . '/tests',
-    ]);
-
-    // register a single rule
-    $rectorConfig->rule(InlineConstructorDefaultToPropertyRector::class);
-
-    $rectorConfig->ruleWithConfiguration(AnnotationToAttributeRector::class, [
+    ])
+    ->withImportNames()
+    ->withPreparedSets(symfonyCodeQuality: true)
+    ->withComposerBased(
+        twig: true,
+        doctrine: true,
+        phpunit: true,
+        symfony: true,
+    )
+    ->withRules([InlineConstructorDefaultToPropertyRector::class])
+    ->withConfiguredRule(AnnotationToAttributeRector::class, [
         new AnnotationToAttribute(Password::class),
         new AnnotationToAttribute(TypoSquatters::class),
         new AnnotationToAttribute(Copyright::class),
     ]);
-
-    // define sets of rules
-    $rectorConfig->sets([
-        SymfonySetList::SYMFONY_62,
-        DoctrineSetList::DOCTRINE_ORM_29,
-        PHPUnitLevelSetList::UP_TO_PHPUNIT_100,
-    ]);
-};

--- a/tests/Controller/ApiControllerTest.php
+++ b/tests/Controller/ApiControllerTest.php
@@ -11,7 +11,7 @@
  */
 
 namespace App\Tests\Controller;
-
+use App\Service\Scheduler;
 use App\Entity\SecurityAdvisory;
 use App\SecurityAdvisory\GitHubSecurityAdvisoriesSource;
 use App\SecurityAdvisory\RemoteSecurityAdvisory;
@@ -44,14 +44,14 @@ class ApiControllerTest extends IntegrationTestCase
         $package = self::createPackage('test/'.bin2hex(random_bytes(10)), $url, maintainers: [$user]);
         $this->store($user, $package);
 
-        $scheduler = $this->createMock('App\Service\Scheduler');
+        $scheduler = $this->createMock(Scheduler::class);
 
         $scheduler->expects($this->once())
             ->method('scheduleUpdate')
             ->with($package);
 
         static::$kernel->getContainer()->set('doctrine.orm.entity_manager', self::getEM());
-        static::$kernel->getContainer()->set('App\Service\Scheduler', $scheduler);
+        static::$kernel->getContainer()->set(Scheduler::class, $scheduler);
 
         $payload = json_encode(['repository' => ['url' => 'git://github.com/composer/composer']]);
         $this->client->request('POST', '/api/github?username=test&apiToken=api-token', ['payload' => $payload]);

--- a/tests/Model/PackageManagerTest.php
+++ b/tests/Model/PackageManagerTest.php
@@ -16,8 +16,11 @@ use App\Audit\AuditRecordType;
 use App\Entity\AuditRecord;
 use App\Entity\Package;
 use App\Entity\User;
+use App\Entity\UserRepository;
 use App\Model\PackageManager;
+use App\Package\Updater;
 use App\Tests\IntegrationTestCase;
+use Doctrine\ORM\EntityManager;
 use PHPUnit\Framework\Attributes\TestWith;
 
 class PackageManagerTest extends IntegrationTestCase
@@ -42,9 +45,9 @@ class PackageManagerTest extends IntegrationTestCase
         $user = new User();
         $user->addPackage($package);
 
-        $repo = $this->createMock('App\Entity\UserRepository');
-        $em = $this->createMock('Doctrine\ORM\EntityManager');
-        $updater = $this->createMock('App\Package\Updater');
+        $repo = $this->createMock(UserRepository::class);
+        $em = $this->createMock(EntityManager::class);
+        $updater = $this->createMock(Updater::class);
 
         $repo->expects($this->once())
             ->method('findOneBy')
@@ -53,7 +56,7 @@ class PackageManagerTest extends IntegrationTestCase
 
         static::$kernel->getContainer()->set('test.user_repo', $repo);
         static::$kernel->getContainer()->set('doctrine.orm.entity_manager', $em);
-        static::$kernel->getContainer()->set('App\Package\Updater', $updater);
+        static::$kernel->getContainer()->set(Updater::class, $updater);
 
         $payload = json_encode(['repository' => ['url' => 'git://github.com/composer/composer']]);
         $client->request('POST', '/api/github?username=test&apiToken=token', ['payload' => $payload]);


### PR DESCRIPTION
The Rector config was not touched since early 2023, when we migrated to PHPUnit 10 and seems to be never used since then. In the meantime, Rector v2 was released with simpler config and easier framework version upgrade control. 

However, since default rules and new framework-specific rules have changed, there are a lot of changes that would be executed at the moment, hence they are not included in this change. I leave it to the maintainer to run afterwards.

Additionally, replaced class FQCN strings in tests with `::class` pseudo-constants.

Note: Rector is not currently required via `composer.json` - it relies on globally installed version instead. We could change that and add a dry-run in the CI if that's necessary.